### PR TITLE
Add changelog check after a new release is created

### DIFF
--- a/.github/workflows/changelog-analysis.yml
+++ b/.github/workflows/changelog-analysis.yml
@@ -6,6 +6,7 @@ on:
       - irios-new-jenkins-file-verify-release-tags
     paths:
       - 'changelog-analysis/**'
+      - '.github/workflows/**'
   workflow_dispatch:
     inputs:
       base_tag:

--- a/.github/workflows/changelog-analysis.yml
+++ b/.github/workflows/changelog-analysis.yml
@@ -1,0 +1,36 @@
+name: Changelog Analysis
+
+on:
+  push:
+    branches:
+      - irios-new-jenkins-file-verify-release-tags
+    paths:
+      - 'changelog-analysis/**'
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Previous release tag (e.g. firefox-v149.3) — leave blank to auto-detect'
+        required: false
+      head_tag:
+        description: 'Current release tag (e.g. firefox-v150.1) — leave blank to auto-detect'
+        required: false
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: pip install requests pyyaml
+
+      - name: Run changelog analysis
+        run: |
+          if [ -n "${{ inputs.base_tag }}" ] && [ -n "${{ inputs.head_tag }}" ]; then
+            python3 changelog-analysis/run_release_selection.py ${{ inputs.base_tag }} ${{ inputs.head_tag }}
+          else
+            python3 changelog-analysis/run_release_selection.py
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog-analysis.yml
+++ b/.github/workflows/changelog-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run changelog analysis
         run: |
           if [ -n "${{ inputs.base_tag }}" ] && [ -n "${{ inputs.head_tag }}" ]; then
-            python3 changelog-analysis/run_release_selection.py ${{ inputs.base_tag }} ${{ inputs.head_tag }}
+            python3 changelog-analysis/run_release_selection.py --base_tag ${{ inputs.base_tag }} --head_tag ${{ inputs.head_tag }}
           else
             python3 changelog-analysis/run_release_selection.py
           fi

--- a/changelog-analysis/Jenkinsfile.create-smart-test-runs
+++ b/changelog-analysis/Jenkinsfile.create-smart-test-runs
@@ -1,0 +1,113 @@
+pipeline {
+    agent any
+
+    parameters {
+        string(name: 'MILESTONE_ID', description: 'TestRail milestone ID')
+    }
+
+    options {
+        timestamps()
+    }
+
+    environment {
+        PATH          = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:${env.PATH}"
+        GITHUB_TOKEN  = credentials('github-token')
+        SLACK_WEBHOOK = credentials('slack-mobile-alerts-tooling-webhook')
+    }
+
+    stages {
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Setup Python') {
+            steps {
+                sh '''
+                    set -e
+                    python3 --version
+                    python3 -m pip --version
+                '''
+            }
+        }
+
+        stage('Install Dependencies') {
+            steps {
+                dir('changelog-analysis') {
+                    sh 'pip3 install --no-cache-dir -r requirements.txt'
+                }
+            }
+        }
+
+        stage('Get Changelog') {
+            steps {
+                dir('changelog-analysis') {
+                    script {
+                        def output = sh(
+                            script: 'python3 run_release_selection.py',
+                            returnStdout: true
+                        ).trim()
+
+                        echo output
+
+                        def headMatch = output =~ /Head tag from latest_tags\.json:\s+(\S+)/
+                        def baseMatch = output =~ /Base tag \(previous version\):\s+(\S+)/
+
+                        env.HEAD_TAG = headMatch ? headMatch[0][1] : 'unknown'
+                        env.BASE_TAG = baseMatch ? baseMatch[0][1] : 'unknown'
+
+                        echo "Changelog: ${env.BASE_TAG} → ${env.HEAD_TAG}"
+                    }
+                }
+            }
+        }
+
+        stage('Notify') {
+            steps {
+                sh """
+                    curl -X POST ${SLACK_WEBHOOK} \
+                    -H 'Content-Type: application/json' \
+                    -d '{
+                        "text": ":mag: *Smart Test Run — Changelog Analysis*",
+                        "attachments": [{
+                            "color": "good",
+                            "fields": [
+                                {"title": "From",         "value": "${env.BASE_TAG}", "short": true},
+                                {"title": "To",           "value": "${env.HEAD_TAG}", "short": true},
+                                {"title": "Milestone ID", "value": "${params.MILESTONE_ID}", "short": true},
+                                {"title": "Status", "value": "Changelog captured — test run creation coming soon", "short": false}
+                            ]
+                        }]
+                    }'
+                """
+            }
+        }
+    }
+
+    post {
+        regression {
+            script {
+                sh """
+                    curl -X POST ${SLACK_WEBHOOK} \
+                    -H 'Content-Type: application/json' \
+                    -d '{
+                        "text": ":x: *REGRESSION*: ${env.JOB_NAME}",
+                        "attachments": [{
+                            "color": "danger",
+                            "fields": [
+                                {"title": "Job",     "value": "${env.JOB_NAME}", "short": true},
+                                {"title": "Build",   "value": "#${env.BUILD_NUMBER}", "short": true},
+                                {"title": "Console", "value": "<${env.BUILD_URL}console|View Logs>", "short": false}
+                            ]
+                        }]
+                    }'
+                """
+            }
+        }
+
+        cleanup {
+            cleanWs()
+        }
+    }
+}

