### PR TITLE
Add Report for number of full functional tests

### DIFF
--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -99,10 +99,7 @@ jobs:
           echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
-          header="*Test Case Counts (Full Functional Tests Suite)*"
-          table_header=$(printf "%-20s %8s  %-10s" "Suite" "Count" "Change")
-          table_sep=$(printf "%-20s %8s  %-10s" "--------------------" "--------" "----------")
-          rows=""
+          blocks=$(jq -n '[{"type":"header","text":{"type":"plain_text","text":"Test Case Counts — Full Functional Tests Suite"}}]')
           counts_json='{}'
           for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite"; do
             csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
@@ -121,13 +118,17 @@ jobs:
               else
                 change="-"
               fi
-              rows="${rows}"$'\n'"$(printf "%-20s %8s  %-10s" "$project" "$count" "$change")"
+              section=$(jq -n \
+                --arg suite "$project" \
+                --arg count "$count" \
+                --arg change "$change" \
+                '{"type":"section","text":{"type":"mrkdwn","text":("*" + $suite + "*")},"fields":[{"type":"mrkdwn","text":("*Count*\n" + $count)},{"type":"mrkdwn","text":("*Change*\n" + $change)}]}')
+              blocks=$(echo "$blocks" | jq --argjson s "$section" '. + [$s]')
               counts_json=$(echo "$counts_json" | jq --arg key "$display" --argjson val "$count" '. + {($key): $val}')
             fi
           done
-          message="${header}"$'\n'"$(printf '```')"$'\n'"${table_header}"$'\n'"${table_sep}${rows}"$'\n'"$(printf '```')"
           echo "$counts_json" > ../test-counts.json
-          jq -n --arg text "$message" '{"text": $text}' > ../slack-counts.json
+          jq -n --argjson blocks "$blocks" '{"blocks": $blocks}' > ../slack-counts.json
 
       - name: Commit updated test counts
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -114,8 +114,8 @@ jobs:
               prev=$(jq -r --arg key "$display" '.[$key] // empty' ../test-counts.json)
               if [ -n "$prev" ]; then
                 delta=$((count - prev))
-                if [ $delta -gt 0 ]; then change="+${delta}"
-                elif [ $delta -lt 0 ]; then change="${delta}"
+                if [ $delta -gt 0 ]; then change="↑ +${delta}"
+                elif [ $delta -lt 0 ]; then change="↓ ${delta}"
                 else change="no change"
                 fi
               else

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -73,17 +73,17 @@ jobs:
           echo "filename=$filename" >> $GITHUB_ENV
           echo "subdir=$subdir" >> $GITHUB_ENV
 
-      # - name: Establish Google Cloud connection
-      #   uses: google-github-actions/auth@v3
-      #   with:
-      #     credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      - name: Establish Google Cloud connection
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
-      # - name: Upload CSV files to GCP bucket
-      #   id: upload-file
-      #   uses: google-github-actions/upload-cloud-storage@v3
-      #   with:
-      #     path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
-      #     destination: ${{ env.BUCKET }}/${{ env.subdir }}
+      - name: Upload CSV files to GCP bucket
+        id: upload-file
+        uses: google-github-actions/upload-cloud-storage@v3
+        with:
+          path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
+          destination: ${{ env.BUCKET }}/${{ env.subdir }}
 
       - name: Output URL to Github Actions summary
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -96,7 +96,7 @@ jobs:
 
       - name: Output test case counts to Github Actions summary
         run: |
-          echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
+          echo ":testops-testrail: Full Functional Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
           table_rows='[[{"type":"raw_text","text":"Suite"},{"type":"raw_text","text":"Count"},{"type":"raw_text","text":"Change"}]]'

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -128,7 +128,8 @@ jobs:
             fi
           done
           echo "$counts_json" > ../test-counts.json
-          jq -n --argjson rows "$table_rows" '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Test Case Counts — Full Functional Tests Suite"}},{"type":"table","rows":$rows}]}' > ../slack-counts.json
+          today=$(date "+%Y-%m-%d")
+          jq -n --argjson rows "$table_rows" --arg date "$today" '{"blocks":[{"type":"header","text":{"type":"plain_text","text":("Test Case Counts — " + $date)}},{"type":"table","rows":$rows}]}' > ../slack-counts.json
 
       - name: Commit updated test counts
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -19,6 +19,8 @@ jobs:
   test:
     name: Backup test suites
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     defaults:
       run:
         working-directory: ${{ env.DEFAULT_DIR }}
