### PR TITLE
Add Apple logo to the notification

### DIFF
--- a/testrail/slack_notifier.py
+++ b/testrail/slack_notifier.py
@@ -130,7 +130,7 @@ SLACK_SUCCESS_MESSAGE_TEMPLATE_IOS = Template(
         "type": "header",
         "text": {
                 "type": "plain_text",
-                "text": "New Release: :firefox: $SHIPPING_PRODUCT-v$RELEASE_VERSION :star:"
+                "text": "New Release: :apple_logo: :firefox: $SHIPPING_PRODUCT-v$RELEASE_VERSION :star:"
         }
     },
     { 


### PR DESCRIPTION
This PR updates the slack notification of the milestone creation with the apple logo.

I've created the apple logo in slack and then add to the slack notification just adding :apple_logo: