### PR TITLE
Include branch info in slack notification

### DIFF
--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -104,6 +104,7 @@ jobs:
           server_url: ${{ github.server_url }}
           repository: ${{ github.repository }}
           run_id: ${{ github.run_id }}
+          branch: ${{ github.ref_name }}
 
       - name: Notify Slack (Success)
         uses: slackapi/slack-github-action@v2.1.1
@@ -118,3 +119,4 @@ jobs:
           server_url: ${{ github.server_url }}
           repository: ${{ github.repository }}
           run_id: ${{ github.run_id }}
+          branch: ${{ github.ref_name }}

--- a/backup-tools/backup_testrail.py
+++ b/backup-tools/backup_testrail.py
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     for project_id in project_ids:
         project = testrail.project(project_id)
         project_name = project.get('name')
-        # Starting v9.3.2, get_cases returns a pagination containing a list of
+        # Starting v9.3.2, get_suites returns a pagination containing a list of
         # suites instead of just a list of suites.
         suites = testrail.test_suites(project_id).get('suites')
         

--- a/backup-tools/slack-fail.json
+++ b/backup-tools/slack-fail.json
@@ -4,7 +4,7 @@
         "type": "header",
         "text": {
           "type": "plain_text",
-          "text": ":x: TestRail Backup Failed",
+          "text": ":x: TestRail Backup Failed (${{ env.branch }})",
           "emoji": true
         }
       },

--- a/backup-tools/slack-success.json
+++ b/backup-tools/slack-success.json
@@ -4,7 +4,7 @@
         "type": "header",
         "text": {
           "type": "plain_text",
-          "text": ":tada: TestRail Backup Successful",
+          "text": ":tada: TestRail Backup Successful (${{ env.branch }})",
           "emoji": true
         }
       },


### PR DESCRIPTION
Let's include the branch info in the notification so that we know if we are running the workflow on a branch or not.

Sample notification: https://mozilla.slack.com/archives/C016BC5FUHJ/p1752815695661459
<img width="594" height="126" alt="Screenshot 2025-07-22 at 10 45 04 AM" src="https://github.com/user-attachments/assets/8763e605-e4c6-49ac-aabf-8b82b79631be" />