@@ -75,7 +77,7 @@ jobs:
       #   uses: google-github-actions/auth@v3
       #   with:
       #     credentials_json: ${{ secrets.GCLOUD_AUTH }}
-    
+
       # - name: Upload CSV files to GCP bucket
       #   id: upload-file
       #   uses: google-github-actions/upload-cloud-storage@v3
@@ -95,18 +97,40 @@ jobs:
       - name: Output test case counts to Github Actions summary
         run: |
           echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
+          [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
           message="Test Case Counts (Full Functional Tests Suite)"
+          counts_json='{}'
           for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite" "Focus for iOS_Full Functional Tests Suite" "Focus for Android_Full Functional Tests Suite"; do
             csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
             if [ -n "$csvfile" ]; then
               count=$(awk -F',' 'NR>1 && $1+0>0 {c++} END {print c+0}' "$csvfile")
               echo "* ${suite}: ${count} test cases" >> $GITHUB_STEP_SUMMARY
               display=$(echo "$suite" | sed 's/_/ - /')
-              message="${message}"$'\n'"• ${display}: ${count} test cases"
+              prev=$(jq -r --arg key "$display" '.[$key] // empty' ../test-counts.json)
+              if [ -n "$prev" ]; then
+                delta=$((count - prev))
+                if [ $delta -gt 0 ]; then change=" _(+${delta})_"
+                elif [ $delta -lt 0 ]; then change=" _(${delta})_"
+                else change=" _(no change)_"
+                fi
+              else
+                change=""
+              fi
+              message="${message}"$'\n'"• ${display}: ${count} test cases${change}"
+              counts_json=$(echo "$counts_json" | jq --arg key "$display" --argjson val "$count" '. + {($key): $val}')
             fi
           done
+          echo "$counts_json" > ../test-counts.json
           jq -n --arg text "$message" '{"text": $text}' > ../slack-counts.json
+
+      - name: Commit updated test counts
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add test-counts.json
+          git diff --staged --quiet || git commit -m "Update test case counts [skip ci]"
+          git push
 
       - name: Notify Slack - Test case counts
         uses: slackapi/slack-github-action@v3.0.1

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -73,17 +73,17 @@ jobs:
           echo "filename=$filename" >> $GITHUB_ENV
           echo "subdir=$subdir" >> $GITHUB_ENV
 
-      - name: Establish Google Cloud connection
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      # - name: Establish Google Cloud connection
+      #   uses: google-github-actions/auth@v3
+      #   with:
+      #     credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
-      - name: Upload CSV files to GCP bucket
-        id: upload-file
-        uses: google-github-actions/upload-cloud-storage@v3
-        with:
-          path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
-          destination: ${{ env.BUCKET }}/${{ env.subdir }}
+      # - name: Upload CSV files to GCP bucket
+      #   id: upload-file
+      #   uses: google-github-actions/upload-cloud-storage@v3
+      #   with:
+      #     path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
+      #     destination: ${{ env.BUCKET }}/${{ env.subdir }}
 
       - name: Output URL to Github Actions summary
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -94,15 +94,25 @@ jobs:
 
       - name: Output test case counts to Github Actions summary
         run: |
-          echo "## Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
+          echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           cd $filename
+          message="Test Case Counts (Full Functional Tests Suite)"
           for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite" "Focus for iOS_Full Functional Tests Suite" "Focus for Android_Full Functional Tests Suite"; do
             csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
             if [ -n "$csvfile" ]; then
               count=$(awk -F',' 'NR>1 && $1+0>0 {c++} END {print c+0}' "$csvfile")
-              echo "* **${suite}**: ${count} test cases" >> $GITHUB_STEP_SUMMARY
+              echo "* ${suite}: ${count} test cases" >> $GITHUB_STEP_SUMMARY
+              message="${message}\n• ${suite}: ${count} test cases"
             fi
           done
+          jq -n --arg text "$message" '{"text": $text}' > ../slack-counts.json
+
+      - name: Notify Slack - Test case counts
+        uses: slackapi/slack-github-action@v3.0.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_TEST_ALERTS_SANDBOX }}
+          webhook-type: incoming-webhook
+          payload-file-path: ${{ env.DEFAULT_DIR }}/slack-counts.json
 
       - name: Notify Slack (Fail)
         uses: slackapi/slack-github-action@v3.0.1

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -71,17 +71,17 @@ jobs:
           echo "filename=$filename" >> $GITHUB_ENV
           echo "subdir=$subdir" >> $GITHUB_ENV
 
-      - name: Establish Google Cloud connection
-        uses: google-github-actions/auth@v3
-        with:
-          credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      # - name: Establish Google Cloud connection
+      #   uses: google-github-actions/auth@v3
+      #   with:
+      #     credentials_json: ${{ secrets.GCLOUD_AUTH }}
     
-      - name: Upload CSV files to GCP bucket
-        id: upload-file
-        uses: google-github-actions/upload-cloud-storage@v3
-        with:
-          path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
-          destination: ${{ env.BUCKET }}/${{ env.subdir }}
+      # - name: Upload CSV files to GCP bucket
+      #   id: upload-file
+      #   uses: google-github-actions/upload-cloud-storage@v3
+      #   with:
+      #     path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
+      #     destination: ${{ env.BUCKET }}/${{ env.subdir }}
 
       - name: Output URL to Github Actions summary
         run: |
@@ -91,6 +91,18 @@ jobs:
           cd $filename
           ls *.csv > files.txt
           awk -F '_' '{print "* " $2 }' < files.txt | uniq >> $GITHUB_STEP_SUMMARY
+
+      - name: Output test case counts to Github Actions summary
+        run: |
+          echo "## Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
+          cd $filename
+          for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite" "Focus for iOS_Full Functional Tests Suite" "Focus for Android_Full Functional Tests Suite"; do
+            csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
+            if [ -n "$csvfile" ]; then
+              count=$(awk -F',' 'NR>1 && $1+0>0 {c++} END {print c+0}' "$csvfile")
+              echo "* **${suite}**: ${count} test cases" >> $GITHUB_STEP_SUMMARY
+            fi
+          done
 
       - name: Notify Slack (Fail)
         uses: slackapi/slack-github-action@v3.0.1

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -99,28 +99,33 @@ jobs:
           echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
-          message="Test Case Counts (Full Functional Tests Suite)"
+          header="*Test Case Counts (Full Functional Tests Suite)*"
+          table_header=$(printf "%-20s %8s  %-10s" "Suite" "Count" "Change")
+          table_sep=$(printf "%-20s %8s  %-10s" "--------------------" "--------" "----------")
+          rows=""
           counts_json='{}'
-          for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite" "Focus for iOS_Full Functional Tests Suite" "Focus for Android_Full Functional Tests Suite"; do
+          for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite"; do
             csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
             if [ -n "$csvfile" ]; then
               count=$(awk -F',' 'NR>1 && $1+0>0 {c++} END {print c+0}' "$csvfile")
               echo "* ${suite}: ${count} test cases" >> $GITHUB_STEP_SUMMARY
               display=$(echo "$suite" | sed 's/_/ - /')
+              project=$(echo "$suite" | sed 's/_Full Functional Tests Suite//')
               prev=$(jq -r --arg key "$display" '.[$key] // empty' ../test-counts.json)
               if [ -n "$prev" ]; then
                 delta=$((count - prev))
-                if [ $delta -gt 0 ]; then change=" _(+${delta})_"
-                elif [ $delta -lt 0 ]; then change=" _(${delta})_"
-                else change=" _(no change)_"
+                if [ $delta -gt 0 ]; then change="+${delta}"
+                elif [ $delta -lt 0 ]; then change="${delta}"
+                else change="no change"
                 fi
               else
-                change=""
+                change="-"
               fi
-              message="${message}"$'\n'"• ${display}: ${count} test cases${change}"
+              rows="${rows}"$'\n'"$(printf "%-20s %8s  %-10s" "$project" "$count" "$change")"
               counts_json=$(echo "$counts_json" | jq --arg key "$display" --argjson val "$count" '. + {($key): $val}')
             fi
           done
