### PR TITLE
Update iOS security triage list

### DIFF
--- a/slack-reminders/firefox-ios-security-monitor.py
+++ b/slack-reminders/firefox-ios-security-monitor.py
@@ -13,10 +13,7 @@ def load_data():
 def get_assignee_for_today():
     data = load_data()
     today = date.today().isoformat()
-    name = data["duty-start-dates"].get(today)
-    if name is None:
-        return None
-    return data["triagers"][name]["slack"]
+    return data["duty-start-dates"].get(today)
 
 
 def get_current_assignee():
@@ -25,8 +22,7 @@ def get_current_assignee():
     past_dates = [d for d in data["duty-start-dates"] if d <= today]
     if not past_dates:
         return None
-    name = data["duty-start-dates"][max(past_dates)]
-    return data["triagers"][name]["slack"]
+    return data["duty-start-dates"][max(past_dates)]
 
 
 if __name__ == "__main__":

--- a/slack-reminders/ios-security-rotation.json
+++ b/slack-reminders/ios-security-rotation.json
@@ -4,7 +4,7 @@
       "type": "section",
       "text": {
         "type": "mrkdwn",
-        "text": ":lock: *iOS Security Monitor \u2014 ${{ env.date }}*\n\nThe current security monitor is now @${{ env.security_monitor_name }}\n\n<https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2426896410/iOS+Security+Monitor+Role|iOS Security Monitor Role>"
+        "text": ":lock: *iOS Security Monitor \u2014 ${{ env.date }}*\n\nThe current security monitor is now ${{ env.security_monitor_name }}\n\n<https://mozilla-hub.atlassian.net/wiki/spaces/FXIOS/pages/2426896410/iOS+Security+Monitor+Role|iOS Security Monitor Role>"
       }
     },
     {

--- a/slack-reminders/ios_sec_triage.json
+++ b/slack-reminders/ios_sec_triage.json
@@ -1,47 +1,43 @@
 {
   "triagers": {
     "Matthew Reagan": {
-      "bzmail": "mreagan",
-      "slack": "Matt Reagan"
+      "bzmail": "mreagan@mozilla.com"
     },
     "Matt Lichtenstein": {
-      "bzmail": "mlichtenstein",
-      "slack": "mattlichtenstein"
+      "bzmail": "mlichtenstein@mozilla.com"
     },
-    "Laurie Marceau": {
-      "bzmail": "lmarceau",
-      "slack": "laurie"
+    "Issam Mani": {
+      "bzmail": "imani@mozilla.com"
     },
     "Cyndi Chin": {
-      "bzmail": "cchin",
-      "slack": "cyndi"
+      "bzmail": "cchin@mozilla.com"
+    },
+    "Carson Ramsden": {
+      "bzmail": "cramsden@mozilla.com"
     }
   },
   "duty-start-dates": {
-    "2026-03-01": "Matthew Reagan",
-    "2026-03-23": "Matt Lichtenstein",
-    "2026-04-20": "Laurie Marceau",
     "2026-05-18": "Cyndi Chin",
     "2026-06-15": "Matthew Reagan",
-    "2026-07-13": "Matt Lichtenstein",
-    "2026-08-10": "Laurie Marceau",
-    "2026-09-07": "Cyndi Chin",
+    "2026-07-13": "Carson Ramsden",
+    "2026-08-10": "Issam Mani",
+    "2026-09-07": "Matt Lichtenstein",
     "2026-10-05": "Matthew Reagan",
-    "2026-11-02": "Matt Lichtenstein",
-    "2026-11-30": "Laurie Marceau",
-    "2026-12-28": "Cyndi Chin",
-    "2027-01-25": "Matthew Reagan",
-    "2027-02-22": "Matt Lichtenstein",
-    "2027-03-22": "Laurie Marceau",
-    "2027-04-19": "Cyndi Chin",
-    "2027-05-17": "Matthew Reagan",
+    "2026-11-02": "Cyndi Chin",
+    "2026-11-30": "Carson Ramsden",
+    "2026-12-28": "Issam Mani",
+    "2027-01-25": "Matt Lichtenstein",
+    "2027-02-22": "Matthew Reagan",
+    "2027-03-22": "Cyndi Chin",
+    "2027-04-19": "Carson Ramsden",
+    "2027-05-17": "Issam Mani",
     "2027-06-14": "Matt Lichtenstein",
-    "2027-07-12": "Laurie Marceau",
+    "2027-07-12": "Matthew Reagan",
     "2027-08-09": "Cyndi Chin",
-    "2027-09-06": "Matthew Reagan",
-    "2027-10-04": "Matt Lichtenstein",
-    "2027-11-01": "Laurie Marceau",
-    "2027-11-29": "Cyndi Chin",
-    "2027-12-27": "Matthew Reagan"
+    "2027-09-06": "Carson Ramsden",
+    "2027-10-04": "Issam Mani",
+    "2027-11-01": "Matt Lichtenstein",
+    "2027-11-29": "Matthew Reagan",
+    "2027-12-27": "Cyndi Chin"
   }
 }


### PR DESCRIPTION
* Update the list of Firefox iOS in security rotation
* Slack notification now prints out full name instead of the Slack handle.