--- a/changelog-analysis/Jenkinsfile.create-smart-test-runs
+++ b/changelog-analysis/Jenkinsfile.create-smart-test-runs
@@ -2,6 +2,7 @@ pipeline {
     agent any
 
     parameters {
+        string(name: 'RELEASE_TAG',  description: 'Current release tag (e.g., firefox-v145.0)')
         string(name: 'MILESTONE_ID', description: 'TestRail milestone ID')
     }
 
@@ -12,7 +13,7 @@ pipeline {
     environment {
         PATH          = "/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin:${env.PATH}"
         GITHUB_TOKEN  = credentials('github-token')
-        SLACK_WEBHOOK = credentials('slack-mobile-alerts-tooling-webhook')
+        SLACK_WEBHOOK = credentials('slack-mobile-alerts-sandbox-webhook')
     }
 
     stages {
@@ -35,7 +36,11 @@ pipeline {
         stage('Install Dependencies') {
             steps {
                 dir('changelog-analysis') {
-                    sh 'pip3 install --no-cache-dir -r requirements.txt'
+                    sh '''
+                        set -e
+                        python3 -m venv .venv
+                        .venv/bin/pip install --no-cache-dir -r requirements.txt
+                    '''
                 }
             }
         }
@@ -45,14 +50,14 @@ pipeline {
                 dir('changelog-analysis') {
                     script {
                         def output = sh(
-                            script: 'python3 run_release_selection.py',
+                            script: ".venv/bin/python3 run_release_selection.py --head_tag ${params.RELEASE_TAG} --milestone_id ${params.MILESTONE_ID}",
                             returnStdout: true
                         ).trim()
 
                         echo output
 
-                        def headMatch = output =~ /Head tag from latest_tags\.json:\s+(\S+)/
-                        def baseMatch = output =~ /Base tag \(previous version\):\s+(\S+)/
+                        def headMatch = output =~ /Head tag:\s+(\S+)/
+                        def baseMatch = output =~ /Base tag:\s+(\S+)/
 
                         env.HEAD_TAG = headMatch ? headMatch[0][1] : 'unknown'
                         env.BASE_TAG = baseMatch ? baseMatch[0][1] : 'unknown'

--- a/changelog-analysis/README.md
+++ b/changelog-analysis/README.md
@@ -1,0 +1,166 @@
+# Smart Test Run Creation — Design
+
+## Goal
+
+Automatically create targeted TestRail test runs based on what code changed between two release versions, added to the same milestone created by the existing iOS release automation.
+
+---
+
+## Current flow (unchanged)
+
+```
+Jenkinsfile.check-bitrise-ios-release-tags  (cron, weekdays)
+  └── detects new Bitrise tag
+  └── triggers ↓
+
+Jenkinsfile.create-milestone  (parameterised: RELEASE_TAG, RELEASE_NAME)
+  └── testrail_main_ios.py
+        └── creates milestone + standard smoke/functional test runs
+        └── sends Slack notification
+```
+
+---
+
+## Proposed addition
+
+```
+Jenkinsfile.create-milestone  (small addition — see below)
+  └── after milestone is created, triggers ↓  (wait: false)
+
+Jenkinsfile.create-smart-test-runs  (new — lives in changelog-analysis/)
+  params: RELEASE_TAG, MILESTONE_ID
+  └── get_release_tags.py   → fetches two latest firefox-v* tags from Bitrise
+  │                            (RELEASE_TAG = head, previous tag = base)
+  └── get_change_log.py     → GitHub compare API between base..head
+  │                            → filters non-product files
+  │                            → maps changed files to component labels (rules.yml)
+  └── get_cases.py          → fetches TestRail cases matching those labels
+  └── creates test runs in the milestone (MILESTONE_ID)
+```
+
+---
+
+## Changes required
+
+### 1. `testrail/testrail_main_ios.py` — expose milestone ID (2 lines)
+
+After the `testrail.create_milestone(...)` call, write the ID to a file so the Jenkinsfile can pass it to the next job:
+
+```python
+milestone = testrail.create_milestone(
+    testrail_project_id, milestone_name, milestone_description
+)
+# Add these two lines:
+with open("milestone_id.txt", "w") as f:
+    f.write(str(milestone["id"]))
+```
+
+### 2. `testrail/Jenkinsfile.create-milestone` — trigger new job
+
+Add a new stage after `Create Milestone`, inside the `when { MILESTONE_CREATED == 'true' }` block:
+
+```groovy
+stage('Trigger Smart Test Runs') {
+    when {
+        expression { env.MILESTONE_CREATED == 'true' }
+    }
+    steps {
+        script {
+            def milestoneId = readFile('testrail/milestone_id.txt').trim()
+            build job: 'create-smart-test-runs',
+                  parameters: [
+                      string(name: 'RELEASE_TAG',   value: params.RELEASE_TAG),
+                      string(name: 'MILESTONE_ID',  value: milestoneId)
+                  ],
+                  wait: false
+        }
+    }
+}
+```
+
+Also add `BITRISE_TOKEN = credentials('bitrise-token')` to the environment block.
+
+### 3. `changelog-analysis/Jenkinsfile.create-smart-test-runs` — new file
+
+New Jenkins job, configured in Jenkins pointing at this Jenkinsfile.
+
+```groovy
+pipeline {
+    agent any
+
+    parameters {
+        string(name: 'RELEASE_TAG',  description: 'e.g. firefox-v150.0')
+        string(name: 'MILESTONE_ID', description: 'TestRail milestone ID')
+    }
+
+    environment {
+        BITRISE_TOKEN  = credentials('bitrise-token')
+        GITHUB_TOKEN   = credentials('github-token')
+        TESTRAIL_HOST  = credentials('testrail-host')
+    }
+
+    stages {
+        stage('Checkout') { steps { checkout scm } }
+
+        stage('Install Dependencies') {
+            steps {
+                dir('changelog-analysis') {
+                    sh 'pip3 install --no-cache-dir -r requirements.txt'
+                }
+            }
+        }
+
+        stage('Create Smart Test Runs') {
+            steps {
+                dir('changelog-analysis') {
+                    withCredentials([usernamePassword(
+                        credentialsId: 'testrail-credentials',
+                        usernameVariable: 'TESTRAIL_USERNAME',
+                        passwordVariable: 'TESTRAIL_PASSWORD')]) {
+                        sh '''
+                            python3 run_release_selection.py \
+                                --head_tag   ${RELEASE_TAG} \
+                                --milestone_id ${MILESTONE_ID}
+                        '''
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+### 4. `changelog-analysis/run_release_selection.py` — add `--head_tag` arg
+
+Currently accepts `base_tag` + `head_tag` as positional args or auto-detects both from Bitrise.  
+Add a `--head_tag` option so Jenkins can supply the known head tag while the script derives `base_tag` automatically from Bitrise:
+
+```
+python3 run_release_selection.py --head_tag firefox-v150.0 --milestone_id 12345
+```
+
+### 5. `changelog-analysis/requirements.txt` — new file
+
+```
+requests
+pyyaml
+```
+
+---
+
+## Credentials needed in Jenkins
+
+| Credential ID      | Used by                        |
+|--------------------|--------------------------------|
+| `bitrise-token`    | get_release_tags.py (Bitrise API) |
+| `github-token`     | get_change_log.py (GitHub API, optional but avoids rate limits) |
+| `testrail-credentials` | get_cases.py (TestRail API) |
+| `testrail-host`    | get_cases.py                   |
+
+---
+
+## What stays unchanged
+
+- `Jenkinsfile.check-bitrise-ios-release-tags`
+- `testrail_main_ios.py` logic (only two lines added)
+- All existing test run creation behaviour

--- a/changelog-analysis/get_change_log.py
+++ b/changelog-analysis/get_change_log.py
@@ -1,0 +1,153 @@
+import os
+from pathlib import Path
+import requests
+import yaml
+from typing import List, Set, Tuple
+
+RULES_FILE = "rules.yml"
+OWNER = "mozilla-mobile"
+REPO = "firefox-ios"
+TAG_PREFIX = "firefox-v"
+
+IGNORED_DIRECTORIES = [
+    ".github/workflows/",
+    "taskcluster/",
+]
+
+IGNORED_FILENAMES = [
+    ".swiftlint.yml",
+    "README.md",
+    "bitrise.yml",
+    "version.txt",
+]
+
+IGNORED_EXACT_PATHS = [
+    "firefox-ios/Client.xcodeproj/project.pbxproj",
+    "firefox-ios/Client/Configuration/version.xcconfig",
+    "taskcluster/requirements.txt",
+]
+
+IGNORED_EXTENSIONS = [
+    ".strings",
+    ".stringsdict",
+]
+
+
+def _github_headers() -> dict:
+    headers = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def get_all_release_tags(owner: str, repo: str, prefix: str = TAG_PREFIX) -> List[str]:
+    """Return all release tags matching prefix, sorted by version descending."""
+    url = f"https://api.github.com/repos/{owner}/{repo}/git/matching-refs/tags/{prefix}"
+    all_tags = []
+
+    while url:
+        response = requests.get(url, headers=_github_headers())
+        response.raise_for_status()
+        all_tags.extend(ref["ref"].removeprefix("refs/tags/") for ref in response.json())
+
+        url = None
+        for part in response.headers.get("Link", "").split(","):
+            if 'rel="next"' in part:
+                url = part[part.index("<") + 1: part.index(">")]
+                break
+
+    def version_key(tag: str) -> tuple:
+        try:
+            return tuple(int(p) for p in tag.removeprefix(prefix).split("."))
+        except ValueError:
+            return (0,)
+
+    all_tags.sort(key=version_key, reverse=True)
+    return all_tags
+
+
+def get_base_tag(head_tag: str, owner: str = OWNER, repo: str = REPO,
+                 prefix: str = TAG_PREFIX) -> str:
+    """Return the release tag immediately before head_tag by version."""
+    tags = get_all_release_tags(owner, repo, prefix)
+
+    try:
+        idx = tags.index(head_tag)
+    except ValueError:
+        raise ValueError(f"Tag '{head_tag}' not found in {owner}/{repo}")
+
+    if idx + 1 >= len(tags):
+        raise ValueError(f"No tag before '{head_tag}' found in {owner}/{repo}")
+
+    return tags[idx + 1]
+
+
+def is_ignored_path(path: str) -> bool:
+    p = path.lower()
+
+    if "/tests/" in p or p.startswith("tests/"):
+        return True
+    if "/uitests/" in p or p.startswith("uitests/"):
+        return True
+
+    for d in IGNORED_DIRECTORIES:
+        if p.startswith(d) or f"/{d}" in p:
+            return True
+
+    for exact in IGNORED_EXACT_PATHS:
+        if p == exact.lower():
+            return True
+
+    if Path(p).name in [f.lower() for f in IGNORED_FILENAMES]:
+        return True
+
+    if any(p.endswith(ext) for ext in IGNORED_EXTENSIONS):
+        return True
+
+    return False
+
+
+def load_rules(filename: str):
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    with open(os.path.join(script_dir, filename)) as f:
+        return yaml.safe_load(f).get("rules", [])
+
+
+def map_files_to_components(files: List[str], rules) -> Tuple[Set[str], List[str]]:
+    impacted: Set[str] = set()
+    unmatched: List[str] = []
+
+    for file_path in files:
+        matched = False
+        for rule in rules:
+            if file_path.startswith(rule["prefix"]):
+                impacted.update(rule["components"])
+                matched = True
+        if not matched:
+            unmatched.append(file_path)
+
+    return impacted, unmatched
+
+
+def get_changed_files(owner: str, repo: str, base: str, head: str) -> List[str]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}"
+    response = requests.get(url, headers=_github_headers())
+    response.raise_for_status()
+
+    all_files = [f["filename"] for f in response.json().get("files", [])]
+    filtered = [f for f in all_files if not is_ignored_path(f)]
+
+    print(f"Total changed files (raw): {len(all_files)}")
+    print(f"After filtering ignored paths: {len(filtered)}")
+
+    return filtered
+
+
+def get_impacted_components(base_tag: str, head_tag: str,
+                             owner: str = OWNER, repo: str = REPO) -> List[str]:
+    rules = load_rules(RULES_FILE)
+    changed_files = get_changed_files(owner, repo, base_tag, head_tag)
+    components, unmatched = map_files_to_components(changed_files, rules)
+    print(f"Unmatched files: {len(unmatched)}")
+    return sorted(components)

--- a/changelog-analysis/get_change_log.py
+++ b/changelog-analysis/get_change_log.py
@@ -69,18 +69,22 @@ def get_all_release_tags(owner: str, repo: str, prefix: str = TAG_PREFIX) -> Lis
 
 def get_base_tag(head_tag: str, owner: str = OWNER, repo: str = REPO,
                  prefix: str = TAG_PREFIX) -> str:
-    """Return the release tag immediately before head_tag by version."""
+    """Return the latest released tag with a lower version than head_tag."""
     tags = get_all_release_tags(owner, repo, prefix)
 
-    try:
-        idx = tags.index(head_tag)
-    except ValueError:
-        raise ValueError(f"Tag '{head_tag}' not found in {owner}/{repo}")
+    def version_tuple(tag: str) -> tuple:
+        try:
+            return tuple(int(p) for p in tag.removeprefix(prefix).split("."))
+        except ValueError:
+            return (0,)
 
-    if idx + 1 >= len(tags):
-        raise ValueError(f"No tag before '{head_tag}' found in {owner}/{repo}")
+    head_version = version_tuple(head_tag)
 
-    return tags[idx + 1]
+    for tag in tags:  # already sorted descending
+        if version_tuple(tag) < head_version:
+            return tag
+
+    raise ValueError(f"No released tag before '{head_tag}' found in {owner}/{repo}")
 
 
 def is_ignored_path(path: str) -> bool:

--- a/changelog-analysis/get_change_log.py
+++ b/changelog-analysis/get_change_log.py
@@ -134,12 +134,20 @@ def map_files_to_components(files: List[str], rules) -> Tuple[Set[str], List[str
     return impacted, unmatched
 
 
+def _release_branch(tag: str) -> str:
+    # firefox-v150.2 -> release/v150.2
+    version = tag.rsplit("-v", 1)[-1]
+    return f"release/v{version}"
+
+
 def get_changed_files(owner: str, repo: str, base: str, head: str) -> List[str]:
+    base_ref = _release_branch(base)
+    head_ref = _release_branch(head)
     commit_shas = []
     page = 1
     while True:
         response = requests.get(
-            f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}",
+            f"https://api.github.com/repos/{owner}/{repo}/compare/{base_ref}...{head_ref}",
             headers=_github_headers(),
             params={"per_page": 100, "page": page},
         )

--- a/changelog-analysis/get_change_log.py
+++ b/changelog-analysis/get_change_log.py
@@ -158,6 +158,7 @@ def get_changed_files(owner: str, repo: str, base: str, head: str) -> List[str]:
             break
         page += 1
 
+    print(f"Total commits ({base_ref} → {head_ref}): {len(commit_shas)}")
     all_files: Set[str] = set()
     for sha in commit_shas:
         response = requests.get(

--- a/changelog-analysis/get_change_log.py
+++ b/changelog-analysis/get_change_log.py
@@ -131,16 +131,33 @@ def map_files_to_components(files: List[str], rules) -> Tuple[Set[str], List[str
 
 
 def get_changed_files(owner: str, repo: str, base: str, head: str) -> List[str]:
-    url = f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}"
-    response = requests.get(url, headers=_github_headers())
-    response.raise_for_status()
+    commit_shas = []
+    page = 1
+    while True:
+        response = requests.get(
+            f"https://api.github.com/repos/{owner}/{repo}/compare/{base}...{head}",
+            headers=_github_headers(),
+            params={"per_page": 100, "page": page},
+        )
+        response.raise_for_status()
+        commits = response.json().get("commits", [])
+        commit_shas.extend(c["sha"] for c in commits)
+        if len(commits) < 100:
+            break
+        page += 1
 
-    all_files = [f["filename"] for f in response.json().get("files", [])]
-    filtered = [f for f in all_files if not is_ignored_path(f)]
+    all_files: Set[str] = set()
+    for sha in commit_shas:
+        response = requests.get(
+            f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}",
+            headers=_github_headers(),
+        )
+        response.raise_for_status()
+        all_files.update(f["filename"] for f in response.json().get("files", []))
 
+    filtered = [f for f in sorted(all_files) if not is_ignored_path(f)]
     print(f"Total changed files (raw): {len(all_files)}")
     print(f"After filtering ignored paths: {len(filtered)}")
-
     return filtered
 
 

--- a/changelog-analysis/requirements.txt
+++ b/changelog-analysis/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pyyaml

--- a/changelog-analysis/run_release_selection.py
+++ b/changelog-analysis/run_release_selection.py
@@ -22,20 +22,24 @@ def main():
         description="Smart release test selection based on changelog diff.",
         epilog="Tags are read from testrail/latest_tags.json when not provided explicitly.",
     )
-    parser.add_argument("base_tag", nargs="?", help="Previous release tag")
-    parser.add_argument("head_tag", nargs="?", help="Current release tag")
+    parser.add_argument("--base_tag", help="Previous release tag")
+    parser.add_argument("--head_tag", help="Current release tag")
     parser.add_argument("--milestone_id", type=int, help="TestRail milestone ID")
     args = parser.parse_args()
 
-    if args.base_tag and args.head_tag:
+    if args.head_tag and not args.base_tag:
+        head_tag = args.head_tag
+        base_tag = get_base_tag(head_tag, IOS_OWNER, IOS_REPO)
+    elif args.base_tag and args.head_tag:
         base_tag, head_tag = args.base_tag, args.head_tag
     elif args.base_tag or args.head_tag:
-        parser.error("Provide both base_tag and head_tag, or neither.")
+        parser.error("Provide both --base_tag and --head_tag, or only --head_tag.")
     else:
         head_tag = read_head_tag()
-        print(f"Head tag from latest_tags.json: {head_tag}")
         base_tag = get_base_tag(head_tag, IOS_OWNER, IOS_REPO)
-        print(f"Base tag (previous version):    {base_tag}")
+
+    print(f"Head tag: {head_tag}")
+    print(f"Base tag: {base_tag}")
 
     print(f"\nComparing {base_tag} → {head_tag}")
 

--- a/changelog-analysis/run_release_selection.py
+++ b/changelog-analysis/run_release_selection.py
@@ -1,0 +1,66 @@
+import argparse
+import json
+from pathlib import Path
+from get_change_log import get_base_tag, get_changed_files
+
+LATEST_TAGS_FILE = Path(__file__).resolve().parent.parent / "testrail" / "latest_tags.json"
+IOS_OWNER = "mozilla-mobile"
+IOS_REPO = "firefox-ios"
+
+
+def read_head_tag(product: str = "firefox") -> str:
+    with open(LATEST_TAGS_FILE) as f:
+        state = json.load(f)
+    entry = state.get(product)
+    if not entry or not entry.get("tag"):
+        raise ValueError(f"No tag found for '{product}' in {LATEST_TAGS_FILE}")
+    return entry["tag"]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Smart release test selection based on changelog diff.",
+        epilog="Tags are read from testrail/latest_tags.json when not provided explicitly.",
+    )
+    parser.add_argument("base_tag", nargs="?", help="Previous release tag")
+    parser.add_argument("head_tag", nargs="?", help="Current release tag")
+    parser.add_argument("--milestone_id", type=int, help="TestRail milestone ID")
+    args = parser.parse_args()
+
+    if args.base_tag and args.head_tag:
+        base_tag, head_tag = args.base_tag, args.head_tag
+    elif args.base_tag or args.head_tag:
+        parser.error("Provide both base_tag and head_tag, or neither.")
+    else:
+        head_tag = read_head_tag()
+        print(f"Head tag from latest_tags.json: {head_tag}")
+        base_tag = get_base_tag(head_tag, IOS_OWNER, IOS_REPO)
+        print(f"Base tag (previous version):    {base_tag}")
+
+    print(f"\nComparing {base_tag} → {head_tag}")
+
+    changed_files = get_changed_files(IOS_OWNER, IOS_REPO, base_tag, head_tag)
+
+    print(f"\nChanged files ({len(changed_files)}):")
+    for f in changed_files[:20]:
+        print(f"  {f}")
+    if len(changed_files) > 20:
+        print(f"  ... and {len(changed_files) - 20} more")
+
+    # Uncomment when ready to select and create the TestRail run:
+    # from get_cases import get_cases_by_labels, create_test_run
+    # cases = get_cases_by_labels(impacted_components)
+    # case_ids = [c["id"] for c in cases]
+    # print(f"Selected {len(case_ids)} test cases")
+    # run = create_test_run(
+    #     case_ids=case_ids,
+    #     milestone_id=args.milestone_id,
+    #     name=f"{head_tag} – Smart Selection",
+    #     description=f"Auto-generated from diff {base_tag}...{head_tag}",
+    # )
+    # print("Created run:", run["id"])
+    # print("Run URL:", run.get("url"))
+
+
+if __name__ == "__main__":
+    main()

--- a/testrail/Jenkinsfile.create-milestone
+++ b/testrail/Jenkinsfile.create-milestone
@@ -94,6 +94,28 @@ EOF
             }
         }
 
+        stage('Trigger Smart Test Runs') {
+            when {
+                expression { env.MILESTONE_CREATED == 'true' }
+            }
+            steps {
+                script {
+                    try {
+                        def milestoneId = readFile('testrail/milestone_id.txt').trim()
+                        build job: 'create-smart-test-runs',
+                              parameters: [
+                                  string(name: 'RELEASE_TAG',  value: params.RELEASE_TAG),
+                                  string(name: 'MILESTONE_ID', value: milestoneId)
+                              ],
+                              wait: false
+                        echo "✅ Smart test runs job triggered for ${params.RELEASE_TAG} / milestone ${milestoneId}"
+                    } catch (e) {
+                        echo "⚠️ Could not trigger smart test runs job: ${e.message}"
+                    }
+                }
+            }
+        }
+
         stage('Trigger Test Jobs') {
             when {
                 expression { env.MILESTONE_CREATED == 'true' }
@@ -173,7 +195,7 @@ EOF
     post {
         always {
             dir('testrail') {
-                sh 'rm -f .testrail_credentials.json'
+                sh 'rm -f .testrail_credentials.json milestone_id.txt'
             }
         }
 

--- a/testrail/testrail_main_ios.py
+++ b/testrail/testrail_main_ios.py
@@ -137,7 +137,8 @@ def main():
             testrail_project_id, milestone_name, milestone_description
         )
 
-        with open("milestone_id.txt", "w") as f:
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        with open(os.path.join(script_dir, "milestone_id.txt"), "w") as f:
             f.write(str(milestone["id"]))
 
         for device in devices:

--- a/testrail/testrail_main_ios.py
+++ b/testrail/testrail_main_ios.py
@@ -137,6 +137,9 @@ def main():
             testrail_project_id, milestone_name, milestone_description
         )
 
+        with open("milestone_id.txt", "w") as f:
+            f.write(str(milestone["id"]))
+
         for device in devices:
             # Create Smoke Tests Suite test runs     
             testrail.create_paginated_test_runs(


### PR DESCRIPTION
The end goal is to automatically create targeted TestRail test runs based on what code changed between two release versions, added to the same milestone created by the existing iOS release automation.

In order to do this iteratively, let's just add the new jenkins file that will check the change log between current and previous release, nothing else for now. It will send a notification like: 

 ```
 Head tag from latest_tags.json: firefox-v150.1
  Base tag (previous version):    firefox-v149.3

  Comparing firefox-v149.3 → firefox-v150.1
  Total changed files (raw): 42
  After filtering ignored paths: 31

  Changed files (31):
    firefox-ios/Client/Frontend/Browser/Tabs/TabTray.swift
    firefox-ios/Client/Frontend/Settings/SettingsTableViewController.swift
    ... and 11 more

  Unmatched files: 3 

```