+          message="${header}"$'\n'"$(printf '```')"$'\n'"${table_header}"$'\n'"${table_sep}${rows}"$'\n'"$(printf '```')"
           echo "$counts_json" > ../test-counts.json
           jq -n --arg text "$message" '{"text": $text}' > ../slack-counts.json
 

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -99,7 +99,7 @@ jobs:
           echo "Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
-          blocks=$(jq -n '[{"type":"header","text":{"type":"plain_text","text":"Test Case Counts — Full Functional Tests Suite"}}]')
+          table_rows='[[{"type":"raw_text","text":"Suite"},{"type":"raw_text","text":"Count"},{"type":"raw_text","text":"Change"}]]'
           counts_json='{}'
           for suite in "Fenix Browser_Full Functional Tests Suite" "Firefox for iOS_Full Functional Tests Suite"; do
             csvfile=$(ls "backup_${suite}_"*.csv 2>/dev/null | head -1)
@@ -118,17 +118,17 @@ jobs:
               else
                 change="-"
               fi
-              section=$(jq -n \
+              row=$(jq -n \
                 --arg suite "$project" \
                 --arg count "$count" \
                 --arg change "$change" \
-                '{"type":"section","text":{"type":"mrkdwn","text":("*" + $suite + "*")},"fields":[{"type":"mrkdwn","text":("*Count*\n" + $count)},{"type":"mrkdwn","text":("*Change*\n" + $change)}]}')
-              blocks=$(echo "$blocks" | jq --argjson s "$section" '. + [$s]')
+                '[{"type":"raw_text","text":$suite},{"type":"raw_text","text":$count},{"type":"raw_text","text":$change}]')
+              table_rows=$(echo "$table_rows" | jq --argjson row "$row" '. + [$row]')
               counts_json=$(echo "$counts_json" | jq --arg key "$display" --argjson val "$count" '. + {($key): $val}')
             fi
           done
           echo "$counts_json" > ../test-counts.json
-          jq -n --argjson blocks "$blocks" '{"blocks": $blocks}' > ../slack-counts.json
+          jq -n --argjson rows "$table_rows" '{"blocks":[{"type":"header","text":{"type":"plain_text","text":"Test Case Counts — Full Functional Tests Suite"}},{"type":"table","rows":$rows}]}' > ../slack-counts.json
 
       - name: Commit updated test counts
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -73,17 +73,17 @@ jobs:
           echo "filename=$filename" >> $GITHUB_ENV
           echo "subdir=$subdir" >> $GITHUB_ENV
 
-      # - name: Establish Google Cloud connection
-      #   uses: google-github-actions/auth@v3
-      #   with:
-      #     credentials_json: ${{ secrets.GCLOUD_AUTH }}
+      - name: Establish Google Cloud connection
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCLOUD_AUTH }}
 
-      # - name: Upload CSV files to GCP bucket
-      #   id: upload-file
-      #   uses: google-github-actions/upload-cloud-storage@v3
-      #   with:
-      #     path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
-      #     destination: ${{ env.BUCKET }}/${{ env.subdir }}
+      - name: Upload CSV files to GCP bucket
+        id: upload-file
+        uses: google-github-actions/upload-cloud-storage@v3
+        with:
+          path: ${{ env.DEFAULT_DIR }}/${{ env.filename }}.tgz
+          destination: ${{ env.BUCKET }}/${{ env.subdir }}
 
       - name: Output URL to Github Actions summary
         run: |
@@ -96,7 +96,7 @@ jobs:
 
       - name: Output test case counts to Github Actions summary
         run: |
-          echo ":testops-testrail: Full Functional Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
+          echo "Full Functional Test Case Counts (Full Functional Tests Suite)" >> $GITHUB_STEP_SUMMARY
           [ -f test-counts.json ] || echo '{}' > test-counts.json
           cd $filename
           table_rows='[[{"type":"raw_text","text":"Suite"},{"type":"raw_text","text":"Count"},{"type":"raw_text","text":"Change"}]]'
