### PR TITLE
Nit: Use the same apple icon for all iOS related notifications

### DIFF
--- a/.github/workflows/ios-insights-slack-notification.yml
+++ b/.github/workflows/ios-insights-slack-notification.yml
@@ -209,7 +209,7 @@ jobs:
                     "type": "section", 
                     "text": { 
                         "type": "mrkdwn", 
-                        "text": ":firefox: :apple_logo: iOS Fennec UI Test Daily Digest for '"$YESTERDAY"'" 
+                        "text": ":firefox: :testops-apple: iOS Fennec UI Test Daily Digest for '"$YESTERDAY"'" 
                     } 
                 },
                 {

--- a/testrail/slack_notifier.py
+++ b/testrail/slack_notifier.py
@@ -130,7 +130,7 @@ SLACK_SUCCESS_MESSAGE_TEMPLATE_IOS = Template(
         "type": "header",
         "text": {
                 "type": "plain_text",
-                "text": "New Release: :apple_logo: :firefox: $SHIPPING_PRODUCT-v$RELEASE_VERSION :star:"
+                "text": "New Release: :testops-apple: :firefox: $SHIPPING_PRODUCT-v$RELEASE_VERSION :star:"
         }
     },
     { 


### PR DESCRIPTION
Suggestion: We should use the same Apple, Android, Firefox and Focus icons throughout the Slack notifications from TestOps.

Currently there's an `:apple_logo:` used
<img width="445" height="253" alt="Screenshot 2026-01-15 at 11 24 36" src="https://github.com/user-attachments/assets/67a0fb6e-e567-482b-a063-9cb589e91a5c" />
