### PR TITLE
Fix testrail API unit tests

### DIFF
--- a/testrail/testrail_api.py
+++ b/testrail/testrail_api.py
@@ -67,6 +67,7 @@ class TestRail:
             "name": test_run_name,
             "milestone_id": milestone_id,
             "suite_id": suite_id,
+            "include_all": True,
         }
         return self.client.send_post(f"add_run/{project_id}", data)
 


### PR DESCRIPTION
The TestRail API server changed behavior. Specifically the add_run/{project_id} endpoint.

Before: if you POSTed without include_all, the server treated it as true by default (include all cases in the suite).

After: the server-side PHP now reads $data['include_all'] without first checking the key exists, so when it's missing you get:

HTTP 500 ({'error': 'Undefined array key "include_all"'})