@@ -129,7 +129,7 @@ jobs:
           done
           echo "$counts_json" > ../test-counts.json
           today=$(date "+%Y-%m-%d")
-          jq -n --argjson rows "$table_rows" --arg date "$today" '{"blocks":[{"type":"header","text":{"type":"plain_text","text":("Test Case Counts — " + $date)}},{"type":"table","rows":$rows}]}' > ../slack-counts.json
+          jq -n --argjson rows "$table_rows" --arg date "$today" '{"blocks":[{"type":"header","text":{"type":"plain_text","text":(":testops-testrail:Full Functional Test Case Counts — " + $date)}},{"type":"table","rows":$rows}]}' > ../slack-counts.json
 
       - name: Commit updated test counts
         run: |

--- a/.github/workflows/testrail-backup.yml
+++ b/.github/workflows/testrail-backup.yml
@@ -102,7 +102,8 @@ jobs:
             if [ -n "$csvfile" ]; then
               count=$(awk -F',' 'NR>1 && $1+0>0 {c++} END {print c+0}' "$csvfile")
               echo "* ${suite}: ${count} test cases" >> $GITHUB_STEP_SUMMARY
-              message="${message}\n• ${suite}: ${count} test cases"
+              display=$(echo "$suite" | sed 's/_/ - /')
+              message="${message}"$'\n'"• ${display}: ${count} test cases"
             fi
           done
           jq -n --arg text "$message" '{"text": $text}' > ../slack-counts.json

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,4 +1,4 @@
 {
-  "Fenix Browser - Full Functional Tests Suite": 1426,
-  "Firefox for iOS - Full Functional Tests Suite": 1702
+  "Fenix Browser - Full Functional Tests Suite": 1444,
+  "Firefox for iOS - Full Functional Tests Suite": 1694
 }

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,6 +1,4 @@
 {
   "Fenix Browser - Full Functional Tests Suite": 1444,
-  "Firefox for iOS - Full Functional Tests Suite": 1694,
-  "Focus for iOS - Full Functional Tests Suite": 116,
-  "Focus for Android - Full Functional Tests Suite": 201
+  "Firefox for iOS - Full Functional Tests Suite": 1694
 }

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,0 +1,6 @@
+{
+  "Fenix Browser - Full Functional Tests Suite": 1444,
+  "Firefox for iOS - Full Functional Tests Suite": 1694,
+  "Focus for iOS - Full Functional Tests Suite": 116,
+  "Focus for Android - Full Functional Tests Suite": 201
+}

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,4 +1,4 @@
 {
-  "Fenix Browser - Full Functional Tests Suite": 1410,
-  "Firefox for iOS - Full Functional Tests Suite": 1701
+  "Fenix Browser - Full Functional Tests Suite": 1444,
+  "Firefox for iOS - Full Functional Tests Suite": 1694
 }

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,4 +1,4 @@
 {
-  "Fenix Browser - Full Functional Tests Suite": 1444,
-  "Firefox for iOS - Full Functional Tests Suite": 1694
+  "Fenix Browser - Full Functional Tests Suite": 1426,
+  "Firefox for iOS - Full Functional Tests Suite": 1702
 }

--- a/backup-tools/test-counts.json
+++ b/backup-tools/test-counts.json
@@ -1,4 +1,4 @@
 {
-  "Fenix Browser - Full Functional Tests Suite": 1444,
-  "Firefox for iOS - Full Functional Tests Suite": 1694
+  "Fenix Browser - Full Functional Tests Suite": 1410,
+  "Firefox for iOS - Full Functional Tests Suite": 1701
 }


### PR DESCRIPTION
For the upcoming TestRail configuration work, Mobile Test Engineering anticipate a decrease in the number of tests in the full functional test suite with the use of configuration settings. Using the existing TestRail backup job, let's report the number of full functional tests on both Firefox iOS and Firefox Android. Over time, we can see how many tests are decreasing on the weekly basis.

Each Slack notification prints the count of the full functional tests on the day and the differences from the last run.
<img width="475" height="159" alt="Screenshot 2026-04-01 at 16 38 12" src="https://github.com/user-attachments/assets/79d7ee93-5ffd-4ba7-b563-28643a1f2bdc" />
