### PR TITLE
Fix get_suites for TestRail v9.3.2

### DIFF
--- a/backup-tools/backup_testrail.py
+++ b/backup-tools/backup_testrail.py
@@ -85,7 +85,9 @@ if __name__ == "__main__":
     for project_id in project_ids:
         project = testrail.project(project_id)
         project_name = project.get('name')
-        suites = testrail.test_suites(project_id)
+        # Starting v9.3.2, get_cases returns a pagination containing a list of
+        # suites instead of just a list of suites.
+        suites = testrail.test_suites(project_id).get('suites')
         
         for suite in suites:
             suite_id = suite.get('id')


### PR DESCRIPTION
Starting in TestRail v9.3.2 (July 14), `get_suites` returns the first 250 items in a pagination by default like the following:
```
{'offset': 0, 'limit': 250, 'size': 19, '_links': {'next': None, 'prev': None}, 'suites': [{'id': 3192, 'name': 'Full Functional Tests Suite', 'description': None, 'project_id': 59, 'is_master': False, 'is_baseline': ....
```
The Github Actions started to fail today because of the change. The API used to return just a list (no pagination) of suites. I have updated the code to get the list of suites.

The limitation is that we can only deal with the first 250 suites in a project. Since I don't think we will ever have over 250 suites in a project, I would not implement pagination for now.

The Github Actions run is successful:
https://github.com/mozilla-mobile/testops-tools/actions/runs/16326710104