### PR TITLE
Udate Release number in slack notification

### DIFF
--- a/testrail/testrail_main_ios.py
+++ b/testrail/testrail_main_ios.py
@@ -140,10 +140,15 @@ def main():
                 case_ids=case_ids
             )
 
+        if build_number and build_number > 1:
+            slack_release_version = f"{release_version} build {build_number}"
+        else:
+            slack_release_version = release_version
+
         # Send success notification
         success_values = {
             "RELEASE_TYPE": release_type,
-            "RELEASE_VERSION": release_version,
+            "RELEASE_VERSION": slack_release_version,
             "SHIPPING_PRODUCT": shipping_product,
             "TESTRAIL_PROJECT_ID": testrail_project_id,
             "TESTRAIL_PRODUCT_TYPE": testrail_product_type,


### PR DESCRIPTION
Milestone has been correctly created but the slack notification does not show release number
<img width="610" height="145" alt="imagen" src="https://github.com/user-attachments/assets/339cfb50-0799-4b2c-912f-7c478aace320" />

<img width="734" height="361" alt="imagen" src="https://github.com/user-attachments/assets/a9c79129-ecd1-4c63-a07d-2e0ecf284456" />

with this change we expect to see that in the notification