### PR TITLE
Refactor MTE-4971 Missed version bump in github actions

### DIFF
--- a/.github/workflows/ios-appstore-ratings.yml
+++ b/.github/workflows/ios-appstore-ratings.yml
@@ -24,10 +24,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
     
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
         cache: 'pip'  


### PR DESCRIPTION
This PR is to bump the missed Github Actions upgrade in the "Monitor iOS App Store Ratings" Github Actions.
https://github.com/mozilla-mobile/testops-tools/pull/210
https://github.com/mozilla-mobile/testops-tools/pull/209 (The versions for `save` and `restore` have been updated.)
https://github.com/mozilla-mobile/testops-tools/pull/211

Sample Github Actions workflow run: https://github.com/mozilla-mobile/testops-tools/actions/runs/21451538010