### PR TITLE
Add script to find automated tests without testrail tests associated

### DIFF
--- a/.github/slack/testrail-missing-links.json
+++ b/.github/slack/testrail-missing-links.json
@@ -1,0 +1,33 @@
+{
+  "text": "XCUITests missing TestRail URLs",
+  "blocks": [
+    {
+      "type": "header",
+      "text": { "type": "plain_text", "text": "❌ XCUITests missing TestRail URLs" }
+    },
+    {
+      "type": "section",
+      "fields": [
+        { "type": "mrkdwn", "text": "*Repo:*\n${{ github.repository }}" },
+        { "type": "mrkdwn", "text": "*Missing:*\n${{ env.MISSING_COUNT }}" }
+      ]
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Job log:*\n${{ env.JOB_LOG_URL }}"
+      }
+    },
+    {
+      "type": "divider"
+    },
+    {
+      "type": "section",
+      "text": {
+        "type": "mrkdwn",
+        "text": "*Tests needing a TestRail URL:*\n${{ env.MISSING_LIST }}"
+      }
+    }
+  ]
+}

--- a/.github/workflows/testrail-missing-links-slack.yml
+++ b/.github/workflows/testrail-missing-links-slack.yml
@@ -1,0 +1,92 @@
+name: Detect firefox-ios XCUITests missing TestRail URL (Slack)
+
+permissions: read-all
+
+on:
+  schedule:
+    - cron: "0 8 * * 1"
+  workflow_dispatch: {}
+  workflow_call:
+    secrets:
+      SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX:
+        required: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout testops-tools
+        uses: actions/checkout@v4
+
+      - name: Checkout firefox-ios
+        uses: actions/checkout@v4
+        with:
+          repository: mozilla-mobile/firefox-ios
+          path: firefox-ios
+          fetch-depth: 1
+          ref: main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Set job log URL
+        if: always()
+        run: |
+          echo "JOB_LOG_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_ENV
+
+      - name: Run detector and prepare Slack content
+        id: scan
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ROOT="firefox-ios/firefox-ios-tests/Tests/XCUITests"
+          DOMAIN="mozilla.testrail.io"
+
+          python test-fixtures/testrail_scan_missing_urls.py \
+            --root "$ROOT" \
+            --testrail-domain "$DOMAIN" \
+            > testrail_missing_report.txt
+
+          grep -E '^- ' testrail_missing_report.txt > missing_items.txt || true
+
+          MISSING_COUNT=$(wc -l < missing_items.txt | tr -d ' ')
+          echo "missing_count=$MISSING_COUNT" >> $GITHUB_OUTPUT
+
+          if [ "$MISSING_COUNT" -gt 0 ]; then
+            MAX_LINES=40
+            head -n "$MAX_LINES" missing_items.txt \
+              | awk '{sub(/^- /,""); print "• " $0}' \
+              > missing_bullets.txt
+
+            if [ "$MISSING_COUNT" -gt "$MAX_LINES" ]; then
+              echo "• …and $((MISSING_COUNT - MAX_LINES)) more" >> missing_bullets.txt
+            fi
+
+            {
+              echo "MISSING_COUNT=$MISSING_COUNT"
+              echo "MISSING_LIST<<EOF"
+              cat missing_bullets.txt
+              echo "EOF"
+            } >> $GITHUB_ENV
+          else
+            echo "MISSING_COUNT=0" >> $GITHUB_ENV
+            {
+              echo "MISSING_LIST<<EOF"
+              echo "None 🎉"
+              echo "EOF"
+            } >> $GITHUB_ENV
+          fi
+
+      - name: Send Slack notification (only if missing links exist)
+        if: ${{ steps.scan.outputs.missing_count != '0' && !cancelled() }}
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          payload-file-path: "test-fixtures/ci/slack-testrail-missing-links.json"
+          payload-templated: true
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook

--- a/testrail/testrail_scan_missing_urls.py
+++ b/testrail/testrail_scan_missing_urls.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+TEST_FUNC_RE = re.compile(r"^\s*func\s+(test[A-Za-z0-9_]+)\s*\(")
+
+# Accept both:
+#   // Smoketest TAE
+#   // Smoke TAE
+SMOKE_RE = re.compile(r"^\s*//\s*smoke(test)?\b.*$", re.IGNORECASE)
+
+# Directories to ignore entirely
+IGNORED_DIRS = {
+    "ExperimentIntegrationTests",
+    "PerformanceTests",
+}
+
+
+@dataclass(frozen=True)
+class MissingLink:
+    file: Path
+    line_no: int
+    test_name: str
+    prev1: str
+    prev2: str
+
+
+def is_testrail_url_line(line: str, testrail_domain: str | None) -> bool:
+    s = line.strip()
+    if not s:
+        return False
+    if testrail_domain:
+        return ("http://" in s or "https://" in s) and (testrail_domain in s)
+    return ("http://" in s or "https://" in s) and ("testrail" in s.lower())
+
+
+def is_linked(lines: list[str], func_idx: int, testrail_domain: str | None) -> bool:
+    """
+    Rules:
+      1) If prev1 is empty => missing
+      2) If prev1 is a TestRail URL => linked
+      3) If prev1 is // Smoke... or // Smoketest... => linked iff prev2 is TestRail URL
+      4) Otherwise => missing
+    """
+    if func_idx == 0:
+        return False
+
+    prev1 = lines[func_idx - 1]
+
+    if prev1.strip() == "":
+        return False
+
+    if is_testrail_url_line(prev1, testrail_domain):
+        return True
+
+    if SMOKE_RE.match(prev1):
+        if func_idx < 2:
+            return False
+        prev2 = lines[func_idx - 2]
+        return is_testrail_url_line(prev2, testrail_domain)
+
+    return False
+
+
+def should_ignore_file(path: Path) -> bool:
+    # Ignore accessibility tests
+    if path.name.startswith("A11y"):
+        return True
+
+    # Ignore performance test files by name (e.g. PerformanceTests.swift)
+    if path.name.startswith("PerformanceTests"):
+        return True
+
+    # Ignore performance test files by name (e.g. PerformanceTests.swift)
+    if path.name.startswith("ExperimentIntegrationTests"):
+        return True
+
+    # Ignore specific directories anywhere in the path
+    for part in path.parts:
+        if part in IGNORED_DIRS:
+            return True
+
+    return False
+
+
+def scan_file(path: Path, testrail_domain: str | None, debug: bool) -> tuple[int, list[MissingLink]]:
+    if should_ignore_file(path):
+        return 0, []
+
+    missing: list[MissingLink] = []
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+    found_tests = 0
+
+    for i, line in enumerate(lines):
+        m = TEST_FUNC_RE.match(line)
+        if not m:
+            continue
+
+        found_tests += 1
+        test_name = m.group(1)
+
+        prev1 = lines[i - 1].rstrip() if i > 0 else "<start of file>"
+        prev2 = lines[i - 2].rstrip() if i > 1 else "<start of file>"
+
+        linked = is_linked(lines, i, testrail_domain)
+
+        if debug:
+            verdict = "LINKED" if linked else "MISSING"
+            print(f"[{verdict}] {path}:{i+1} {test_name}")
+            print(f"  prev1: {prev1.strip() or '<empty>'}")
+            print(f"  prev2: {prev2.strip() or '<empty>'}")
+
+        if not linked:
+            missing.append(
+                MissingLink(
+                    file=path,
+                    line_no=i + 1,
+                    test_name=test_name,
+                    prev1=prev1,
+                    prev2=prev2,
+                )
+            )
+
+    return found_tests, missing
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Detect Swift XCUITests missing a TestRail URL above the test function."
+    )
+    ap.add_argument("--root", required=True)
+    ap.add_argument("--testrail-domain", default=None)
+    ap.add_argument("--fail", action="store_true")
+    ap.add_argument("--debug", action="store_true")
+    args = ap.parse_args()
+
+    root = Path(args.root)
+    if not root.exists():
+        print(f"ERROR: root does not exist: {root}", file=sys.stderr)
+        return 2
+
+    swift_files = sorted(root.rglob("*.swift"))
+
+    total_tests = 0
+    all_missing: list[MissingLink] = []
+
+    for f in swift_files:
+        found, missing = scan_file(f, args.testrail_domain, args.debug)
+        total_tests += found
+        all_missing.extend(missing)
+
+    print(f"\nScanned {len(swift_files)} Swift files, found {total_tests} tests.")
+
+    if not all_missing:
+        print("✅ No missing TestRail URLs found.")
+        return 0
+
+    print(f"\n❌ Found {len(all_missing)} tests missing TestRail URLs:\n")
+    for item in all_missing:
+        p1 = item.prev1.strip() or "<empty>"
+        p2 = item.prev2.strip() or "<empty>"
+        print(f"- {item.file}:{item.line_no}  {item.test_name}")
+        print(f"  prev1: {p1}")
+        print(f"  prev2: {p2}")
+
+    return 1 if args.fail else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
This is a first step working on the testrail clean up / organization. The intent is to identify those tests without a testrail tests associated not only to update what we have now but to be aware when developers create new tests directly in the repo