### PR TITLE
Fix reading from latest_tags.json

### DIFF
--- a/testrail/check_bitrise_for_release.py
+++ b/testrail/check_bitrise_for_release.py
@@ -135,7 +135,7 @@ def run_create_milestone(product, tag, rc_number: int):
         release_name = f"{release_name} build {rc_number}"
 
     print(f"Triggering milestone creation for: {release_name}")
-    '''
+
     result = subprocess.run([
         "gh", "workflow", "run", "create-milestone.yml",
         "-f", f"release-name={release_name}",
@@ -146,7 +146,7 @@ def run_create_milestone(product, tag, rc_number: int):
         print(f"❌ Failed to trigger workflow for {product}: {result.stderr}")
     else:
         print(f"✅ Milestone workflow triggered successfully for {product}")
-    '''
+
 def run_handle_new_rc(product, tag, new_build):
     """
     Called when tag is the same, but new builds appear.


### PR DESCRIPTION
We are not reading from latest_tags.json file.

Even though we have the file in the repo and new version is detected, the script can not compare values..

> No previous tag file found. Creating new one...
> Latest info: {'firefox': {'tag': 'firefox-v145.3', 'rc_number': 4}, 'focus/klar': {'tag': 'focus/klar-v145.0', 'rc_number': 1}}
> Previous state: {}

https://github.com/mozilla-mobile/testops-tools/actions/runs/19740518894/job/56563007867
