### PR TITLE
Add country parameter to appstore lookup URL

### DIFF
--- a/ios-appstore-ratings/check_ratings.py
+++ b/ios-appstore-ratings/check_ratings.py
@@ -7,7 +7,7 @@ import json
 import requests
 
 def get_app_rating(package_id: str, timeout: int = 15) -> str :
-    appstore_lookup_url = f"https://itunes.apple.com/lookup?bundleId={package_id}"
+    appstore_lookup_url = f"https://itunes.apple.com/lookup?bundleId={package_id}&country=us"
 
     try:
         response = requests.get(appstore_lookup_url, timeout=timeout)


### PR DESCRIPTION
To ensure ratings are derived from the US in-case of Github Runner provisioning in Europe, we'll want to pin the US `country=us` to the query.