### PR TITLE
Fix - Android reported tests without url

### DIFF
--- a/.github/workflows/testrail-missing-links-slack.yml
+++ b/.github/workflows/testrail-missing-links-slack.yml
@@ -88,6 +88,7 @@ jobs:
             --platform ${{ matrix.platform }} \
             --root "$TEST_ROOT" \
             --testrail-domain "$DOMAIN" \
+            ${{ matrix.platform == 'android' && '--no-recurse' || '' }} \
             > testrail_missing_report.txt
 
           # Extract the test lines

--- a/testrail/testrail_scan_missing_urls.py
+++ b/testrail/testrail_scan_missing_urls.py
@@ -214,20 +214,24 @@ def is_linked(lines: list[str], func_idx: int, testrail_domain: str | None, plat
         return False
 
     if platform == "android":
-        # For Android/Kotlin, skip back over annotations (@Test, @SmokeTest, etc.)
+        # Scan upward past annotations and comments to find the TestRail URL
         idx = func_idx - 1
         while idx >= 0:
             line = lines[idx].strip()
             if not line:
                 idx -= 1
                 continue
-            # If we hit an annotation, keep going up
             if line.startswith("@"):
                 idx -= 1
                 continue
-            # Found a non-annotation, non-empty line
-            # This should be the TestRail comment
-            return is_testrail_url_line(lines[idx], testrail_domain)
+            if is_testrail_url_line(lines[idx], testrail_domain):
+                return True
+            # Keep scanning upward through non-testrail comment lines
+            if line.startswith("//"):
+                idx -= 1
+                continue
+            # Hit a non-comment, non-annotation line — stop
+            return False
 
         return False
 

--- a/testrail/testrail_scan_missing_urls.py
+++ b/testrail/testrail_scan_missing_urls.py
@@ -214,8 +214,9 @@ def is_linked(lines: list[str], func_idx: int, testrail_domain: str | None, plat
         return False
 
     if platform == "android":
-        # Scan upward past annotations and comments to find the TestRail URL
+        # Scan upward past annotations, single-line comments, and block comments
         idx = func_idx - 1
+        in_block_comment = False
         while idx >= 0:
             line = lines[idx].strip()
             if not line:
@@ -226,11 +227,21 @@ def is_linked(lines: list[str], func_idx: int, testrail_domain: str | None, plat
                 continue
             if is_testrail_url_line(lines[idx], testrail_domain):
                 return True
-            # Keep scanning upward through non-testrail comment lines
+            # Closing marker of a block comment — enter traversal mode
+            if line.endswith("*/"):
+                in_block_comment = True
+                idx -= 1
+                continue
+            if in_block_comment:
+                # Opening marker — exit block comment
+                if line.startswith("/**") or line.startswith("/*"):
+                    in_block_comment = False
+                idx -= 1
+                continue
             if line.startswith("//"):
                 idx -= 1
                 continue
-            # Hit a non-comment, non-annotation line — stop
+            # Non-comment, non-annotation line — stop
             return False
 
         return False

--- a/testrail/testrail_scan_missing_urls.py
+++ b/testrail/testrail_scan_missing_urls.py
@@ -412,6 +412,7 @@ def main() -> int:
         default=None,
         help="TestRail domain to check for (default: mozilla.testrail.io for Android, any for iOS)",
     )
+    ap.add_argument("--no-recurse", action="store_true", help="Scan only the root directory, not subdirectories")
     ap.add_argument("--fail", action="store_true", help="Exit with error code if missing URLs found")
     ap.add_argument("--debug", action="store_true", help="Print debug information")
     args = ap.parse_args()
@@ -464,7 +465,7 @@ def main() -> int:
             print(f"ERROR: root does not exist: {root}", file=sys.stderr)
             return 2
 
-        test_files = sorted(root.rglob(file_pattern))
+        test_files = sorted(root.glob(file_pattern) if args.no_recurse else root.rglob(file_pattern))
         file_count = len(test_files)
 
         for f in test_files:


### PR DESCRIPTION
There were several errors with this action and so there were more tests shown without testrail url than the real ones.

There are several cases in which the url to testrail is few lines above the test name. We were also looking into Efficiency and Component tests.

With these changes we will check only tests in the root ui folder.