### PR TITLE
First version of the test recommender project

### DIFF
--- a/test-recommender/.gitignore
+++ b/test-recommender/.gitignore
@@ -1,0 +1,33 @@
+# Secrets — never commit
+.env
+.env.*
+!.env.example
+*.key
+*.pem
+secrets/
+
+# Generated outputs (regenerate per release)
+release_report_*.md
+pending_mapping_review.yaml
+
+# TestRail exports — ad-hoc xlsx files are ignored, but the canonical
+# test catalogue export is versioned so recommend.py can consume it directly.
+*.xlsx
+!testrail_export_ios.xlsx
+
+# Backups produced by align.py
+section_to_module_mapping.yaml.bak
+*.bak
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+
+# OS / editor noise
+.DS_Store
+.vscode/
+.idea/
+*.swp

--- a/test-recommender/README.md
+++ b/test-recommender/README.md
@@ -1,0 +1,547 @@
+# Firefox iOS Test Recommender
+
+LLM-assisted system that suggests which TestRail tests to run for each Firefox iOS
+release, by cross-referencing the code changes in the release against the
+manual + automated test catalogue.
+
+---
+
+## Objective
+
+The full functional regression suite for Firefox iOS (well over a thousand
+cases) cannot be fully executed on every release. This project produces,
+per release, a prioritized Markdown report that answers:
+
+1. Which manual tests from the existing test plan are most likely affected by
+   the PRs in this release (P0 / P1 / P2 priority with per-test reasons).
+2. Whether any new manual tests should be added — coverage gaps in the
+   catalogue.
+3. Whether any new automated regression tests should be added for critical
+   flows.
+4. What risks the release introduces (concurrency changes, force-unwraps,
+   dependency bumps, Nimbus flag flips, hotspot files, large PRs without
+   tests).
+5. Which areas should be the focus of exploratory testing.
+6. Which PRs warrant deeper code review beyond QA.
+
+The system is a **suggestion layer that complements QA judgment**, never a
+replacement. The goal is to make the limited manual testing time hit the
+highest-value subset of the catalogue, not to declare anything "safe to skip".
+
+### Why this is feasible
+
+- Firefox iOS follows a predictable release flow: long-lived `release/vMAJOR`
+  branches, tagged as `firefox-vMAJOR.MINOR[.PATCH]`, with Mergify
+  auto-backports from `main`. The natural diff for analysis is between two
+  consecutive tags.
+- TestRail's `Section Hierarchy` column is 100% populated and the top-level
+  sections map cleanly to code modules (Toolbar → `BrowserKit/ToolbarKit`,
+  Menu redesign → `MenuKit`, Library → `firefox-ios/Client/Frontend/Library`,
+  etc.).
+- A significant subset of TestRail cases include explicit
+  `Automated Test Name(s)` paths to their Swift implementation, enabling
+  direct code↔test mapping without LLM inference.
+
+### Constraints we work around
+
+- TestRail's `Labels` column is empty, and `Priority` is effectively flat
+  (nearly all Medium, only a handful High). `Section Hierarchy` is the only
+  useful structural signal — the system relies on it.
+- Major release diffs touch ~300 files / ~12k LOC — too large to feed raw
+  to an LLM. The pipeline summarizes by module before reasoning.
+- PR labels are inconsistently applied. The system relies on file paths and
+  on the strong `<Verb> FXIOS-NNNNN [Area] description` PR title convention.
+- Nimbus feature flags can change behaviour server-side without a code diff
+  in the product. The pipeline always flags changes to `nimbus-features/` or
+  `initial_experiments.json` as a separate risk.
+
+---
+
+## Architecture
+
+```
+                ┌─────────────────────────────┐
+                │  TestRail export (.xlsx)    │  refreshed when QA lead
+                │  manual + automated cases   │  re-exports from TestRail
+                └──────────────┬──────────────┘
+                               │
+                               ▼
+   ┌───────────────────────────────────────────────────┐
+   │  section_to_module_mapping.yaml                    │  human-curated config:
+   │  TestRail sections ↔ firefox-ios code modules      │  the "Rosetta stone"
+   │  + drift_detection rules                           │
+   │  + special_rules (Nimbus, dependencies, strings,   │
+   │    Mergify backports)                              │
+   └──────────────────────┬────────────────────────────┘
+                          │
+        ┌─────────────────┴─────────────────┐
+        ▼                                   ▼
+┌───────────────────┐               ┌────────────────────┐
+│  align.py         │               │  recommend.py      │
+│  (planned)        │               │  (batch)           │
+│                   │               │                    │
+│  Run on demand    │               │  Run per release   │
+│  when TestRail or │               │  by QA lead        │
+│  the repo changes │               │                    │
+│  structurally     │               │                    │
+└─────────┬─────────┘               └──────────┬─────────┘
+          │                                    │
+          ▼                                    ▼
+  ┌────────────────────────────┐    ┌──────────────────────────┐
+  │ pending_mapping_review.yaml│    │ release_report_<tag>.md  │
+  │ (LLM proposals for humans  │    │ (the deliverable for QA) │
+  │  to accept/edit/reject)    │    │                          │
+  └────────────────────────────┘    └──────────────────────────┘
+```
+
+### Components
+
+| File | Type | Edited by | Read by |
+|---|---|---|---|
+| `section_to_module_mapping.yaml` | Config (human-curated) | QA lead | `recommend.py`, `align.py` |
+| `testrail_export_ios.xlsx` | TestRail export | TestRail admin | `recommend.py`, `align.py` |
+| `recommend.py` | Script (working) | Engineering | Run per release |
+| `align.py` | Interactive CLI (planned) | Engineering | Run when drift is detected |
+| `pending_mapping_review.yaml` | Output (planned) | `align.py` will write it, humans will review | `align.py` (planned) |
+| `release_report_<tag>.md` | Output | Generated each run | QA team (the deliverable) |
+
+### Why two scripts, not one
+
+`recommend.py` and `align.py` have different cadences and different stakes:
+
+- **`recommend.py`** runs every release (weekly). It must never block a
+  release report on a mapping gap — it surfaces drift as a visible warning
+  at the top of the report and produces the recommendations with whatever
+  mapping is available.
+- **`align.py`** (planned) will run on demand when TestRail or the repo
+  changes structurally. It will be interactive (CLI prompts) and update
+  the mapping YAML directly. Curating a mapping needs a human in the loop;
+  recommendation generation does not.
+
+Both will share the same drift-detection logic. Until `align.py` ships,
+`recommend.py`'s inline drift detection is the only mechanism surfacing
+gaps.
+
+---
+
+## How `recommend.py` works
+
+```
+INPUT: prev_tag, new_tag, testrail_export.xlsx, mapping.yaml
+  │
+  ├─ 1. Diff via `gh api compare prev_tag...new_tag`
+  │       → list of PRs, files changed, authors, sizes, commit list
+  │
+  ├─ 2. Filter low-impact PRs:
+  │       · string imports (weekly l10n PRs)
+  │       · Mergify backports already shipped on main
+  │       · mechanical Rust component bumps
+  │
+  ├─ 3. Light risk heuristics (no LLM, deterministic):
+  │       Per PR:
+  │         · LOC, # files, tests added or not
+  │         · concurrency keywords (async/await/actor/DispatchQueue) in
+  │           added lines
+  │         · force-unwrap / try! / fatalError introduced
+  │         · error-handling changes (catch/throw/Result)
+  │         · last-minute merge timing
+  │       Per file:
+  │         · hotspot (precomputed: bug-fix frequency in git log)
+  │         · author churn last 90 days
+  │       Per release:
+  │         · dependency files changed (Package.swift, Podfile.lock,
+  │           MozillaRustComponents/)
+  │         · Nimbus feature flags changed (nimbus-features/,
+  │           initial_experiments.json)
+  │
+  ├─ 4. Drift detection (cheap, fail-loud, non-blocking):
+  │       · TestRail sections in export but not in YAML → LLM proposes
+  │         mapping → written to pending_mapping_review.yaml
+  │       · Modules touched in diff but not in YAML → same treatment
+  │       · YAML entries whose section name or module path no longer
+  │         exists → flagged stale
+  │       Test files and noise paths (.xcodeproj, .plist, Assets/, .lproj/)
+  │       are excluded from this check.
+  │
+  ├─ 5. Group changed product-code files by code module
+  │       (BrowserKit/Sources/<Kit>, firefox-ios/Client/Frontend/<area>, …)
+  │       Test files and noise are excluded from module-touched counting;
+  │       test files are used only for exact match in step 6.
+  │
+  ├─ 6. Exact match: changed `.swift` test files → cross-reference
+  │       TestRail cases with explicit `Automated Test Name(s)` paths.
+  │       → "these TestRail tests are directly affected by code changes"
+  │
+  ├─ 7. Section match: code modules → TestRail sections, via mapping.yaml.
+  │       → candidate test set (typically ~989 after dedup + Smoke filter).
+  │
+  ├─ 8. Compute test budget (deterministic, no LLM):
+  │       · detect release type from tag names: patch / minor / major
+  │       · base range per type: patch 25-40, minor 40-70, major 100-160
+  │       · additive bumps: +15 if total LOC > 15k, +10 if any PR > 2k LOC,
+  │         +10 if ≥3 high-severity risk signals
+  │       · clamp to [15, 200]
+  │       · used both to configure the LLM's target and to cap its output
+  │
+  ├─ 9. Pre-filter candidates (deterministic score, no LLM):
+  │       Score each candidate: +50 exact-match, +30 section maps to
+  │       top-quartile-LOC module, +20 section has risk signal, +10 manual
+  │       only, -20 CI-Completed. Sort by score, keep top budget_hi × 4
+  │       (typically ~280). This 3-4× reduction in pool size drops rerank
+  │       token cost and improves inter-run stability.
+  │
+  ├─ 10. LLM rerank (Sonnet 4.6 by default, structured JSON output):
+  │       Inputs: module diff summary + risk signals + drift findings +
+  │       filtered candidate list including each candidate's score.
+  │       Output: ranked subset of budget_lo-budget_hi tests with
+  │       priority (P0/P1/P2) and per-test reasons; plus narrative notes.
+  │       Temperature: 0 (for Sonnet 4.6). Prompt cached.
+  │
+  ├─ 11. LLM synthesize (Sonnet 5 by default, streaming):
+  │       Produces the final 7-section Markdown report:
+  │         · Executive summary
+  │         · Suggested manual tests (P0/P1/P2)
+  │         · Coverage gaps — manual tests to add
+  │         · Suggested automated regression
+  │         · Risks
+  │         · Exploratory testing focus
+  │         · High-risk PRs to review more deeply
+  │       Effort: medium. Thinking: disabled. Prompt cached.
+  │       Report header includes the computed budget as an auditable line.
+  │
+  └─ OUTPUT: release_report_<new_tag>.md (English)
+```
+
+See `metrics_baseline.md` for measured cost, latency, and inter-run overlap
+across each phase of pipeline evolution.
+
+---
+
+## Setup
+
+### Prerequisites
+
+- macOS or Linux
+- Python 3.9+ (tested on 3.9.6 and 3.11)
+- `gh` CLI authenticated against `github.com/mozilla-mobile/firefox-ios`
+- An Anthropic API key (Tier 1 minimum — 30k TPM; Tier 2 recommended for
+  comfort: 80k TPM)
+
+### Install dependencies
+
+```bash
+pip3 install --user -r requirements.txt
+```
+
+Pinned minimums: `openpyxl>=3.1.5`, `pyyaml>=6.0.3`, `anthropic>=0.109.1`. See
+`requirements.txt` for the source of truth. Newer versions usually work but
+the Anthropic SDK's messages API evolves — the code has model-specific
+handling for `effort`, `temperature`, and `thinking` and may need adjustment
+if you jump many SDK versions.
+
+### Configure your API key
+
+The safest option for personal use on macOS is to export the key from
+`~/.zshrc` so it lives outside the repo and is never committed:
+
+```bash
+echo 'export ANTHROPIC_API_KEY="sk-ant-api03-..."' >> ~/.zshrc
+chmod 600 ~/.zshrc
+source ~/.zshrc
+```
+
+Verify (truncated for safety):
+
+```bash
+echo "${ANTHROPIC_API_KEY:0:15}..."
+```
+
+If you are on Tier 1 (30k TPM), the pipeline still works — the SDK retries
+with backoff on rate-limit responses. For frictionless runs deposit credits
+to reach Tier 2 ($40 cumulative purchases → 80k TPM for Sonnet 4.6). See
+https://console.anthropic.com/settings/limits for your current tier.
+
+If the API key is not set, `recommend.py` falls back to a deterministic
+ranker and writer — the script still runs end-to-end.
+
+### Optional environment variables
+
+All three are optional. Use them to override defaults for experiments or
+emergency rollback without touching code.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `RECOMMEND_MODEL_RERANK` | `claude-sonnet-4-6` | Model used for the rerank stage. Sonnet 4.6 was selected empirically (see `metrics_baseline.md`) over Haiku 4.5 and Sonnet 5 — the alternatives had lower inter-run stability. |
+| `RECOMMEND_MODEL_SYNTHESIZE` | `claude-sonnet-5` | Model used to write the narrative report. Sonnet 5 gives slightly better prose than 4.6 at similar cost. |
+| `RECOMMEND_RERANK_EFFORT` | `low` | Effort level for rerank on models that support it (Sonnet/Opus). Ignored for Haiku. Increasing it does NOT improve stability empirically; kept configurable for future models. |
+
+Example — try Opus 4.7 for synthesize on a specific release:
+
+```bash
+RECOMMEND_MODEL_SYNTHESIZE=claude-opus-4-7 python3 recommend.py --from ... --to ...
+```
+
+### Refresh the TestRail export
+
+The TestRail catalogue evolves. Re-export `testrail_export_ios.xlsx`
+from TestRail before each release run to keep the mapping current. The
+file is **not versioned in this repo** — export it from your TestRail
+instance and place it at the project root (or anywhere else and pass
+the path via `--testrail`). The expected columns are documented at the
+top of `section_to_module_mapping.yaml`.
+
+---
+
+## Usage
+
+### Generate a release report
+
+```bash
+cd test-recommender
+
+python3 recommend.py \
+  --from firefox-v151.2 \
+  --to firefox-v151.3 \
+  --testrail ./testrail_export_ios.xlsx \
+  --mapping ./section_to_module_mapping.yaml \
+  --output ./release_report_firefox-v151.3.md \
+  --verbose
+```
+
+Arguments:
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--from` | yes | Previous release tag, e.g. `firefox-v151.2` |
+| `--to` | yes | New release tag, e.g. `firefox-v151.3` |
+| `--testrail` | yes | Path to a TestRail `.xlsx` export |
+| `--mapping` | yes | Path to `section_to_module_mapping.yaml` |
+| `--output` | no | Output Markdown path. Default: `release_report_<to_tag>.md` |
+| `--verbose` / `-v` | no | Stream pipeline progress and token usage to stderr |
+
+**Note on branch names in `--to`**: The default output path
+(`release_report_<to_tag>.md`) is a direct string substitution. If `--to`
+is a branch name like `release/v153.0` (rather than a tag like
+`firefox-v153.0`), the default becomes `release_report_release/v153.0.md`
+— which Python treats as a subdirectory `release_report_release/` plus a
+file, and the write fails because the directory doesn't exist. When
+running against a branch, pass `--output` explicitly, e.g.
+`--output ./release_report_firefox-v153.0.md`.
+
+Typical wall-clock time: 30-90 seconds. Typical cost: ~$0.30 per release
+with Sonnet 4.6.
+
+### Interpret the output
+
+The report has seven sections in this order:
+
+1. **Executive summary** — 2-4 bullets. The two or three things QA should
+   know first.
+2. **Suggested manual tests** — divided into P0 (must run), P1 (should
+   run), P2 (if time). Each test has a one-line reason specific to this
+   release.
+3. **Coverage gaps — manual tests to add** — areas where the diff suggests
+   behaviour that the existing catalogue does not cover.
+4. **Suggested automated regression** — critical flows that touched
+   manual-only tests and would benefit from automation.
+5. **Risks** — concurrency changes, force-unwraps, dependency bumps,
+   Nimbus changes, large PRs, hotspot files, in plain prose ranked by
+   severity.
+6. **Exploratory testing focus** — 3-6 specific areas to poke at, each
+   tied to a concrete change in the diff.
+7. **High-risk PRs to review more deeply** — PRs that warrant code review
+   beyond QA.
+
+If the system detects mapping drift (new sections in TestRail or new
+modules in the repo without YAML mapping), a `⚠️ Mapping drift detected`
+warning appears at the very top of the report. Until `align.py` ships,
+curate the mapping YAML by hand to resolve.
+
+### Verbose output
+
+With `--verbose`, the script prints token telemetry per LLM call:
+
+```
+[recommend] rerank usage: input=43228 cache_write=1087 cache_read=0 output=2101
+[recommend]   49 tests ranked (P0=21, P1=25, P2=3)
+[recommend] synth usage: input=9426 cache_write=0 cache_read=0 output=6348
+```
+
+`cache_read` will be 0 on the first run with a given system prompt. On
+subsequent runs (within the 5-minute cache TTL, or 1-hour with explicit
+TTL configuration), `cache_read` will populate and you'll pay ~0.1× input
+cost for the cached portion.
+
+If `cache_write` stays at 0 across multiple runs, the system prompt is
+below Anthropic's ≥1024-token minimum for prompt caching — a silent
+failure with no error, only a ~20% cost bump. After editing either
+system prompt in `recommend.py`, run
+`python3 scripts/count_prompt_tokens.py` to verify the prompts still
+meet the threshold.
+
+---
+
+## Configuration: `section_to_module_mapping.yaml`
+
+The mapping YAML is the most important human-curated artifact in the
+project. It has four top-level blocks:
+
+- `sections:` — one entry per top-level TestRail section, listing the
+  code modules that map to it. Confidence is annotated (high / medium /
+  low) for manual review.
+- `modules_without_clear_section:` — code modules that don't have a
+  TestRail section. These are coverage blind spots and the recommender
+  flags changes to them explicitly.
+- `special_rules:` — **descriptive documentation** of how the pipeline
+  handles Nimbus changes, dependency bumps, string imports, and Mergify
+  backports. The actual behaviour is hardcoded in `recommend.py` (see
+  `LOW_IMPACT_TITLE_KEYWORDS`, `DEPENDENCY_PATHS`, `NIMBUS_PATHS`); this
+  block is NOT parsed at runtime, it exists as a reference for readers.
+- `drift_detection:` — **descriptive documentation** of the drift-detection
+  design. `recommend.py` implements the basic checks (TestRail sections
+  and repo modules not in the YAML); the rest of the block describes
+  goals for `align.py` (not yet implemented).
+
+When TestRail adds a new section, or the repo adds a new module, the
+mapping needs to be updated. The drift-detection logic in `recommend.py`
+will surface this as a warning; you should then either edit the YAML
+directly or run `align.py` once it exists.
+
+---
+
+## Cost estimate
+
+Per release run with the default models (rerank on Sonnet 4.6, synthesize on
+Sonnet 5):
+
+| Stage | Model (default) | Notes |
+|---|---|---|
+| Rerank | Sonnet 4.6 | Structured JSON output, prompt-cached |
+| Synthesize | Sonnet 5 | Streaming Markdown, prompt-cached |
+| **Total** | | **~$0.24–0.38 per run** |
+
+Measured range across recent runs — see `metrics_baseline.md` for the
+per-phase evolution. A weekly cadence yields ~$15–20/year. A major release
+(12k LOC diff) stays under $1. With prompt caching on the second run onward
+(within the 5-minute TTL), rerank input costs drop ~20%.
+
+Override the models via `RECOMMEND_MODEL_RERANK` / `RECOMMEND_MODEL_SYNTHESIZE`
+env vars if you want to run cheaper (e.g. Sonnet 4.6 on both) or more expensive
+(e.g. Opus 4.7 on synthesize for the highest prose quality). See the
+"Optional environment variables" table in the Setup section above.
+
+If you run on the deterministic fallback only (no API key), cost is zero
+but the report is materially less useful — the P0/P1/P2 distribution
+collapses, and the narrative sections become boilerplate.
+
+---
+
+## Limitations and known issues
+
+- **Section-match candidate sets are coarse.** A single touched file in a
+  given area pulls in every TestRail test in that section. The LLM rerank
+  trims this from ~900 candidates down to 25-50, but the candidate pool
+  is broader than ideal. A future iteration could weight candidates by
+  the LOC touched in the corresponding module.
+- **TestRail Section ID is not currently exported.** Section renames
+  break the mapping by name. The TestRail admin should add Section ID to
+  the export to make rename detection robust. Until then, `align.py`
+  will fall back to fuzzy name match and case-ID set overlap.
+- **Nimbus feature flag state in production is opaque to this system.**
+  A change in `nimbus-features/` is flagged as a risk, but the recommender
+  doesn't know whether the affected flag is on or off in production. The
+  QA team should cross-check Nimbus rollout status manually.
+- **`align.py` is not yet implemented.** Drift findings are surfaced in
+  the report and to `pending_mapping_review.yaml` (in the recommender's
+  inline drift check), but the interactive curation tool is still to be
+  built.
+- **The deterministic fallback ranker is intentionally crude.** It exists
+  to keep the pipeline from failing closed, not to replace the LLM. When
+  the LLM is unavailable, the fallback sorts candidates by sub-suite and
+  automation status, truncates to the release-specific budget ceiling,
+  and assigns P1 to manual-only tests and P2 to the rest. No release-
+  specific reasoning, no narrative sections — just a ranked list.
+
+---
+
+## Project layout
+
+```
+test-recommender/
+├── README.md                              ← this file
+├── requirements.txt                       ← pinned deps
+├── section_to_module_mapping.yaml         ← human-curated config
+├── recommend.py                           ← release pipeline (working)
+├── budget_calculator.py                   ← per-release test budget (Phase 2)
+├── candidate_scorer.py                    ← deterministic pre-filter (Phase 3)
+├── git_pr_extractor.py                    ← git-first PR resolver (ready for CI)
+├── (align.py — planned, not yet in repo)  ← interactive curation
+├── metrics_baseline.md                    ← measured cost/latency/overlap
+├── tests/                                 ← unit tests (78 tests across 3 modules)
+│   ├── test_budget_calculator.py
+│   ├── test_candidate_scorer.py
+│   └── test_git_pr_extractor.py
+├── scripts/
+│   └── count_prompt_tokens.py             ← Anthropic count_tokens helper
+├── .gitignore                             ← excludes secrets, outputs, backups
+└── release_report_<tag>.md                ← generated per run (gitignored)
+```
+
+External inputs:
+
+- TestRail export: `testrail_export_ios.xlsx` (not versioned — supplied by
+  the operator; refresh from your TestRail instance before each release run).
+- GitHub: `mozilla-mobile/firefox-ios`, accessed via `gh` CLI.
+- Anthropic API: models are configurable via env vars (see the Setup
+  section); defaults are Sonnet 4.6 for rerank and Sonnet 5 for synthesize.
+
+---
+
+## Roadmap
+
+1. **Now**: move `recommend.py` into a GitHub Action triggered by
+   `workflow_dispatch(from_tag, to_tag)`. The Action clones `firefox-ios`
+   locally and uses `git diff` / `git log` (instead of the truncated
+   GitHub compare API), and integrates `git_pr_extractor.py` for
+   API-free PR resolution. This removes the 300-file hard cap on the
+   compare endpoint and eliminates ~281 API calls per major release.
+2. **Then**: validate the recommender against 2-3 historical releases.
+   Compare the system's `Suggested manual tests` list against what QA
+   actually executed and the bugs found after the release. Feed findings
+   back into the rerank prompt.
+3. **Then**: implement `align.py` — the interactive mapping-curation
+   tool. Target design:
+
+   ```
+   INPUT: testrail_export.xlsx, mapping.yaml
+     │
+     ├─ 1. Diff TestRail sections vs YAML sections.
+     │     · For each new section: LLM proposes mapping using the section
+     │       name, a sample of 5 random test titles + steps from that
+     │       section, and the current repo module list.
+     │     · For each stale YAML section: attempt rename detection in
+     │       this order — fuzzy name match, then case-ID set overlap,
+     │       then Section ID once TestRail exports it.
+     │
+     ├─ 2. Diff repo modules vs YAML references.
+     │     · For each new module not referenced: LLM proposes a section.
+     │     · For each YAML path that no longer exists: mark stale.
+     │
+     ├─ 3. Interactive review (CLI prompts):
+     │       For each proposal:
+     │         [a] accept   [e] edit   [r] reject   [s] skip
+     │       Accepted changes are written into mapping.yaml directly
+     │       (with a .bak backup); rejected go to
+     │       pending_mapping_review.yaml.
+     │
+     └─ OUTPUT: updated mapping.yaml + pending_mapping_review.yaml
+   ```
+4. **Then**: ask the TestRail admin to add Section ID to the export.
+   Use it as the stable mapping key once available.
+5. **Later**: integrate Jira (`FXIOS-NNNNN` enrichment from PR titles)
+   and Sentry (recent crashes weight on priority).
+6. **Out of MVP scope**: web UI for the QA team to consume reports,
+   integration with the release-management workflow, feedback loop
+   from executed tests back into ranking.
+
+---

--- a/test-recommender/budget_calculator.py
+++ b/test-recommender/budget_calculator.py
@@ -1,0 +1,185 @@
+"""
+Test budget calculator.
+
+Determines how many tests QA should be asked to run for a given release, based
+on:
+  - Release type detected from tag names (patch / minor / major)
+  - Deterministic bumps triggered by release signal (LOC, big PRs, risks)
+
+The budget flows into two places:
+  1. The rerank prompt (as a "return N-M tests" range).
+  2. The defensive cap that truncates the LLM output if it overshoots.
+  3. A transparency line in the report header, so the QA lead knows why
+     THIS release has THIS budget.
+
+Design principles:
+  - Predictable base per release type (QA can plan capacity).
+  - Bumps are additive to the ceiling only, and each bump carries a
+    human-readable reason for audit.
+  - Absolute floor (15) and ceiling (200) prevent runaway outputs.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+
+# Version can be referenced either as a shipped tag (`firefox-v153.0`) or as
+# an in-flight release branch (`release/v153.0`). Both parse to the same
+# version tuple; downstream detection (patch/minor/major) is identical.
+TAG_RE = re.compile(r"firefox-v(\d+)(?:\.(\d+))?(?:\.(\d+))?$")
+BRANCH_RE = re.compile(r"release/v(\d+)(?:\.(\d+))?(?:\.(\d+))?$")
+
+
+# Base test-count ranges per release type. 
+BASE_RANGES: dict[str, tuple[int, int]] = {
+    "patch": (25, 40),
+    "minor": (40, 70),
+    "major": (100, 160),
+}
+
+# Absolute clamps regardless of type or bumps.
+ABSOLUTE_FLOOR = 15
+ABSOLUTE_CEILING = 200
+
+# Thresholds for the three deterministic bump rules.
+BUMP_LOC_THRESHOLD = 15000
+BUMP_LOC_AMOUNT = 15
+BUMP_BIG_PR_LOC = 2000
+BUMP_BIG_PR_AMOUNT = 10
+BUMP_HIGH_RISKS_COUNT = 3
+BUMP_HIGH_RISKS_AMOUNT = 10
+
+
+@dataclass
+class BudgetDecision:
+    """Full budget decision, self-describing enough to render as a report line."""
+    release_type: str          # "patch" | "minor" | "major"
+    base_lo: int
+    base_hi: int
+    bump: int
+    bump_reasons: list[str]
+    final_lo: int
+    final_hi: int
+
+    def summary_line(self) -> str:
+        """Human-readable line for the report header.
+
+        Example (minor release with two bumps):
+            'Test budget: 40-95 (base minor: 40-70; +15 total LOC 20,000 > 15,000; +10 large PR (2,100 LOC))'
+        """
+        parts = [f"base {self.release_type}: {self.base_lo}-{self.base_hi}"]
+        if self.bump:
+            parts.extend(f"+{r}" for r in self.bump_reasons)
+        # Defensive: report if the floor/ceiling clamp actually kicked in.
+        # With current constants (BASE_RANGES min = 25, max realistic ceiling
+        # = 160 + 35 bumps = 195, floor = 15, ceiling = 200) this branch is
+        # unreachable. Kept as scaffolding so future constant changes don't
+        # silently mask a clamp.
+        raw_hi = self.base_hi + self.bump
+        if raw_hi != self.final_hi or self.base_lo != self.final_lo:
+            parts.append(f"clamped to floor/ceiling {ABSOLUTE_FLOOR}/{ABSOLUTE_CEILING}")
+        return f"Test budget: {self.final_lo}-{self.final_hi} ({'; '.join(parts)})"
+
+
+# =============================================================================
+# 2.1 — Detect release type
+# =============================================================================
+
+
+def _parse_tag(tag: str) -> tuple[int, ...] | None:
+    """Extract numeric parts from a firefox-vX.Y[.Z] tag or release/vX.Y[.Z]
+    branch. Returns None if neither pattern matches."""
+    s = tag.strip()
+    m = TAG_RE.match(s) or BRANCH_RE.match(s)
+    if not m:
+        return None
+    return tuple(int(x) for x in m.groups() if x is not None)
+
+
+def detect_release_type(from_tag: str, to_tag: str) -> str:
+    """Return "patch", "minor", or "major" based on the tag delta.
+
+    Rules:
+      - X changes → "major"     (e.g. v153.2 → v154.0)
+      - Y changes, no Z         → "minor"     (e.g. v153.1 → v153.2)
+      - Z appears/changes       → "patch"     (e.g. v153.2 → v153.2.1)
+
+    Falls back to "minor" if either tag is unparseable (safest middle ground).
+    """
+    fr = _parse_tag(from_tag)
+    to = _parse_tag(to_tag)
+    if fr is None or to is None:
+        return "minor"
+
+    # Major = first part differs
+    if fr[0] != to[0]:
+        return "major"
+
+    # Patch = destination has a third component that changed, or appeared
+    if len(to) == 3:
+        return "patch"
+
+    # Otherwise minor
+    return "minor"
+
+
+# =============================================================================
+# 2.2 — Compute bumps
+# =============================================================================
+
+
+@dataclass
+class ReleaseSignal:
+    """The minimal subset of Analysis this module needs. Kept as its own
+    dataclass so the module has no reverse dependency on recommend.py."""
+    total_loc: int
+    max_pr_loc: int
+    high_severity_risk_count: int
+
+
+def compute_bumps(signal: ReleaseSignal) -> tuple[int, list[str]]:
+    """Compute the additive bump to the budget ceiling and the human-readable
+    reasons list. Each rule fires independently; total is the sum."""
+    bump = 0
+    reasons: list[str] = []
+
+    if signal.total_loc > BUMP_LOC_THRESHOLD:
+        bump += BUMP_LOC_AMOUNT
+        reasons.append(f"{BUMP_LOC_AMOUNT} total LOC {signal.total_loc:,} > {BUMP_LOC_THRESHOLD:,}")
+
+    if signal.max_pr_loc > BUMP_BIG_PR_LOC:
+        bump += BUMP_BIG_PR_AMOUNT
+        reasons.append(f"{BUMP_BIG_PR_AMOUNT} large PR ({signal.max_pr_loc:,} LOC)")
+
+    if signal.high_severity_risk_count >= BUMP_HIGH_RISKS_COUNT:
+        bump += BUMP_HIGH_RISKS_AMOUNT
+        reasons.append(f"{BUMP_HIGH_RISKS_AMOUNT} for {signal.high_severity_risk_count} high-severity risks")
+
+    return bump, reasons
+
+
+# =============================================================================
+# 2.3 — Compute final budget
+# =============================================================================
+
+
+def compute_test_budget(release_type: str, signal: ReleaseSignal) -> BudgetDecision:
+    """Return the full budget decision, ready to inject into the rerank prompt
+    and to render in the report header."""
+    base_lo, base_hi = BASE_RANGES.get(release_type, BASE_RANGES["minor"])
+    bump, reasons = compute_bumps(signal)
+
+    final_lo = max(base_lo, ABSOLUTE_FLOOR)
+    final_hi = min(base_hi + bump, ABSOLUTE_CEILING)
+
+    return BudgetDecision(
+        release_type=release_type,
+        base_lo=base_lo,
+        base_hi=base_hi,
+        bump=bump,
+        bump_reasons=reasons,
+        final_lo=final_lo,
+        final_hi=final_hi,
+    )

--- a/test-recommender/candidate_scorer.py
+++ b/test-recommender/candidate_scorer.py
@@ -1,0 +1,150 @@
+"""
+Deterministic candidate scorer and pre-filter.
+
+Before sending candidates to the LLM rerank stage, score each one with a
+transparent heuristic and truncate to the top K. Two benefits:
+
+  1. Cost: input tokens drop from ~43k (999 candidates) to ~10-15k (~280).
+  2. Stability: with a smaller, better-ranked pool the LLM makes fewer
+     marginal choices between near-equivalents → output overlap between
+     runs improves.
+
+Score components (additive):
+  +50   exact match (Automated Test Name references a file changed in this release)
+  +30   the test's section maps to a touched module in the top quartile of LOC
+  +20   the test's section maps to a module that has any risk signal attached
+  +10   automation status is manual-only ("Unsuitable" or "Untriaged")
+  -20   automation status is "Completed" (CI already covers it)
+
+Ties are broken deterministically by test ID to keep output stable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+# =============================================================================
+# Data — a minimal protocol so this module has no reverse dependency
+# =============================================================================
+
+
+@dataclass
+class ScoringContext:
+    """Everything the scorer needs to look at, pre-computed once per pipeline."""
+    exact_match_ids: set[str]                     # test IDs matched by file path
+    high_loc_modules: set[str]                    # top-quartile of touched modules
+    sections_with_risk: set[str]                  # section_top names with an associated risk
+    section_to_touched_modules: dict[str, set[str]]  # section_top → set of touched module paths
+
+
+# =============================================================================
+# Context builder
+# =============================================================================
+
+
+def _top_quartile(values: dict[str, int]) -> set[str]:
+    """Return the keys whose values fall in the top quartile (25%). Ties are
+    resolved by keeping keys with equal-or-greater than the quartile threshold."""
+    if not values:
+        return set()
+    sorted_vals = sorted(values.values(), reverse=True)
+    quartile_size = max(1, len(sorted_vals) // 4)
+    threshold = sorted_vals[quartile_size - 1]
+    return {k for k, v in values.items() if v >= threshold}
+
+
+def build_scoring_context(
+    exact_matched_tests: list,
+    module_changes: dict,           # module_path → ModuleChange
+    risks: list,                    # RiskSignal list
+    mapping: dict,                  # the section_to_module_mapping YAML content
+) -> ScoringContext:
+    """Compute the lookup structures used by score_candidate.
+
+    Kept as plain positional args of common types so this module doesn't need
+    to import from recommend.py (avoids a cycle when tests import both).
+    """
+    exact_match_ids = {tc.id for tc in exact_matched_tests}
+
+    # Top-quartile modules by LOC touched
+    module_locs = {m: mc.total_loc for m, mc in module_changes.items()}
+    high_loc_modules = _top_quartile(module_locs)
+
+    # section_top → set of touched module paths (from mapping.yaml, filtered by what actually changed)
+    section_to_touched: dict[str, set[str]] = {}
+    for section_def in mapping.get("sections", []):
+        section_name = section_def["name"]
+        for m in section_def.get("modules", []):
+            module_path = m["path"]
+            for touched in module_changes.keys():
+                if touched == module_path or touched.startswith(module_path.rstrip("/") + "/") \
+                        or module_path.startswith(touched.rstrip("/") + "/"):
+                    section_to_touched.setdefault(section_name, set()).add(touched)
+
+    # Sections with risk: any section whose touched modules host a risk signal
+    # whose `location` is a file path (not a PR-level signal).
+    # A risk signal's location is either "PR #N" or a file path like
+    # "firefox-ios/Client/Frontend/Reader/ReaderModeSchemeHandler.swift".
+    sections_with_risk: set[str] = set()
+    for r in risks:
+        loc = r.location
+        if loc.startswith("PR #") or "/" not in loc:
+            continue
+        # Find which touched module this file lives under, then which sections cover it
+        for section_name, touched_modules in section_to_touched.items():
+            if any(loc.startswith(tm.rstrip("/") + "/") or loc == tm for tm in touched_modules):
+                sections_with_risk.add(section_name)
+
+    return ScoringContext(
+        exact_match_ids=exact_match_ids,
+        high_loc_modules=high_loc_modules,
+        sections_with_risk=sections_with_risk,
+        section_to_touched_modules=section_to_touched,
+    )
+
+
+# =============================================================================
+# Scoring
+# =============================================================================
+
+
+SCORE_EXACT_MATCH = 50
+SCORE_HIGH_LOC_MODULE = 30
+SCORE_RISK_ASSOCIATION = 20
+SCORE_MANUAL_ONLY = 10
+SCORE_CI_COMPLETED = -20
+
+
+def score_candidate(tc, ctx: ScoringContext) -> int:
+    """Compute the score for a TestCase against the scoring context.
+
+    Higher is more relevant to this release. Purely deterministic — same
+    (tc, ctx) always returns the same value.
+    """
+    score = 0
+
+    if tc.id in ctx.exact_match_ids:
+        score += SCORE_EXACT_MATCH
+
+    touched = ctx.section_to_touched_modules.get(tc.section_top, set())
+    if touched and any(m in ctx.high_loc_modules for m in touched):
+        score += SCORE_HIGH_LOC_MODULE
+
+    if tc.section_top in ctx.sections_with_risk:
+        score += SCORE_RISK_ASSOCIATION
+
+    if tc.automation in ("Unsuitable", "Untriaged"):
+        score += SCORE_MANUAL_ONLY
+    elif tc.automation == "Completed":
+        score += SCORE_CI_COMPLETED
+
+    return score
+
+
+def pre_filter_candidates(candidates: list, ctx: ScoringContext, top_k: int) -> list[tuple[object, int]]:
+    """Score every candidate, sort by score desc (ties broken by test ID for
+    stability), and return the top_k as (TestCase, score) pairs."""
+    scored = [(tc, score_candidate(tc, ctx)) for tc in candidates]
+    scored.sort(key=lambda pair: (-pair[1], pair[0].id))
+    return scored[:top_k]

--- a/test-recommender/git_pr_extractor.py
+++ b/test-recommender/git_pr_extractor.py
@@ -1,0 +1,312 @@
+"""
+Git-first PR extractor for the release test recommender.
+
+Given a list of commits between two release tags, produce a list of PR records
+by parsing commit subjects locally. Falls back to `gh api /commits/<sha>/pulls`
+only for commits where no PR number can be extracted from the subject.
+
+Design goals:
+  - Zero API calls for standard squash-merged PRs (the ~99% case in firefox-ios).
+  - Explicit handling of Mergify backports, reverts, and known bot commits.
+  - Orphan commits (no PR reference anywhere) are surfaced, not dropped.
+  - Cross-validation samples the git-extracted result against the API to catch
+    silent drift if commit conventions change.
+"""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+import subprocess
+from dataclasses import dataclass, field
+from typing import Callable, Optional
+
+
+# =============================================================================
+# Data models
+# =============================================================================
+
+
+@dataclass
+class GitCommit:
+    """A commit as reported by git log (or the compare API)."""
+    sha: str
+    subject: str
+    author_name: str
+    # Aspirational: reserved for future author-domain filtering
+    # (e.g. distinguishing @mozilla.com contributors from externals).
+    # Populated but not read today.
+    author_email: str
+    additions: int = 0
+    deletions: int = 0
+
+
+@dataclass
+class ExtractedPR:
+    """A PR resolved from one or more commits."""
+    number: int
+    title: str
+    author: str
+    additions: int
+    deletions: int
+    commits: list[str] = field(default_factory=list)
+    is_revert: bool = False
+    is_backport: bool = False
+    source: str = "git"          # "git" (from subject) or "api" (fallback)
+
+
+@dataclass
+class OrphanCommit:
+    """A commit that could not be attributed to any PR."""
+    sha: str
+    subject: str
+    author: str
+    additions: int
+    deletions: int
+    reason: str                   # "bot_version_bump" | "no_pr_reference" | ...
+
+
+@dataclass
+class ExtractionResult:
+    prs: list[ExtractedPR]
+    orphans: list[OrphanCommit]
+    warnings: list[str] = field(default_factory=list)
+
+
+# =============================================================================
+# Patterns
+# =============================================================================
+
+
+# "Refactor FXIOS-NNNNN <description> (#NNNNN)"
+# "[TICKET-NNNN] - <description> (#NNNNN)"
+# "Bump <package> from X.Y.Z to A.B.C ... (#NNNNN)"
+PR_SUFFIX_RE = re.compile(r"\s*\(#(\d+)\)\s*$")
+
+# "Merge pull request #NNNNN from mozilla-mobile/<branch-name>"
+PR_MERGE_RE = re.compile(r"^Merge pull request #(\d+)\b")
+
+# "Revert FXIOS-NNNNN <description> ... (#NNNNN)"
+REVERT_PREFIX_RE = re.compile(r"^Revert\b", re.IGNORECASE)
+
+# "[vNNN] <description>" — backport marker from Mergify or manual tag
+BACKPORT_PREFIX_RE = re.compile(r"^\[(?:v\d+(?:\.\d+)*|backport)\]", re.IGNORECASE)
+
+# Known bot authors whose commits are low-signal by construction.
+# Value describes why they're orphans; the report groups by reason.
+BOT_AUTHORS: dict[str, str] = {
+    "releng-treescript[bot]": "bot_version_bump",
+    "dependabot[bot]": "bot_dependency_bump",
+    "github-actions[bot]": "bot_automated",
+    "mozilla-mobile-l10n-bot": "bot_l10n",
+}
+
+
+# =============================================================================
+# Core extraction
+# =============================================================================
+
+
+def strip_pr_suffix(subject: str) -> str:
+    """Return the subject without the trailing `(#12345)` suffix."""
+    return PR_SUFFIX_RE.sub("", subject).rstrip()
+
+
+def extract_pr_number(subject: str) -> Optional[int]:
+    """Try to find a PR number in the subject via known patterns.
+
+    Priority: merge commit → suffix `(#N)`. Anything not matching yields None.
+    Note: a bare `#N` in prose (e.g. "fixes #1234") is intentionally NOT matched
+    to avoid false positives on issue references.
+    """
+    m = PR_MERGE_RE.match(subject)
+    if m:
+        return int(m.group(1))
+    m = PR_SUFFIX_RE.search(subject)
+    if m:
+        return int(m.group(1))
+    return None
+
+
+def classify_commit(commit: GitCommit) -> tuple[Optional[int], dict]:
+    """Return (pr_number, flags) for a single commit.
+
+    flags is a dict with:
+        is_revert: bool
+        is_backport: bool
+        bot_reason: str | None   — if this is a known bot commit
+    """
+    flags = {
+        "is_revert": bool(REVERT_PREFIX_RE.search(commit.subject)),
+        "is_backport": bool(BACKPORT_PREFIX_RE.search(commit.subject)),
+        "bot_reason": BOT_AUTHORS.get(commit.author_name),
+    }
+    return extract_pr_number(commit.subject), flags
+
+
+# =============================================================================
+# API fallback (isolated so tests can inject a stub)
+# =============================================================================
+
+
+ApiFetcher = Callable[[str], list[dict]]
+"""Callable that takes a repo-relative API path and returns parsed JSON.
+Injected to keep the module testable without network I/O."""
+
+
+def _default_api_fetcher(path: str) -> list[dict]:
+    """Real implementation using the `gh` CLI. Raises on failure."""
+    out = subprocess.run(
+        ["gh", "api", path], capture_output=True, text=True, check=False,
+    )
+    if out.returncode != 0:
+        raise RuntimeError(f"gh api {path} failed: {out.stderr}")
+    return json.loads(out.stdout)
+
+
+def resolve_pr_via_api(sha: str, repo: str, fetcher: ApiFetcher) -> Optional[dict]:
+    """Fallback: ask GitHub which PR contains this commit. Returns the first
+    matching PR payload, or None. Errors are swallowed to a None — the caller
+    treats the commit as orphan and records a warning."""
+    try:
+        pulls = fetcher(f"repos/{repo}/commits/{sha}/pulls")
+    except Exception:
+        return None
+    if not pulls:
+        return None
+    return pulls[0]
+
+
+# =============================================================================
+# Main entry
+# =============================================================================
+
+
+def build_prs_from_git(
+    commits: list[GitCommit],
+    repo: str,
+    api_fetcher: Optional[ApiFetcher] = None,
+) -> ExtractionResult:
+    """Convert a list of git commits into (prs, orphans, warnings).
+
+    Behavior:
+      - Commit with a `(#N)` or `Merge pull request #N` subject → grouped by N.
+      - Commit by a known bot author → orphan with reason from BOT_AUTHORS.
+      - Commit without PR ref → API fallback; if API also silent → orphan.
+    """
+    fetch = api_fetcher or _default_api_fetcher
+
+    pr_map: dict[int, ExtractedPR] = {}
+    orphans: list[OrphanCommit] = []
+    warnings: list[str] = []
+
+    for commit in commits:
+        pr_num, flags = classify_commit(commit)
+
+        if pr_num is not None:
+            pr = pr_map.get(pr_num)
+            if pr is None:
+                title = strip_pr_suffix(commit.subject)
+                pr = ExtractedPR(
+                    number=pr_num,
+                    title=title,
+                    author=commit.author_name,
+                    additions=0,
+                    deletions=0,
+                    is_revert=flags["is_revert"],
+                    is_backport=flags["is_backport"],
+                    source="git",
+                )
+                pr_map[pr_num] = pr
+            pr.commits.append(commit.sha)
+            pr.additions += commit.additions
+            pr.deletions += commit.deletions
+            continue
+
+        if flags["bot_reason"]:
+            orphans.append(OrphanCommit(
+                sha=commit.sha, subject=commit.subject,
+                author=commit.author_name,
+                additions=commit.additions, deletions=commit.deletions,
+                reason=flags["bot_reason"],
+            ))
+            continue
+
+        # No PR number and not a known bot → try API fallback
+        pr_payload = resolve_pr_via_api(commit.sha, repo, fetch)
+        if pr_payload:
+            pr_num = pr_payload["number"]
+            pr = pr_map.get(pr_num)
+            if pr is None:
+                pr = ExtractedPR(
+                    number=pr_num,
+                    title=pr_payload.get("title", commit.subject),
+                    author=(pr_payload.get("user") or {}).get("login", commit.author_name),
+                    additions=0, deletions=0,
+                    is_revert=flags["is_revert"],
+                    is_backport=flags["is_backport"],
+                    source="api",
+                )
+                pr_map[pr_num] = pr
+            pr.commits.append(commit.sha)
+            pr.additions += commit.additions
+            pr.deletions += commit.deletions
+            warnings.append(
+                f"Commit {commit.sha[:8]} required API fallback (no #N in subject: {commit.subject[:80]!r})"
+            )
+        else:
+            orphans.append(OrphanCommit(
+                sha=commit.sha, subject=commit.subject,
+                author=commit.author_name,
+                additions=commit.additions, deletions=commit.deletions,
+                reason="no_pr_reference",
+            ))
+
+    prs = sorted(pr_map.values(), key=lambda p: p.number)
+    return ExtractionResult(prs=prs, orphans=orphans, warnings=warnings)
+
+
+# =============================================================================
+# Cross-validation
+# =============================================================================
+
+
+def cross_validate_sample(
+    result: ExtractionResult,
+    commits: list[GitCommit],
+    repo: str,
+    api_fetcher: Optional[ApiFetcher] = None,
+    sample_size: int = 5,
+    rng: Optional[random.Random] = None,
+) -> list[str]:
+    """Pick N random git-sourced commits, verify their PR mapping against the
+    API. Returns a list of mismatch warnings (empty = clean)."""
+    fetch = api_fetcher or _default_api_fetcher
+    rng = rng or random.Random(0)
+
+    git_sourced_commits = [
+        (c, pr) for c in commits
+        for pr in result.prs
+        if c.sha in pr.commits and pr.source == "git"
+    ]
+    if not git_sourced_commits:
+        return []
+
+    sample = rng.sample(
+        git_sourced_commits, min(sample_size, len(git_sourced_commits)),
+    )
+
+    mismatches: list[str] = []
+    for commit, git_pr in sample:
+        api_pr = resolve_pr_via_api(commit.sha, repo, fetch)
+        if not api_pr:
+            mismatches.append(
+                f"Commit {commit.sha[:8]}: git said PR #{git_pr.number}, API returned no PR"
+            )
+            continue
+        if api_pr["number"] != git_pr.number:
+            mismatches.append(
+                f"Commit {commit.sha[:8]}: git said PR #{git_pr.number}, API says PR #{api_pr['number']}"
+            )
+    return mismatches

--- a/test-recommender/metrics_baseline.md
+++ b/test-recommender/metrics_baseline.md
@@ -1,0 +1,191 @@
+# Metrics: baseline and phased optimization
+
+> **Snapshot from 2026-07-13.** Concrete numbers below reflect the Anthropic
+> SDK, model, and prompt state at the time of measurement. Ratios and
+> qualitative findings are more durable; specific token counts and cost
+> figures will drift with model / pricing / prompt changes. Treat as a
+> historical reference for the design decisions, not a live benchmark.
+
+This document captures two things:
+
+1. The **baseline** measurements of the system before the Phase 1-3
+   optimizations (sections 0.1–0.3 below).
+2. The **actual results** after each phase, alongside the original targets
+   (see "Original targets and actual results" and "Phase-by-phase evolution"
+   further down).
+
+The baseline was measured against the `firefox-v151.2 → firefox-v151.3`
+release (minor, 282 files, 48 commits, 47 PRs kept after low-impact
+filtering). Every optimization was validated against this same release
+pair on the same day, three runs each for statistical stability.
+
+---
+
+## 0.1 — System prompt sizes vs cache threshold
+
+Anthropic ephemeral prompt caching requires ≥1024 tokens in the cached block.
+Measured with `client.messages.count_tokens(...)` on `claude-sonnet-4-6`.
+
+| Prompt | Tokens (count_tokens) | Actual behavior in production log | Cacheable in production? |
+|---|---:|---|---|
+| `SYSTEM_PROMPT_RERANK` | 785 | `cache_write=1087` (protocol overhead pushes it over) | YES (by accident) |
+| `SYSTEM_PROMPT_SYNTHESIZE` | 954 | `cache_write=0` | **NO** |
+
+**Finding:** synthesize prompt is 70 tokens short of the effective cache
+threshold in production. Rerank is under the count_tokens number too, but wire
+protocol overhead (~300 tokens for tool/schema metadata) accidentally pushes it
+over 1024, so it does cache.
+
+**Action item for Phase 1.4 — RESOLVED:** Extended `SYSTEM_PROMPT_SYNTHESIZE`
+with concrete section examples and style samples. Now cacheable in production
+(see the "Synthesize prompt cacheable" row of the results table further down).
+
+---
+
+## 0.2 — Variability across identical runs
+
+Three independent runs of `recommend.py` with identical inputs
+(v151.2 → v151.3, same TestRail export, same mapping, same model, same day).
+Each returns 47 ranked test IDs.
+
+### Pairwise overlap of returned test IDs
+
+| Pair | Intersection | Union | Jaccard | Overlap-of-smaller |
+|---|---:|---:|---:|---:|
+| run1 vs run2 | 28 | 66 | **42.4%** | 59.6% |
+| run1 vs run3 | 27 | 67 | **40.3%** | 57.4% |
+| run2 vs run3 | 29 | 65 | **44.6%** | 61.7% |
+
+### Consensus and spread
+
+| Metric | Value |
+|---|---:|
+| Tests common to all 3 runs | **23** (49% of any single run's output) |
+| Tests that appeared in ≥1 run | **80** |
+| Tests that appeared in only 1 run | ~30 |
+
+**Finding:** the LLM oscillates significantly between runs. Only ~49% of the
+returned set is stable. This means:
+
+- QA sees a substantially different set of "recommended tests" on each run.
+- Trust erodes ("why is C3897624 P0 today but not last release?").
+- ~30 of the 47 tests per run are effectively "coin-flip picks" from a wider
+  pool of near-equivalent candidates.
+
+**Action items — RESOLVED (with partial success on the overlap target):**
+- Phase 1.1 (`temperature=0`) applied. Combined with Phase 3, the actual
+  overlap reached 64% Jaccard, not the 95% originally targeted. Cloud LLM
+  residual non-determinism sets a ceiling well below 95%; see the
+  phase-by-phase table further down.
+- Phase 3 (pre-filter deterministic top-K) applied as planned. Candidate
+  pool shrunk from ~999 to ~280 via a deterministic score field embedded
+  in the prompt.
+
+---
+
+## 0.3 — Cost per run
+
+Pricing model (Sonnet 4.6, as of run date):
+
+| Rate | $/million tokens |
+|---|---:|
+| Regular input | 3.00 |
+| Cache write (1.25×) | 3.75 |
+| Cache read (0.1×) | 0.30 |
+| Output | 15.00 |
+
+### Token usage per run
+
+| Stage | Metric | Run 1 | Run 2 | Run 3 |
+|---|---|---:|---:|---:|
+| Rerank | input | 43226 | 43229 | 43211 |
+| Rerank | cache_write | 1087 | 1087 | 0 |
+| Rerank | cache_read | 0 | 0 | **1087** |
+| Rerank | output | 2047 | 2024 | 2009 |
+| Synth | input | 9447 | 9345 | 9276 |
+| Synth | cache_write | 0 | 0 | 0 |
+| Synth | cache_read | 0 | 0 | 0 |
+| Synth | output | 6259 | 5753 | 5681 |
+
+Run 3 saw cache_read on rerank because it fired within 5 minutes of run 2 —
+the ephemeral cache window. This confirms caching works in principle, but the
+5-min TTL is too short for the weekly release cadence (releases are days
+apart, cache always expires between them).
+
+### Cost per run
+
+| Run | Rerank | Synth | Total |
+|---|---:|---:|---:|
+| Run 1 | $0.164 | $0.122 | **$0.287** |
+| Run 2 | $0.164 | $0.115 | **$0.279** |
+| Run 3 | $0.160 (cache hit) | $0.113 | **$0.273** |
+
+**Average: ~$0.28 per release report.**
+
+The cache-read saving on Run 3 was only ~$0.004 because the cached block is
+tiny (1087 tokens). Even if we made caching work perfectly, the ceiling of
+savings from *this* cache mechanism is ~1% of run cost. Real cost reduction
+must come from Phase 3 (pre-filter reduces input tokens by ~30k) and Phase 1.3
+(Haiku instead of Sonnet for rerank).
+
+---
+
+## Original targets and actual results
+
+Targets set optimistically before implementation. Actuals measured after each
+phase on the same v151.2 → v151.3 minor release (3 runs each, same day).
+
+| Metric | Baseline | Target | Actual after Phase 3b |
+|---|---:|---:|---:|
+| Cost per run | $0.28 | ~$0.05 | ~$0.24 (14% cheaper) |
+| Overlap between identical runs (Jaccard) | 42% | ≥95% | **64%** |
+| Tests common to N runs | 23 (49% of run) | ≥45 (≥95%) | **46 (70% of run)** |
+| Rerank input tokens | 43k | ~10k | **15k** (65% smaller) |
+| Synthesize prompt cacheable | No | Yes | **Yes** |
+
+**Honest reflection:** the 95% overlap target was unreachable with cloud LLMs.
+The 64% we hit reflects the ceiling imposed by Anthropic's residual
+non-determinism. The 46 stable tests (out of 67) is a substantive improvement
+over baseline's 23 — QA trust should be measurably better.
+
+The single biggest lever was Phase 3b's prompt instruction on how to use the
+`score` field: +9.4pp Jaccard from one prompt change. This was found only
+because the user asked "shouldn't we re-measure after changing the prompt?"
+after the initial Phase 3 measurement was declared done. **Every prompt
+change is a behavior change and must be validated with fresh runs** — added
+as a project principle.
+
+## Phase-by-phase evolution (Jaccard, common tests)
+
+| Phase | Config | Jaccard | Common | Counts |
+|---|---|---:|---:|---:|
+| Baseline | Sonnet 4.6, no temp, budget 25-50 | 42.4% | 23 | 47/47/47 |
+| Phase 1 | + temp=0 | 48.5% | 25 | 48/49/47 |
+| Phase 2 | + budget 40-70 (adaptive) | 52.4% | 37 | 65/67/63 |
+| Phase 3 | + pre-filter 989→280, score in payload | 54.7% | 38 | 63/67/67 |
+| Phase 3b | + prompt instruction on how to use score | **64.1%** | **46** | 65/67/69 |
+
+---
+
+## Reproducing these measurements
+
+The individual report files from the runs above are gitignored and not
+included in this repo. To reproduce the measurements:
+
+- **Section 0.1** (system prompt sizes vs cache threshold):
+  run `python3 scripts/count_prompt_tokens.py`. The script imports the
+  prompts from `recommend.py` and asks Anthropic's `count_tokens` endpoint
+  for the authoritative token count.
+
+- **Sections 0.2 and 0.3** (variability + cost):
+  run `python3 recommend.py --verbose ...` three consecutive times against
+  the same release pair on the same day with identical inputs. Extract
+  token usage from the stderr telemetry (see README "Verbose output"
+  section) and compute Jaccard overlap between the three ranked test-ID
+  sets. The reports themselves are not versioned; only their contents
+  matter.
+
+- **Phase-by-phase table**: reproducing this requires running the pipeline
+  against the same release pair after each incremental code change
+  (temperature, budget, pre-filter, prompt tuning). The commit history of
+  `recommend.py` shows the sequence of changes.

--- a/test-recommender/recommend.py
+++ b/test-recommender/recommend.py
@@ -1,0 +1,1274 @@
+#!/usr/bin/env python3
+"""
+Firefox iOS Test Recommender
+
+Reads a release diff (between two firefox-vX.Y tags), the TestRail catalogue
+export, and the section→module mapping YAML; produces a prioritized Markdown
+report of tests to run, risks, and exploratory focus areas.
+
+The pipeline is LLM-assisted (Claude Sonnet 4.6 for rerank, Sonnet 5 for
+synthesize by default; both overridable via RECOMMEND_MODEL_* env vars).
+Falls back to a deterministic ranker + Markdown writer when the API key is
+missing or any LLM call fails — the script never fails closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import openpyxl
+import yaml
+
+from budget_calculator import (
+    BudgetDecision,
+    ReleaseSignal,
+    compute_test_budget,
+    detect_release_type,
+)
+from candidate_scorer import (
+    ScoringContext,
+    build_scoring_context,
+    pre_filter_candidates,
+)
+
+try:
+    import anthropic
+    _ANTHROPIC_AVAILABLE = True
+except ImportError:
+    _ANTHROPIC_AVAILABLE = False
+
+REPO = "mozilla-mobile/firefox-ios"
+
+# Two-model split, decided empirically after A/B testing four configs
+# (see metrics_baseline.md and Phase 1 comparison notes):
+#   - Rerank on Sonnet 4.6 with temperature=0 gave the best output stability
+#     (48% Jaccard vs 28% for Haiku, 39% for Sonnet 5 default).
+#   - Synthesize on Sonnet 5 gives better prose than 4.6 at similar cost.
+# Both overridable via env vars for quick rollback if a model change regresses
+# output quality on a future release.
+LLM_MODEL_RERANK = os.environ.get("RECOMMEND_MODEL_RERANK", "claude-sonnet-4-6")
+LLM_MODEL_SYNTHESIZE = os.environ.get("RECOMMEND_MODEL_SYNTHESIZE", "claude-sonnet-5")
+
+# Paths that are noise for "module touched" classification: build/project files,
+# localization, assets, and the test trees themselves (the test tree is used for
+# exact-match against TestRail Automated Test Name, but it is NOT a "product
+# module" we'd ask QA to retest).
+NOISE_PATH_PATTERNS = (
+    re.compile(r"\.xcodeproj(/|$)"),
+    re.compile(r"\.xcworkspace(/|$)"),
+    re.compile(r"Info\.plist$"),
+    re.compile(r"\.entitlements$"),
+    re.compile(r"\.lproj/"),
+    re.compile(r"/Assets\.xcassets/"),
+    re.compile(r"(^|/)Assets/"),
+    re.compile(r"Localizable\.strings$"),
+    re.compile(r"\.strings$"),
+    re.compile(r"\.gitignore$"),
+    re.compile(r"\.md$"),
+    re.compile(r"^\.github/"),
+)
+
+TEST_PATH_PATTERNS = (
+    re.compile(r"/Tests/"),
+    re.compile(r"Tests\.swift$"),
+    re.compile(r"-tests/"),
+)
+
+
+def is_noise_path(p: str) -> bool:
+    return any(rx.search(p) for rx in NOISE_PATH_PATTERNS)
+
+
+def is_test_path(p: str) -> bool:
+    return any(rx.search(p) for rx in TEST_PATH_PATTERNS)
+
+
+# =============================================================================
+# Data models
+# =============================================================================
+
+
+@dataclass
+class FileChange:
+    path: str
+    additions: int
+    deletions: int
+    patch: str = ""       # truncated diff text (for grep heuristics + LLM)
+
+
+@dataclass
+class PR:
+    number: int
+    title: str
+    author: str
+    additions: int
+    deletions: int
+
+
+@dataclass
+class TestCase:
+    id: str
+    title: str
+    section_top: str           # top-level section, e.g. "Library"
+    section_hierarchy: str     # full path
+    sub_suite: str
+    automation: str
+    automated_test_name: Optional[str]
+
+
+@dataclass
+class RiskSignal:
+    kind: str
+    severity: str              # "high" | "medium" | "low"
+    location: str              # "PR #1234" or "BrowserKit/Sources/WebEngine/Foo.swift"
+    detail: str
+
+
+@dataclass
+class ModuleChange:
+    module: str
+    files: list[FileChange] = field(default_factory=list)
+
+    @property
+    def total_loc(self) -> int:
+        return sum(f.additions + f.deletions for f in self.files)
+
+
+@dataclass
+class DriftFinding:
+    kind: str                  # "testrail_new_section", "testrail_stale_section",
+                               # "repo_new_module", "repo_dead_path"
+    item: str
+    detail: str
+
+
+@dataclass
+class Analysis:
+    """The full deterministic analysis, before LLM rerank/synthesize."""
+    from_tag: str
+    to_tag: str
+    prs: list[PR]
+    skipped_prs: list[tuple[PR, str]]
+    file_changes: list[FileChange]
+    module_changes: dict[str, ModuleChange]
+    risks: list[RiskSignal]
+    drift: list[DriftFinding]
+    exact_matched_tests: list[TestCase]          # by Automated Test Name path
+    section_matched_tests: list[TestCase]        # by mapping.yaml lookup
+    unclassified_files: list[FileChange]
+    budget: BudgetDecision                       # test count budget (Phase 2)
+    scoring_context: ScoringContext              # for pre-filter (Phase 3)
+
+
+# =============================================================================
+# Loaders
+# =============================================================================
+
+
+def load_mapping(path: Path) -> dict:
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+def load_testrail(path: Path) -> list[TestCase]:
+    wb = openpyxl.load_workbook(path, read_only=True, data_only=True)
+    # TestRail exports have shipped with different default sheet names
+    # over the years ("Worksheet", "Sheet1", localized variants…). Use the
+    # first sheet regardless of its name.
+    ws = wb.worksheets[0]
+    rows = list(ws.iter_rows(values_only=True))
+    headers = list(rows[0])
+    idx = {h: i for i, h in enumerate(headers)}
+
+    cases: list[TestCase] = []
+    for r in rows[1:]:
+        sh = r[idx["Section Hierarchy"]] or ""
+        cases.append(TestCase(
+            id=str(r[idx["ID"]] or ""),
+            title=str(r[idx["Title"]] or ""),
+            section_top=sh.split(">")[0].strip() if sh else "",
+            section_hierarchy=sh,
+            sub_suite=str(r[idx["Sub Test Suite(s)"]] or ""),
+            automation=str(r[idx["Automation"]] or ""),
+            automated_test_name=(str(r[idx["Automated Test Name(s)"]]) if r[idx["Automated Test Name(s)"]] else None),
+        ))
+    return cases
+
+
+# =============================================================================
+# GitHub diff fetching (via gh CLI)
+# =============================================================================
+
+
+def gh_json(args: list[str]) -> dict | list:
+    """Run a gh api call and return parsed JSON. Exits on failure."""
+    cmd = ["gh", "api"] + args
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.stderr.write(f"gh api failed: {' '.join(cmd)}\n{out.stderr}\n")
+        sys.exit(1)
+    return json.loads(out.stdout)
+
+
+def fetch_compare(from_tag: str, to_tag: str, max_files: int = 300) -> tuple[list[FileChange], list[dict]]:
+    """Return (file_changes, commits) between two tags.
+
+    TODO(git-first): replace this GitHub compare API call with local git
+    diff parsing to eliminate the 300-file cap (see NEXT_STEPS.md Priority 1).
+    The current path aborts loudly rather than truncating, so it fails-loud
+    instead of silently omitting changes on large majors.
+    """
+    data = gh_json([f"repos/{REPO}/compare/{from_tag}...{to_tag}?per_page=300"])
+    files = []
+    for f in data.get("files", [])[:max_files]:
+        files.append(FileChange(
+            path=f["filename"],
+            additions=f.get("additions", 0),
+            deletions=f.get("deletions", 0),
+            patch=(f.get("patch") or "")[:8000],   # truncate per-file patch
+        ))
+    if len(data.get("files", [])) >= max_files:
+        sys.stderr.write(
+            f"ERROR: diff has >= {max_files} files (GitHub compare API cap; "
+            f"the report would silently omit changes). Aborting.\n"
+        )
+        sys.exit(2)
+    return files, data.get("commits", [])
+
+
+def fetch_prs_for_commits(commits: list[dict], limit: int = 500) -> list[PR]:
+    """For each commit, find its PR and then fetch the full PR for accurate
+    additions/deletions (the /commits/<sha>/pulls payload omits those).
+
+    TODO(git-first): replace with git_pr_extractor.build_prs_from_git — the
+    module is fully tested but not yet integrated (see NEXT_STEPS.md
+    Priority 1). Removing this function eliminates ~281 API calls per major.
+    """
+    pr_numbers: set[int] = set()
+    pr_basics: dict[int, dict] = {}
+    for c in commits[:limit]:
+        sha = c["sha"]
+        try:
+            data = gh_json([f"repos/{REPO}/commits/{sha}/pulls"])
+        except SystemExit:
+            continue
+        for p in data:
+            n = p["number"]
+            if n not in pr_numbers:
+                pr_numbers.add(n)
+                pr_basics[n] = p
+
+    prs: list[PR] = []
+    for n in sorted(pr_numbers):
+        try:
+            full = gh_json([f"repos/{REPO}/pulls/{n}"])
+        except SystemExit:
+            full = pr_basics[n]
+        prs.append(PR(
+            number=n,
+            title=full.get("title", ""),
+            author=(full.get("user") or {}).get("login", ""),
+            additions=full.get("additions", 0),
+            deletions=full.get("deletions", 0),
+        ))
+    return prs
+
+
+# =============================================================================
+# PR filtering (low-impact)
+# =============================================================================
+
+
+LOW_IMPACT_TITLE_PREFIXES = (
+    "string import",
+    "strings import",
+    "[v",                    # version bumps in title
+    "bump ",
+)
+
+LOW_IMPACT_TITLE_KEYWORDS = (
+    "string import",
+    "strings import",
+    "l10n",
+    "localization",
+)
+
+
+def is_low_impact_pr(pr: PR) -> Optional[str]:
+    """Return reason string if this PR should be filtered out, else None."""
+    title_lc = pr.title.lower()
+    if any(title_lc.startswith(p) for p in LOW_IMPACT_TITLE_PREFIXES):
+        return f"title prefix: {pr.title[:60]}"
+    if any(k in title_lc for k in LOW_IMPACT_TITLE_KEYWORDS):
+        return f"localization/strings: {pr.title[:60]}"
+    # Mergify backport detection happens at branch level (not visible from PR
+    # number alone); we approximate via title.
+    if "[backport]" in title_lc or "mergify" in title_lc:
+        return "mergify backport"
+    return None
+
+
+# =============================================================================
+# Risk heuristics (cheap, no LLM)
+# =============================================================================
+
+
+CONCURRENCY_RE = re.compile(r"\b(async|await|actor|DispatchQueue|Task\.|withCheckedContinuation|@MainActor|@Sendable)\b")
+FORCE_UNWRAP_RE = re.compile(r"(?<![A-Za-z_])try!|fatalError|preconditionFailure|!\s*\.|\![\s\)\.,;]")
+ERROR_HANDLING_RE = re.compile(r"\b(throw|throws|try\b|catch|Result<)")
+
+DEPENDENCY_PATHS = (
+    "Package.swift",
+    "Package.resolved",
+    "Podfile",
+    "Podfile.lock",
+    "MozillaRustComponents/",
+)
+
+# TODO(nimbus-fml): replace this coarse "any change to Nimbus config = high risk"
+# heuristic with FML-based auto-detection. Currently every touched file under
+# nimbus-features/ produces a "high" severity risk regardless of whether the
+# feature is off_in_release. Planned: parse the FML defaults per channel
+# between --from and --to tags, only flag as risk when the release-channel
+# `enabled` state changed, and route off-in-release features to a
+# "Nightly-only tests" report section. Note: fewer 'high' severity risks
+# means budget_calculator will bump less often — expected side effect.
+NIMBUS_PATHS = (
+    "firefox-ios/nimbus.fml.yaml",
+    "firefox-ios/nimbus-features/",
+    "firefox-ios/initial_experiments.json",
+)
+
+
+def patch_added_lines(patch: str) -> str:
+    """Return only the lines added by the patch (lines starting with +, excluding +++)."""
+    out = []
+    for line in patch.splitlines():
+        if line.startswith("+") and not line.startswith("+++"):
+            out.append(line[1:])
+    return "\n".join(out)
+
+
+def detect_risks(prs: list[PR], file_changes: list[FileChange]) -> list[RiskSignal]:
+    """Compute deterministic risk signals from PR-level and file-level heuristics.
+
+    NOTE: RiskSignal.location has an undocumented-but-load-bearing contract
+    used by candidate_scorer.build_scoring_context. It must be either:
+      - "PR #N"           → PR-level, skipped by the scorer's section mapping
+      - a file path with "/" → file-level, matched against touched modules
+    Locations without "/" (e.g. bare "Package.swift", "Podfile.lock") are
+    intentionally excluded from the "sections with risk" score boost, since
+    they don't map to any single TestRail section. If you add a new risk
+    type whose location doesn't fit either shape, either fix its location
+    or update the scorer's filter (candidate_scorer.py ~line 92).
+    """
+    risks: list[RiskSignal] = []
+
+    # Per-PR signals
+    for pr in prs:
+        loc = pr.additions + pr.deletions
+        if loc > 1000:
+            risks.append(RiskSignal("large_pr", "high", f"PR #{pr.number}",
+                                    f"{loc} LOC, '{pr.title[:80]}' by @{pr.author}"))
+
+    # Per-file content signals (uses patch text from compare endpoint).
+    # Test and noise files are excluded — these flags are about product risk,
+    # not test code style.
+    for fc in file_changes:
+        if not fc.patch:
+            continue
+        if is_noise_path(fc.path) or is_test_path(fc.path) or "Mock" in fc.path:
+            continue
+        added = patch_added_lines(fc.patch)
+        if CONCURRENCY_RE.search(added):
+            risks.append(RiskSignal("concurrency", "medium", fc.path,
+                                    "added/modified concurrent code (async/await/actor/DispatchQueue)"))
+        if FORCE_UNWRAP_RE.search(added):
+            risks.append(RiskSignal("force_unwrap", "low", fc.path,
+                                    "added force-unwrap, try!, or fatalError"))
+        if ERROR_HANDLING_RE.search(added) and ".swift" in fc.path:
+            if fc.additions > 50:
+                risks.append(RiskSignal("error_handling", "low", fc.path,
+                                        f"error-handling changes ({fc.additions} added lines)"))
+
+    # Release-level signals (deps + nimbus)
+    touched_paths = {fc.path for fc in file_changes}
+    for dep in DEPENDENCY_PATHS:
+        if any(p.startswith(dep) or p == dep for p in touched_paths):
+            hits = [p for p in touched_paths if p.startswith(dep) or p == dep]
+            risks.append(RiskSignal("dependency", "medium", dep,
+                                    f"dependency files changed: {', '.join(hits[:3])}"))
+    for n in NIMBUS_PATHS:
+        if any(p.startswith(n) for p in touched_paths):
+            hits = [p for p in touched_paths if p.startswith(n)]
+            risks.append(RiskSignal("nimbus_flags", "high", n,
+                                    f"Nimbus/feature-flag config changed — behavior may flip server-side without code change in product. Files: {', '.join(hits[:3])}"))
+
+    return risks
+
+
+# =============================================================================
+# Module classification
+# =============================================================================
+
+
+def known_modules_from_mapping(mapping: dict) -> list[str]:
+    """Collect every code path referenced anywhere in the mapping."""
+    paths: set[str] = set()
+    for s in mapping.get("sections", []):
+        for m in s.get("modules", []):
+            paths.add(m["path"])
+    for p in mapping.get("modules_without_clear_section", []) or []:
+        paths.add(p)
+    return sorted(paths, key=len, reverse=True)   # longest first for longest-prefix match
+
+
+def classify_file(path: str, known: list[str]) -> Optional[str]:
+    """Map a changed file to a known module path (longest-prefix match)."""
+    for m in known:
+        if path == m or path.startswith(m.rstrip("/") + "/"):
+            return m
+    return None
+
+
+def group_by_module(file_changes: list[FileChange], prs: list[PR], mapping: dict) -> tuple[dict[str, ModuleChange], list[FileChange]]:
+    """Group changed product-code files by module path. Test files and noise
+    paths are excluded — tests are handled separately via exact match, noise
+    is dropped entirely. Return (groups, unclassified_product_files)."""
+    known = known_modules_from_mapping(mapping)
+    groups: dict[str, ModuleChange] = {}
+    unclassified: list[FileChange] = []
+
+    for fc in file_changes:
+        if is_noise_path(fc.path) or is_test_path(fc.path):
+            continue
+        m = classify_file(fc.path, known)
+        if m is None:
+            unclassified.append(fc)
+            continue
+        if m not in groups:
+            groups[m] = ModuleChange(module=m)
+        groups[m].files.append(fc)
+    return groups, unclassified
+
+
+# =============================================================================
+# Test matching
+# =============================================================================
+
+
+def normalize_automated_path(s: str) -> list[str]:
+    """Extract Swift file paths from an Automated Test Name(s) field, which may
+    contain multiple entries separated by newlines, with formats like:
+        firefox-ios/firefox-ios-tests/Tests/XCUITests/TodayWidgetTests.swift#testFoo()
+        Tests/XCUITests/ModernKitOnboardingTests/testFoo
+        XCUITests/IntegrationTests#testFoo
+    Return the file-path portion(s) without the # suffix.
+    """
+    paths = []
+    for entry in re.split(r"[\n,]+", s):
+        entry = entry.strip()
+        if not entry:
+            continue
+        path = entry.split("#", 1)[0].strip()
+        if path:
+            paths.append(path)
+    return paths
+
+
+def exact_match_by_test_file(file_changes: list[FileChange], tests: list[TestCase]) -> list[TestCase]:
+    """Find TestRail cases whose Automated Test Name references a changed file."""
+    changed_test_files = [fc.path for fc in file_changes if "/Tests/" in fc.path or fc.path.endswith("Tests.swift")]
+    matched: list[TestCase] = []
+    for tc in tests:
+        if not tc.automated_test_name:
+            continue
+        for ref in normalize_automated_path(tc.automated_test_name):
+            # match if any changed test file ends-with or contains this ref tail
+            tail = ref.split("Tests/", 1)[-1]
+            for cf in changed_test_files:
+                if tail and tail in cf:
+                    matched.append(tc)
+                    break
+            else:
+                continue
+            break
+    return matched
+
+
+def section_match_tests(modules_touched: list[str], mapping: dict, tests: list[TestCase]) -> list[TestCase]:
+    """For each touched module, find sections that map to it, then return tests in those sections."""
+    module_to_sections: dict[str, set[str]] = defaultdict(set)
+    for s in mapping.get("sections", []):
+        name = s["name"]
+        for m in s.get("modules", []):
+            module_to_sections[m["path"]].add(name)
+
+    relevant_sections: set[str] = set()
+    for mt in modules_touched:
+        # exact + parent matches (since modules in YAML may be coarser than touched paths)
+        for known_module, sections in module_to_sections.items():
+            if mt == known_module or mt.startswith(known_module.rstrip("/") + "/") or known_module.startswith(mt.rstrip("/") + "/"):
+                relevant_sections.update(sections)
+
+    return [tc for tc in tests if tc.section_top in relevant_sections]
+
+
+# =============================================================================
+# Drift detection
+# =============================================================================
+
+
+def detect_drift(file_changes: list[FileChange], tests: list[TestCase], mapping: dict) -> list[DriftFinding]:
+    findings: list[DriftFinding] = []
+
+    # TestRail-side: sections in export but not in YAML
+    yaml_sections = {s["name"] for s in mapping.get("sections", [])}
+    export_sections = {tc.section_top for tc in tests if tc.section_top}
+    new_in_export = export_sections - yaml_sections
+    stale_in_yaml = yaml_sections - export_sections
+    for s in sorted(new_in_export):
+        sample_titles = [tc.title for tc in tests if tc.section_top == s][:5]
+        findings.append(DriftFinding("testrail_new_section", s,
+                                     f"sample test titles: {sample_titles}"))
+    for s in sorted(stale_in_yaml):
+        findings.append(DriftFinding("testrail_stale_section", s,
+                                     "section name in YAML not present in latest export (rename or removal?)"))
+
+    # Repo-side: touched product-code paths under known parent dirs but not in any YAML module.
+    # Test files and noise (Info.plist, .xcodeproj, .lproj/, Assets/) are excluded.
+    known = known_modules_from_mapping(mapping)
+    parents = ("BrowserKit/Sources/", "firefox-ios/Client/Frontend/", "firefox-ios/Client/", "firefox-ios/")
+    unclassified_modules: set[str] = set()
+    for fc in file_changes:
+        if is_noise_path(fc.path) or is_test_path(fc.path):
+            continue
+        if classify_file(fc.path, known) is not None:
+            continue
+        for parent in parents:
+            if fc.path.startswith(parent):
+                rest = fc.path[len(parent):]
+                head = rest.split("/", 1)[0]
+                if head:
+                    unclassified_modules.add(parent + head)
+                break
+    for m in sorted(unclassified_modules):
+        findings.append(DriftFinding("repo_new_module", m,
+                                     "module appears in diff but is not referenced in mapping YAML"))
+
+    return findings
+
+
+# =============================================================================
+# LLM rerank + synthesize  (models configured via LLM_MODEL_RERANK / LLM_MODEL_SYNTHESIZE)
+# =============================================================================
+# Design notes:
+#   - Two stages: rerank produces a prioritized subset with structured output;
+#     synthesize produces the Markdown narrative.
+#   - Pool sizing: candidates are pre-filtered deterministically (see
+#     candidate_scorer.py) to top_k = budget.final_hi * 4 BEFORE reaching the
+#     LLM. Typical minor release: ~989 raw → ~280 after pre-filter.
+#   - Prompt caching: both stages put stable instructions in the `system`
+#     block with cache_control:ephemeral. The 5-min TTL means cross-release
+#     cache misses (releases are days apart) but same-session reruns hit
+#     cache — useful for retries, dry-runs, and back-to-back experiments.
+#   - Graceful fallback: if ANTHROPIC_API_KEY is unset or the SDK isn't
+#     installed, or any API call fails, fall back to the deterministic ranker
+#     (`_deterministic_rerank`) and the deterministic Markdown writer
+#     (`render_deterministic_report`). The pipeline never fails closed.
+#   - Determinism: temperature=0 on Sonnet 4.6 (Sonnet 5+ deprecated
+#     temperature; effort=low is the equivalent). Combined with the
+#     deterministic pre-filter, run-to-run overlap on identical inputs is
+#     ~55% Jaccard on our v151.2→v151.3 baseline. Residual variance is cloud
+#     non-determinism; not reducible without ensemble or LLM bypass.
+#   - Effort: "low" for rerank (classification-shaped task), "medium" for
+#     synthesize (writing a structured report). Skipped for Haiku (rejects).
+#   - Thinking: disabled — neither stage needs multi-step reasoning, and
+#     disabling avoids spending tokens on it.
+
+
+@dataclass
+class RankedTest:
+    test_id: str
+    priority: str           # "P0" | "P1" | "P2"
+    reason: str
+
+
+SYSTEM_PROMPT_RERANK = """You are a release QA test-prioritization assistant for the Firefox iOS application (github.com/mozilla-mobile/firefox-ios). The manual QA team cannot execute the full ~1650-case regression suite on every release, so you select the highest-value subset to run.
+
+# Your task
+Given:
+  1. A list of "candidate" TestRail test cases (already filtered to areas plausibly affected by this release). Each candidate includes a deterministic `score` field (integer, can be negative). Higher score means stronger a-priori signal: exact code↔test match, section maps to a high-LOC touched module, section has an attached risk signal, or the test is manual-only. Negative scores are for tests already covered by CI. Use `score` as a strong hint but not a hard constraint — you may still promote a lower-score candidate if the risk context justifies it, or demote a high-score candidate if the reason is thin.
+  2. A summary of the modules touched in the release diff
+  3. A list of risk signals computed from the diff (concurrency changes, dependency bumps, Nimbus feature-flag changes, force-unwraps, hotspots, large PRs without tests, etc.)
+  4. A list of "drift" findings (modules touched that are not yet mapped to any TestRail section — coverage blind spots)
+
+Return a prioritized subset of {budget_lo}-{budget_hi} tests, each tagged with:
+  - priority: "P0" | "P1" | "P2"
+  - reason: one short sentence (under 25 words) explaining why this test is worth running for THIS release specifically (not generic descriptions of the test)
+
+# Priority rubric
+
+P0 (must run)
+  - Directly tests behavior in a module that was modified with substantial LOC (>100) AND has risk signals attached, OR
+  - Covers a flow that depends on a changed dependency (Rust components, Package.swift), OR
+  - Cross-references a Nimbus feature flag that changed, OR
+  - Tests a critical user flow (authentication, sync, tab management, search) where the touched module is implicated.
+
+P1 (should run)
+  - Tests behavior in a touched module but with lower change volume or no risk signals, OR
+  - Adjacent to a P0 test in the same section (smoke-coverage of the area).
+
+P2 (run if time)
+  - Tests in sections only loosely connected to the changes (e.g. shared UI components, settings adjacent to changed areas).
+  - DO NOT include tests purely because they share a section with a touched module if no real connection exists.
+
+# Important rules
+  - Tests marked `automation: Completed` are already covered by CI — DEPRIORITIZE these (P2 at best) unless the change directly modified the underlying tests too.
+  - Smoke & Sanity tests are handled separately by the automated smoke suite and are NOT in the candidate list. Do not ask for them; focus on the release-specific regression the candidates represent.
+  - Tests marked `automation: Unsuitable` are manual-only and must be run by humans — favor these for P0/P1 when relevant.
+  - Do not invent test IDs. Only return IDs present in the candidate list.
+  - Hard cap: return at most {budget_hi} ranked tests.
+  - Be honest about uncertainty in the `reason` field. A reason like "tests the touched module" is fine if you genuinely don't have more signal.
+
+# Output format
+You will respond using the provided JSON schema. Order the `ranked_tests` array by priority (P0 first, then P1, then P2). Within the same priority, order by the section that received the most changes first.
+
+In `notes`, briefly list (under 200 words):
+  - Any coverage gaps you noticed (modules touched but with no candidates that meaningfully cover them)
+  - Any flows where you think a new automated regression test would be valuable
+  - Any areas suitable for exploratory testing
+"""
+
+
+SYSTEM_PROMPT_SYNTHESIZE = """You are a release QA report writer for the Firefox iOS application. You produce a single Markdown report per release that the manual QA team uses to decide what to test.
+
+# Inputs you receive
+  1. The release tag pair (from → to)
+  2. Module-level summary of code changes
+  3. Risk signals (concurrency, force-unwraps, dependency bumps, Nimbus changes, large PRs, hotspots)
+  4. Mapping drift findings (modules touched without TestRail coverage — these are coverage blind spots)
+  5. A ranked list of TestRail tests with priorities (P0/P1/P2) and per-test reasons, plus narrative notes from the rerank stage
+  6. Unclassified file changes (touched paths the pipeline could not map to any module)
+
+# Report structure (use exactly these section headings, in this order)
+
+## Executive summary
+2-4 bullets. What is the headline of this release? Top 2-3 areas the QA team should focus on. Mention the largest single risk if one stands out.
+
+## Suggested manual tests
+Three subsections: ### P0 (must run), ### P1 (should run), ### P2 (if time).
+Under each, list the tests like:
+  - `C123456` — Test title — *Reason: ...*  _(section, sub_suite, automation status)_
+Group by section_top when there are 5+ tests in the same area.
+
+## Coverage gaps — manual tests to add
+Identify areas where:
+  - Modules were touched but no TestRail tests exist for them (use the drift findings + unclassified files)
+  - Changes introduce behavior that the existing catalog plausibly does not cover
+  - The QA team should consider adding a new manual test case
+Be specific. Cite the touched module or PR pattern.
+
+## Suggested automated regression
+For critical flows touched in this release that lack automated regression:
+  - Identify candidate flows (auth, sync, tabs, search, etc.) where the diff suggests new behavior or risk
+  - Suggest where a new automated regression test would prevent future drift
+  - Prefer suggestions where `automation: Unsuitable` is high — those are manual-only and the team is bottlenecked there
+
+## Risks
+Translate the risk signals into prose, ranked high → low severity:
+  - Concurrency changes — name the files, explain why they matter
+  - Force-unwrap / try! introductions — risk of runtime crashes
+  - Dependency bumps (especially MozillaRustComponents) — explain downstream impact (Sync, Logins, Autofill)
+  - Nimbus / feature-flag changes — flag that production behavior may differ from build behavior depending on rollout
+  - Large PRs (>1000 LOC) — name the PR titles, suggest reviewers
+  - Hotspot files (modified by many authors recently) — flag for closer review
+
+## Exploratory testing focus
+Suggest 3-6 specific areas of the app for exploratory testing this release, framed as "Spend 20-30 min poking at X with focus on Y". Tie each suggestion to a concrete change in the diff.
+
+## High-risk PRs to review more deeply
+A short list of PRs that warrant deeper code review beyond QA — large refactors, hotspot-heavy changes, dependency bumps, or PRs that introduced multiple risk signals. One bullet per PR with the # and a one-line justification.
+
+# Examples of good vs bad output
+
+For the Risks section, prefer specific and actionable framings over generic warnings.
+
+BAD:  "PR #33846 introduces concurrency changes that may cause issues."
+GOOD: "PR #33846 — ReaderModeSchemeHandler refactor (1142 LOC, @Alex-Bangu): async/await plus a new force-unwrap in the scheme handler that every Reader Mode entry point depends on. A crash here is user-visible on every article page."
+
+For Coverage gaps, name the exact files or modules and propose specific test scenarios rather than restating that coverage is missing.
+
+BAD:  "Add tests for the WorldCup widget."
+GOOD: "WorldCup widget (989 LOC across 7 files, including WorldCupWinnerBackgroundView.swift with a force-unwrap) — no TestRail cases exist. Add: (1) widget renders knockout-phase brackets correctly; (2) widget handles API error state without crash; (3) widget survives homepage foreground-resume without duplicating requests."
+
+For High-risk PRs, keep bullets to one line each. The reader wants to skim, not to read a paragraph per PR.
+
+GOOD: "- #33846 (Reader mode scheme refactor, 1142 LOC): async concurrency plus a new force-unwrap on the critical Reader Mode path — warrants senior iOS review."
+
+Anti-patterns to avoid in every section:
+  - Hedge language ("could potentially", "may possibly", "it is worth noting"). Lead with the fact.
+  - Rewriting the input JSON as prose. The reader has the diff; give them insight, not restatement.
+  - Bullets that end in "…" or trail off. Every bullet must land a claim.
+
+# Style guide
+  - English, professional, direct.
+  - No filler ("It is important to note that..."). Lead with the fact.
+  - Use Markdown lists liberally; minimize prose paragraphs.
+  - Cite test IDs as backticked codes: `C123456`.
+  - Cite paths as backticked: `firefox-ios/Client/Frontend/Reader/...`.
+  - Never invent details. If a section has no content, write a one-line "No findings in this release" instead of fabricating.
+  - The report goes to a QA lead who will read it in 5 minutes — every word should earn its place.
+"""
+
+
+RERANK_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "ranked_tests": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "test_id": {"type": "string"},
+                    "priority": {"type": "string", "enum": ["P0", "P1", "P2"]},
+                    "reason": {"type": "string"},
+                },
+                "required": ["test_id", "priority", "reason"],
+                "additionalProperties": False,
+            },
+        },
+        "notes": {"type": "string"},
+    },
+    "required": ["ranked_tests", "notes"],
+    "additionalProperties": False,
+}
+
+
+def _llm_available() -> bool:
+    return _ANTHROPIC_AVAILABLE and bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+
+def _candidates_for_prompt(analysis: Analysis) -> tuple[list[TestCase], list[dict]]:
+    """Dedup exact + section matches, pre-filter to top-K by deterministic
+    score, and return (TestCase list, compact dicts for prompt).
+
+    Two-stage narrowing:
+      1. Dedup + drop Smoke & Sanity (Smoke runs automatically).
+      2. Score each remaining candidate; keep only the top-K where
+         K = budget.final_hi * 4 (Phase 3 pre-filter).
+
+    The score is included in the compact payload as a hint for the LLM —
+    a numeric signal it can weight when its judgment is uncertain."""
+    # Stage 1: dedup + Smoke filter
+    seen: set[str] = set()
+    deduped: list[TestCase] = []
+    for tc in analysis.exact_matched_tests + analysis.section_matched_tests:
+        if tc.id in seen:
+            continue
+        if tc.sub_suite == "Smoke & Sanity":
+            continue
+        seen.add(tc.id)
+        deduped.append(tc)
+
+    # Stage 2: pre-filter by score. top_k = budget_hi * 4 gives the LLM ~4×
+    # the ceiling to choose from — enough room for judgment, but far tighter
+    # than the raw ~999-candidate pool.
+    top_k = analysis.budget.final_hi * 4
+    scored = pre_filter_candidates(deduped, analysis.scoring_context, top_k=top_k)
+
+    out = [tc for tc, _ in scored]
+    compact = [
+        {
+            "id": tc.id,
+            "title": tc.title,
+            "section": tc.section_top,
+            "suite": tc.sub_suite,
+            "auto": tc.automation,
+            "score": score,
+        }
+        for tc, score in scored
+    ]
+    return out, compact
+
+
+def _module_summary_for_prompt(analysis: Analysis) -> list[dict]:
+    return [
+        {
+            "module": mc.module,
+            "loc": mc.total_loc,
+            "files": [f.path for f in mc.files[:20]],   # cap to keep prompt reasonable
+        }
+        for mc in sorted(analysis.module_changes.values(), key=lambda m: m.total_loc, reverse=True)
+    ]
+
+
+def _risks_for_prompt(analysis: Analysis) -> list[dict]:
+    return [
+        {"kind": r.kind, "severity": r.severity, "location": r.location, "detail": r.detail}
+        for r in analysis.risks
+    ]
+
+
+def _drift_for_prompt(analysis: Analysis) -> list[dict]:
+    return [{"kind": d.kind, "item": d.item, "detail": d.detail} for d in analysis.drift]
+
+
+def _deterministic_rerank(analysis: Analysis) -> list[RankedTest]:
+    """Fallback when LLM unavailable. Rough heuristic ordering by sub_suite and
+    automation status — not a substitute for the LLM, but better than nothing.
+    Respects the release-specific budget ceiling."""
+    candidates, _ = _candidates_for_prompt(analysis)
+    # Smoke & Sanity is filtered out upstream in _candidates_for_prompt.
+    suite_order = {"Functional": 0, "Special Case": 1}
+    auto_order = {"Unsuitable": 0, "Untriaged": 1, "Suitable": 2, "Disabled": 3, "Completed": 4}
+    candidates.sort(key=lambda tc: (suite_order.get(tc.sub_suite, 9), auto_order.get(tc.automation, 9)))
+    out: list[RankedTest] = []
+    for tc in candidates[:analysis.budget.final_hi]:
+        # crude priority: manual-only = P1 (must be run by humans), automated = P2
+        if tc.automation in ("Unsuitable", "Untriaged"):
+            prio = "P1"
+        else:
+            prio = "P2"
+        out.append(RankedTest(test_id=tc.id, priority=prio,
+                              reason=f"section '{tc.section_top}' was matched against touched modules (deterministic fallback)"))
+    return out
+
+
+def llm_rerank(analysis: Analysis) -> tuple[list[RankedTest], str]:
+    """Call the configured rerank model (LLM_MODEL_RERANK) to prioritize
+    candidates. Returns (ranked, notes). Falls back to deterministic ranker
+    on any failure. Uses analysis.budget to size the request."""
+    if not _llm_available():
+        return _deterministic_rerank(analysis), ""
+
+    candidates, compact = _candidates_for_prompt(analysis)
+    if not compact:
+        return [], ""
+
+    user_payload = {
+        "release": {"from": analysis.from_tag, "to": analysis.to_tag},
+        "module_changes": _module_summary_for_prompt(analysis),
+        "risks": _risks_for_prompt(analysis),
+        "drift": _drift_for_prompt(analysis),
+        "candidates": compact,
+    }
+    user_text = (
+        "Rank the candidates for this release. Use the rubric in the system prompt.\n\n"
+        "## Release data (JSON)\n"
+        f"```json\n{json.dumps(user_payload, separators=(',', ':'))}\n```"
+    )
+
+    # Model-specific parameter compatibility:
+    #   - `effort` is a Sonnet/Opus feature; Haiku rejects it.
+    #   - `temperature` is deprecated on Sonnet 5+ / Opus 4.8+ (determinism
+    #     is controlled implicitly by effort/thinking on those models).
+    # Structured output via json_schema is universal.
+    model_lc = LLM_MODEL_RERANK.lower()
+    output_config: dict = {"format": {"type": "json_schema", "schema": RERANK_SCHEMA}}
+    if "haiku" not in model_lc:
+        output_config["effort"] = os.environ.get("RECOMMEND_RERANK_EFFORT", "low")
+
+    # Inject the release-specific budget into the prompt. `{budget_lo}` and
+    # `{budget_hi}` placeholders come from Phase 2. Everything else in the
+    # prompt is stable, so the cached prefix is still hit.
+    prompt_rendered = SYSTEM_PROMPT_RERANK.format(
+        budget_lo=analysis.budget.final_lo,
+        budget_hi=analysis.budget.final_hi,
+    )
+
+    kwargs: dict = {
+        "model": LLM_MODEL_RERANK,
+        "max_tokens": 8000,
+        "thinking": {"type": "disabled"},
+        "output_config": output_config,
+        "system": [{
+            "type": "text",
+            "text": prompt_rendered,
+            "cache_control": {"type": "ephemeral"},
+        }],
+        "messages": [{"role": "user", "content": user_text}],
+    }
+    # Only set temperature on models that still accept it.
+    if "sonnet-5" not in model_lc and "opus-4-8" not in model_lc:
+        kwargs["temperature"] = 0
+
+    try:
+        # max_retries=6 so the SDK rides out 30k-TPM rolling-window resets (~60s).
+        client = anthropic.Anthropic(max_retries=6)
+        response = client.messages.create(**kwargs)
+    except anthropic.APIStatusError as e:
+        sys.stderr.write(f"[recommend] LLM rerank failed ({e.status_code}): {e.message}\n")
+        return _deterministic_rerank(analysis), ""
+    except Exception as e:
+        sys.stderr.write(f"[recommend] LLM rerank failed: {e}\n")
+        return _deterministic_rerank(analysis), ""
+
+    sys.stderr.write(
+        f"[recommend]   rerank usage: input={response.usage.input_tokens} "
+        f"cache_write={response.usage.cache_creation_input_tokens} "
+        f"cache_read={response.usage.cache_read_input_tokens} "
+        f"output={response.usage.output_tokens}\n"
+    )
+
+    text = next((b.text for b in response.content if b.type == "text"), "")
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"[recommend] LLM rerank returned non-JSON: {e}\n")
+        return _deterministic_rerank(analysis), ""
+
+    valid_ids = {tc.id for tc in candidates}
+    ranked: list[RankedTest] = []
+    for item in parsed.get("ranked_tests", []):
+        tid = item.get("test_id")
+        prio = item.get("priority")
+        reason = item.get("reason", "")
+        if tid in valid_ids and prio in ("P0", "P1", "P2"):
+            ranked.append(RankedTest(test_id=tid, priority=prio, reason=reason))
+
+    # Defensive cap based on the release-specific budget. The prompt asks for
+    # at most `budget_hi`, but some models (notably Haiku 4.5) do not respect
+    # the instruction reliably. Enforce it here so downstream consumers can
+    # trust the length regardless of model.
+    hard_cap = analysis.budget.final_hi
+    if len(ranked) > hard_cap:
+        sys.stderr.write(
+            f"[recommend] rerank returned {len(ranked)} tests, over the budget "
+            f"ceiling {hard_cap}. Trimming to first {hard_cap} (order preserved).\n"
+        )
+        ranked = ranked[:hard_cap]
+
+    return ranked, parsed.get("notes", "")
+
+
+def llm_synthesize(analysis: Analysis, ranked: list[RankedTest], notes: str, test_index: dict[str, TestCase]) -> str:
+    """Call the configured synthesize model (LLM_MODEL_SYNTHESIZE) to write
+    the full Markdown report. Falls back to deterministic Markdown if LLM is
+    unavailable or fails."""
+    if not _llm_available():
+        return render_deterministic_report(analysis, [test_index[r.test_id] for r in ranked if r.test_id in test_index])
+
+    # Enrich ranked tests with title/section/automation so the LLM has full context.
+    ranked_payload = []
+    for r in ranked:
+        tc = test_index.get(r.test_id)
+        if not tc:
+            continue
+        ranked_payload.append({
+            "test_id": r.test_id,
+            "priority": r.priority,
+            "reason": r.reason,
+            "title": tc.title,
+            "section": tc.section_hierarchy,
+            "sub_suite": tc.sub_suite,
+            "automation": tc.automation,
+        })
+
+    user_payload = {
+        "release": {"from": analysis.from_tag, "to": analysis.to_tag},
+        "stats": {
+            "prs_in_scope": len(analysis.prs),
+            "prs_skipped": len(analysis.skipped_prs),
+            "files_changed": len(analysis.file_changes),
+            "total_loc": sum(f.additions + f.deletions for f in analysis.file_changes),
+            "modules_touched": len(analysis.module_changes),
+            "unclassified_files": len(analysis.unclassified_files),
+        },
+        "module_changes": _module_summary_for_prompt(analysis),
+        "risks": _risks_for_prompt(analysis),
+        "drift": _drift_for_prompt(analysis),
+        "ranked_tests": ranked_payload,
+        "rerank_notes": notes,
+        "unclassified_files": [{"path": f.path, "additions": f.additions, "deletions": f.deletions}
+                               for f in analysis.unclassified_files[:30]],
+        "largest_prs": [
+            {"number": p.number, "title": p.title, "author": p.author,
+             "additions": p.additions, "deletions": p.deletions}
+            for p in sorted(analysis.prs, key=lambda p: p.additions + p.deletions, reverse=True)[:10]
+        ],
+        "skipped_prs": [{"number": p.number, "title": p.title, "reason": reason}
+                        for p, reason in analysis.skipped_prs],
+    }
+
+    user_text = (
+        "Write the release QA report. Follow the structure exactly as specified in the system prompt.\n\n"
+        "## Release data (JSON)\n"
+        f"```json\n{json.dumps(user_payload, separators=(',', ':'))}\n```"
+    )
+
+    try:
+        client = anthropic.Anthropic(max_retries=6)
+        with client.messages.stream(
+            model=LLM_MODEL_SYNTHESIZE,
+            max_tokens=16000,
+            thinking={"type": "disabled"},
+            output_config={"effort": "medium"},
+            system=[{
+                "type": "text",
+                "text": SYSTEM_PROMPT_SYNTHESIZE,
+                "cache_control": {"type": "ephemeral"},
+            }],
+            messages=[{"role": "user", "content": user_text}],
+        ) as stream:
+            final = stream.get_final_message()
+    except anthropic.APIStatusError as e:
+        sys.stderr.write(f"[recommend] LLM synthesize failed ({e.status_code}): {e.message}\n")
+        return render_deterministic_report(analysis, [test_index[r.test_id] for r in ranked if r.test_id in test_index])
+    except Exception as e:
+        sys.stderr.write(f"[recommend] LLM synthesize failed: {e}\n")
+        return render_deterministic_report(analysis, [test_index[r.test_id] for r in ranked if r.test_id in test_index])
+
+    sys.stderr.write(
+        f"[recommend]   synth usage: input={final.usage.input_tokens} "
+        f"cache_write={final.usage.cache_creation_input_tokens} "
+        f"cache_read={final.usage.cache_read_input_tokens} "
+        f"output={final.usage.output_tokens}\n"
+    )
+
+    body = next((b.text for b in final.content if b.type == "text"), "").strip()
+
+    # Prepend the drift warning + budget line (both deterministic, must
+    # always be visible regardless of LLM output).
+    header_parts = [
+        f"# Release Test Recommendation — {analysis.from_tag} → {analysis.to_tag}\n",
+        f"_Generated by recommend.py — rerank: {LLM_MODEL_RERANK}, synthesize: {LLM_MODEL_SYNTHESIZE}._\n",
+        f"_{analysis.budget.summary_line()}_\n",
+    ]
+    if analysis.drift:
+        header_parts.append("## ⚠️ Mapping drift detected\n")
+        for d in analysis.drift:
+            header_parts.append(f"- **{d.kind}** — `{d.item}` — {d.detail}")
+        header_parts.append("\n_Run `align.py` to curate the mapping YAML._\n")
+    return "\n".join(header_parts) + "\n" + body
+
+
+# =============================================================================
+# Report writer (deterministic fallback)
+# =============================================================================
+
+
+def render_deterministic_report(analysis: Analysis, ranked_tests: list[TestCase]) -> str:
+    lines: list[str] = []
+    lines.append(f"# Release Test Recommendation — {analysis.from_tag} → {analysis.to_tag}\n")
+    lines.append(f"_Generated by recommend.py — deterministic fallback (LLM unavailable or failed)._\n")
+    lines.append(f"_{analysis.budget.summary_line()}_\n")
+
+    # Drift warning at the top
+    if analysis.drift:
+        lines.append("## ⚠️ Mapping drift detected\n")
+        for d in analysis.drift:
+            lines.append(f"- **{d.kind}** — `{d.item}` — {d.detail}")
+        lines.append("\n_Run `align.py` to curate. The report below still reflects all data available._\n")
+
+    # Executive summary
+    lines.append("## Executive summary\n")
+    lines.append(f"- **PRs in scope**: {len(analysis.prs)} (after filtering {len(analysis.skipped_prs)} low-impact)")
+    lines.append(f"- **Files changed**: {len(analysis.file_changes)}")
+    total_loc = sum(f.additions + f.deletions for f in analysis.file_changes)
+    lines.append(f"- **Total LOC changed**: {total_loc}")
+    lines.append(f"- **Modules touched**: {len(analysis.module_changes)}")
+    lines.append(f"- **Unclassified files**: {len(analysis.unclassified_files)}")
+    lines.append(f"- **Risk signals**: {len(analysis.risks)} ({sum(1 for r in analysis.risks if r.severity=='high')} high)")
+    lines.append(f"- **Candidate tests**: {len(ranked_tests)}")
+    lines.append("")
+
+    # Modules with most change
+    lines.append("## Most-changed modules\n")
+    top_modules = sorted(analysis.module_changes.values(), key=lambda m: m.total_loc, reverse=True)
+    for mc in top_modules[:15]:
+        lines.append(f"- `{mc.module}` — {len(mc.files)} files, {mc.total_loc} LOC")
+    lines.append("")
+
+    # Risks
+    if analysis.risks:
+        lines.append("## Risks\n")
+        by_severity = {"high": [], "medium": [], "low": []}
+        for r in analysis.risks:
+            by_severity[r.severity].append(r)
+        for sev in ("high", "medium", "low"):
+            if by_severity[sev]:
+                lines.append(f"### {sev.upper()}\n")
+                for r in by_severity[sev]:
+                    lines.append(f"- **{r.kind}** at `{r.location}`: {r.detail}")
+                lines.append("")
+
+    # Ranked tests
+    lines.append("## Suggested tests to run\n")
+    if not ranked_tests:
+        lines.append("_No candidate tests matched. Check the drift section and/or the mapping YAML._\n")
+    else:
+        # group by section_top for readability
+        by_section: dict[str, list[TestCase]] = defaultdict(list)
+        for tc in ranked_tests:
+            by_section[tc.section_top].append(tc)
+        for sec, group in sorted(by_section.items(), key=lambda kv: -len(kv[1])):
+            lines.append(f"### {sec} ({len(group)} tests)\n")
+            for tc in group[:50]:
+                lines.append(f"- `{tc.id}` — {tc.title} _(suite: {tc.sub_suite}; automation: {tc.automation})_")
+            if len(group) > 50:
+                lines.append(f"- _… and {len(group)-50} more in this section_")
+            lines.append("")
+
+    # Unclassified files (so they're not lost)
+    if analysis.unclassified_files:
+        lines.append("## Unclassified changes — no section mapping\n")
+        lines.append("_These files were modified but no TestRail section maps to their module. They are NOT silently dropped._\n")
+        for fc in analysis.unclassified_files[:30]:
+            lines.append(f"- `{fc.path}` (+{fc.additions} / -{fc.deletions})")
+        if len(analysis.unclassified_files) > 30:
+            lines.append(f"- _… and {len(analysis.unclassified_files)-30} more_")
+        lines.append("")
+
+    # High-risk PRs
+    high_risk_prs = sorted(analysis.prs, key=lambda p: p.additions + p.deletions, reverse=True)[:10]
+    if high_risk_prs:
+        lines.append("## Largest PRs (candidates for deeper review)\n")
+        for p in high_risk_prs:
+            lines.append(f"- #{p.number} (+{p.additions}/-{p.deletions}) — {p.title[:90]} _by @{p.author}_")
+        lines.append("")
+
+    # Skipped PRs (for transparency)
+    if analysis.skipped_prs:
+        lines.append("## Skipped (auto-classified low-impact)\n")
+        for p, reason in analysis.skipped_prs:
+            lines.append(f"- #{p.number} — {p.title[:80]} _({reason})_")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("_End of deterministic report. When the LLM is available, its rerank/synthesize output replaces the test-prioritization and narrative sections._")
+    return "\n".join(lines)
+
+
+# =============================================================================
+# Main
+# =============================================================================
+
+
+def run_pipeline(from_tag: str, to_tag: str, testrail_path: Path, mapping_path: Path, output_path: Path, verbose: bool = False) -> None:
+    def vlog(msg: str) -> None:
+        if verbose:
+            print(f"[recommend] {msg}", file=sys.stderr)
+
+    vlog("loading mapping + testrail export …")
+    mapping = load_mapping(mapping_path)
+    tests = load_testrail(testrail_path)
+    vlog(f"  {len(tests)} TestRail cases loaded, {len(mapping.get('sections', []))} sections in YAML")
+
+    vlog(f"fetching diff {from_tag}...{to_tag} …")
+    file_changes, commits = fetch_compare(from_tag, to_tag)
+    vlog(f"  {len(file_changes)} files, {len(commits)} commits")
+
+    vlog("resolving PRs from commits …")
+    prs = fetch_prs_for_commits(commits)
+    vlog(f"  {len(prs)} unique PRs")
+
+    vlog("filtering low-impact PRs …")
+    kept_prs: list[PR] = []
+    skipped: list[tuple[PR, str]] = []
+    for p in prs:
+        reason = is_low_impact_pr(p)
+        if reason:
+            skipped.append((p, reason))
+        else:
+            kept_prs.append(p)
+    vlog(f"  kept {len(kept_prs)}, skipped {len(skipped)}")
+
+    vlog("detecting drift …")
+    drift = detect_drift(file_changes, tests, mapping)
+    vlog(f"  {len(drift)} drift findings")
+
+    vlog("computing risk heuristics …")
+    risks = detect_risks(kept_prs, file_changes)
+    vlog(f"  {len(risks)} risk signals ({sum(1 for r in risks if r.severity=='high')} high)")
+
+    vlog("grouping files by module …")
+    module_changes, unclassified = group_by_module(file_changes, kept_prs, mapping)
+    vlog(f"  {len(module_changes)} modules touched, {len(unclassified)} unclassified files")
+
+    vlog("matching tests (exact, by automated test name) …")
+    exact = exact_match_by_test_file(file_changes, tests)
+    vlog(f"  {len(exact)} exact matches")
+
+    vlog("matching tests (by section) …")
+    section_tests = section_match_tests(list(module_changes.keys()), mapping, tests)
+    vlog(f"  {len(section_tests)} section-matched")
+
+    vlog("computing test budget …")
+    release_type = detect_release_type(from_tag, to_tag)
+    # NOTE: max_pr_loc uses kept_prs (post low-impact filter), NOT the raw
+    # `prs` list. Rationale: a 3000-LOC strings import or Mergify backport
+    # shouldn't inflate the test budget just because it's large — those
+    # changes are behaviour-neutral. Only PRs that survive the low-impact
+    # filter count toward the "big PR" budget bump.
+    signal = ReleaseSignal(
+        total_loc=sum(f.additions + f.deletions for f in file_changes),
+        max_pr_loc=max((p.additions + p.deletions for p in kept_prs), default=0),
+        high_severity_risk_count=sum(1 for r in risks if r.severity == "high"),
+    )
+    budget = compute_test_budget(release_type, signal)
+    vlog(f"  release_type={release_type}  budget={budget.final_lo}-{budget.final_hi}  "
+         f"(bump=+{budget.bump}: {budget.bump_reasons or 'none'})")
+
+    vlog("building scoring context (Phase 3 pre-filter) …")
+    scoring_context = build_scoring_context(exact, module_changes, risks, mapping)
+    vlog(f"  {len(scoring_context.high_loc_modules)} high-LOC modules, "
+         f"{len(scoring_context.sections_with_risk)} sections with risk signal")
+
+    analysis = Analysis(
+        from_tag=from_tag, to_tag=to_tag,
+        prs=kept_prs, skipped_prs=skipped,
+        file_changes=file_changes,
+        module_changes=module_changes,
+        risks=risks, drift=drift,
+        exact_matched_tests=exact,
+        section_matched_tests=section_tests,
+        unclassified_files=unclassified,
+        budget=budget,
+        scoring_context=scoring_context,
+    )
+
+    # Preview the pre-filter effect for visibility in the log
+    raw_pool_size = len({tc.id for tc in exact + section_tests if tc.sub_suite != "Smoke & Sanity"})
+    top_k = budget.final_hi * 4
+    vlog(f"pre-filter: {raw_pool_size} candidates → top {min(top_k, raw_pool_size)} (budget_hi × 4 = {top_k})")
+
+    vlog("LLM rerank …")
+    ranked, rerank_notes = llm_rerank(analysis)
+    vlog(f"  {len(ranked)} tests ranked (P0={sum(1 for r in ranked if r.priority=='P0')}, "
+         f"P1={sum(1 for r in ranked if r.priority=='P1')}, "
+         f"P2={sum(1 for r in ranked if r.priority=='P2')})")
+
+    vlog("LLM synthesize …")
+    test_index = {tc.id: tc for tc in tests}
+    report = llm_synthesize(analysis, ranked, rerank_notes, test_index)
+
+    output_path.write_text(report)
+    print(f"wrote {output_path}  ({len(report)} chars)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(description="Firefox iOS Test Recommender")
+    p.add_argument("--from", dest="from_tag", required=True, help="Previous release tag, e.g. firefox-v150.0")
+    p.add_argument("--to", dest="to_tag", required=True, help="New release tag, e.g. firefox-v151.0")
+    p.add_argument("--testrail", required=True, type=Path, help="Path to TestRail export .xlsx")
+    p.add_argument("--mapping", required=True, type=Path, help="Path to section_to_module_mapping.yaml")
+    p.add_argument("--output", type=Path, default=None, help="Output Markdown path (default: release_report_<to_tag>.md)")
+    p.add_argument("--verbose", "-v", action="store_true")
+    args = p.parse_args()
+
+    output = args.output or Path(f"release_report_{args.to_tag}.md")
+    run_pipeline(args.from_tag, args.to_tag, args.testrail, args.mapping, output, verbose=args.verbose)
+
+
+if __name__ == "__main__":
+    main()

--- a/test-recommender/requirements.txt
+++ b/test-recommender/requirements.txt
@@ -1,0 +1,17 @@
+# Minimum versions pinned to the ones this project has been tested against.
+# Update carefully — the Anthropic SDK evolves the messages API frequently
+# (see the model-specific parameter handling in recommend.py).
+#
+# The upper cap on `anthropic` is a safety net: Anthropic's pre-1.0 SDK has
+# introduced breaking changes at minor bumps in the past (budget_tokens
+# deprecation, output_config.format reshape, model-specific parameter
+# handling). The cap gives ~1 year of headroom for new models without
+# requiring code changes. When it needs raising, verify:
+#   - messages.create() signature (kwargs still accepted)
+#   - output_config.format schema (json_schema still supported)
+#   - streaming API (client.messages.stream still returns the same shape)
+#   - error class hierarchy (anthropic.APIStatusError still exposes .status_code)
+
+openpyxl>=3.1.5
+pyyaml>=6.0.3
+anthropic>=0.109.1,<0.200

--- a/test-recommender/scripts/count_prompt_tokens.py
+++ b/test-recommender/scripts/count_prompt_tokens.py
@@ -1,0 +1,62 @@
+"""Measure exact token counts of the recommend.py system prompts.
+
+Uses Anthropic's count_tokens endpoint to get the authoritative number for the
+model we run in production. Prints a table with a verdict on whether each
+prompt exceeds the 1024-token minimum required for prompt caching.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Import the actual prompts from recommend.py without running the pipeline
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from recommend import (  # noqa: E402
+    LLM_MODEL_RERANK,
+    LLM_MODEL_SYNTHESIZE,
+    SYSTEM_PROMPT_RERANK,
+    SYSTEM_PROMPT_SYNTHESIZE,
+)
+
+import anthropic  # noqa: E402
+
+
+CACHE_MIN_TOKENS = 1024
+
+client = anthropic.Anthropic()
+
+
+def count(model: str, prompt: str) -> int:
+    resp = client.messages.count_tokens(
+        model=model,
+        system=[{"type": "text", "text": prompt}],
+        messages=[{"role": "user", "content": "x"}],   # minimal placeholder
+    )
+    total = resp.input_tokens
+    # Subtract 1 token roughly for the "x" user message; enough for verdict purposes
+    system_only = total - 1
+    return system_only
+
+
+def main() -> None:
+    print(f"Cache minimum: {CACHE_MIN_TOKENS} tokens")
+    print()
+    print(f"{'Prompt':<28}{'Model':<20}{'Tokens':>10}{'Cacheable?':>18}")
+    print("-" * 76)
+
+    # Render placeholders with realistic values so the count reflects what
+    # actually gets sent to the API in production.
+    rerank_rendered = SYSTEM_PROMPT_RERANK.format(budget_lo=40, budget_hi=70)
+
+    for name, prompt, model in [
+        ("SYSTEM_PROMPT_RERANK", rerank_rendered, LLM_MODEL_RERANK),
+        ("SYSTEM_PROMPT_SYNTHESIZE", SYSTEM_PROMPT_SYNTHESIZE, LLM_MODEL_SYNTHESIZE),
+    ]:
+        n = count(model, prompt)
+        verdict = "yes" if n >= CACHE_MIN_TOKENS else f"NO (short by {CACHE_MIN_TOKENS - n})"
+        print(f"{name:<28}{model:<20}{n:>10}{verdict:>18}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-recommender/section_to_module_mapping.yaml
+++ b/test-recommender/section_to_module_mapping.yaml
@@ -1,0 +1,670 @@
+# Mapping: TestRail "Section Hierarchy" top-level  →  firefox-ios code modules
+#
+# Generated 2026-06-12 from:
+#   - TestRail export: firefox_for_ios_regression.xlsx (1652 cases, 52 top-level sections)
+#   - Repo inspection: mozilla-mobile/firefox-ios (firefox-ios/Client/Frontend, BrowserKit/Sources)
+#
+# Confidence levels:
+#   high   = name match or unambiguous mapping
+#   medium = reasonable inference, please verify with the team
+#   low    = guess based on context, needs confirmation
+#
+# Format:
+#   test_count    = how many TestRail cases live under this section (informational)
+#   automated     = how many of those are already marked Completed in automation (deprioritize signal)
+#   modules       = code paths that, when changed, suggest running tests from
+#                   this section. Usually a directory (e.g.
+#                   `firefox-ios/Client/Frontend/Library`), but a specific
+#                   `.swift` file is allowed when a broader directory entry
+#                   would over-match. Both use longest-prefix matching in the
+#                   pipeline; a file entry only fires on changes to that exact
+#                   file. See "Adresses autofill" (AccessoryViewProvider.swift)
+#                   and "Ad Blocker V1" (FirefoxTabContentBlocker.swift) for
+#                   examples of the file-level convention.
+#   notes         = clarifications, gotchas, things to verify
+
+sections:
+
+  - name: "Share Sheet"
+    test_count: 228
+    automated: 27
+    modules:
+      - { path: firefox-ios/Client/Frontend/Share, confidence: high }
+      - { path: firefox-ios/Extensions, confidence: medium }   # ShareTo extension target
+    notes: |
+      Largest section. Verify whether "Extensions/ShareTo" or similar exists as a separate target.
+
+  - name: "Toolbar Specs & Flows"
+    test_count: 147
+    automated: 15
+    modules:
+      - { path: BrowserKit/Sources/ToolbarKit, confidence: high }
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: high }
+    notes: |
+      Note: separate from the smaller "Toolbar" section below. This is the redesigned/spec'd toolbar.
+
+  - name: "Library"
+    test_count: 139
+    automated: 65
+    modules:
+      - { path: firefox-ios/Client/Frontend/Library, confidence: high }
+    notes: |
+      Covers Bookmarks, History, Reading List, Downloads. Already 47% automated — deprioritize unless heavy diff here.
+
+  - name: "Platform search suggestions"
+    test_count: 95
+    automated: 17
+    modules:
+      - { path: BrowserKit/Sources/UnifiedSearchKit, confidence: high }
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: medium }
+    notes: |
+      Includes third-party search engine settings. Verify if there's a SearchEngines/ module.
+
+  - name: "Translations"
+    test_count: 87
+    automated: 4
+    modules:
+      - { path: firefox-ios/Client/Frontend/Translations, confidence: high }
+    notes: |
+      Very low automation coverage (4/87) — high priority for manual when touched.
+
+  - name: "Settings - General"
+    test_count: 70
+    automated: 21
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+    notes: |
+      All "Settings - *" sections likely share the same root path; needs sub-section granularity to dispatch tests precisely.
+
+  - name: "Settings - Privacy"
+    test_count: 69
+    automated: 16
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+      - { path: firefox-ios/Client/Frontend/TrackingProtection, confidence: medium }
+      - { path: firefox-ios/Client/ContentBlocker, confidence: medium }
+
+  - name: "Adresses autofill"   # sic — typo in TestRail
+    test_count: 64
+    automated: 33
+    modules:
+      - { path: firefox-ios/Client/Frontend/Autofill, confidence: high }
+      - { path: firefox-ios/Client/AccessoryViewProvider.swift, confidence: medium }   # shared accessory bar used by autofill
+    notes: |
+      Heavy automation coverage. The section title has a typo ("Adresses").
+      AccessoryViewProvider.swift added 2026-07-14 — feeds the accessory bar
+      used from AutofillAccessoryViewButtonItem.
+
+  - name: "Brand refresh onboarding"
+    test_count: 62
+    automated: 4
+    modules:
+      - { path: BrowserKit/Sources/OnboardingKit, confidence: high }
+      - { path: firefox-ios/Client/Frontend/Onboarding, confidence: high }
+      - { path: firefox-ios/Client/Frontend/DefaultBrowserOnboarding, confidence: medium }
+
+  - name: "Menu redesign"
+    test_count: 59
+    automated: 4
+    modules:
+      - { path: BrowserKit/Sources/MenuKit, confidence: high }
+
+  - name: "Shake to summarize"
+    test_count: 51
+    automated: 3
+    modules:
+      - { path: BrowserKit/Sources/SummarizeKit, confidence: high }
+      - { path: BrowserKit/Sources/LLMKit, confidence: medium }
+      - { path: firefox-ios/Client/Frontend/Summarizer, confidence: high }
+
+  # "Homepage" removed 2026-07-14 — renamed to "Current Homepage Structure" in TestRail.
+  # See the new section further down.
+
+  - name: "Tab Tray"
+    test_count: 49
+    automated: 27
+    modules:
+      - { path: firefox-ios/Client/TabManagement, confidence: high }
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }   # TabTrayViewController may live here
+    notes: |
+      Includes "Top Tabs" iPad variant — verify path for iPad-specific code.
+
+  - name: "Logins"
+    test_count: 47
+    automated: 19
+    modules:
+      - { path: firefox-ios/Client/Frontend/PasswordManagement, confidence: high }
+      - { path: firefox-ios/Client/Frontend/PasswordGenerator, confidence: high }
+      - { path: firefox-ios/Client/Frontend/AuthenticationManager, confidence: medium }
+
+  - name: "Private Browsing"
+    test_count: 42
+    automated: 12
+    modules:
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+      - { path: firefox-ios/Client/TabManagement, confidence: medium }
+    notes: |
+      Cross-cutting. Private mode toggle is wired across many places. Verify if there's a dedicated PrivateBrowsing/ folder.
+
+  - name: "Search box in the Middle"
+    test_count: 41
+    automated: 0
+    modules:
+      - { path: BrowserKit/Sources/ToolbarKit, confidence: high }
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: high }
+    notes: |
+      0% automated, fully manual. UX variant of toolbar — overlaps with "Toolbar Specs & Flows".
+
+  - name: "Homescreen Redesign - Discover content feed"
+    test_count: 25
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/Home, confidence: high }
+      - { path: firefox-ios/Client/Frontend/StoriesFeed, confidence: high }
+
+  - name: "Settings"
+    test_count: 23
+    automated: 20
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+    notes: |
+      Generic settings — may overlap with "Settings - General".
+
+  - name: "Felt Privacy - Unified Panel"
+    test_count: 22
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Frontend/FeltPrivacy, confidence: high }
+
+  - name: "ToU update for existing users"
+    test_count: 21
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/Onboarding, confidence: medium }
+      - { path: firefox-ios/Client/Frontend/SurveySurface, confidence: low }
+    notes: |
+      Terms of Use update flow. Verify which target hosts the ToU modal.
+
+  - name: "Keyboard shortcuts"
+    test_count: 20
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Application, confidence: medium }
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+    notes: |
+      iOS key commands. Likely registered at BrowserViewController or AppDelegate level. Verify.
+
+  - name: "External links opening options"
+    test_count: 19
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Coordinators, confidence: high }
+      - { path: firefox-ios/Client/Application, confidence: medium }
+    notes: |
+      Deep link handling, openURL, "while dedicated app is installed" branching.
+
+  - name: "PDF management"
+    test_count: 17
+    automated: 5
+    modules:
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+      - { path: BrowserKit/Sources/WebEngine, confidence: medium }
+    notes: |
+      In-app PDF view + save/share. Verify where PDF preview is implemented.
+
+  - name: "Widget"
+    test_count: 16
+    automated: 6
+    modules:
+      - { path: firefox-ios/WidgetKit, confidence: high }
+      - { path: firefox-ios/Client/Frontend/Widgets, confidence: medium }
+
+  - name: "Long Tap Interaction - Context menu"
+    test_count: 15
+    automated: 11
+    modules:
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+      - { path: BrowserKit/Sources/ComponentLibrary, confidence: low }
+
+  # "Homescreen redesign V2" removed 2026-07-14 — renamed to
+  # "Homescreen redesign V2 - not applicable anymore" in TestRail.
+  # See the new section further down.
+
+  - name: "Toolbar"
+    test_count: 13
+    automated: 8
+    modules:
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: high }
+      - { path: BrowserKit/Sources/ToolbarKit, confidence: medium }
+    notes: |
+      Older/smaller section — likely legacy. "Toolbar Specs & Flows" is the redesigned variant.
+
+  - name: "Auto Push Notification"
+    test_count: 12
+    automated: 0
+    modules:
+      - { path: firefox-ios/Push, confidence: high }
+      - { path: firefox-ios/Client/Frontend/NotificationSurface, confidence: medium }
+
+  - name: "US1 - Internet Connection Error"
+    test_count: 12
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/NativeErrorPage, confidence: high }
+      - { path: BrowserKit/Sources/WebEngine, confidence: medium }
+
+  - name: "Pull to refresh"
+    test_count: 11
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+    notes: |
+      Verify the actual gesture-recognizer host. May live in WebEngine or BrowserViewController.
+
+  - name: "Sync Integration Tests"
+    test_count: 10
+    automated: 10
+    modules:
+      - { path: firefox-ios/Sync, confidence: high }
+      - { path: firefox-ios/Account, confidence: high }
+      - { path: firefox-ios/RustFxA, confidence: high }
+    notes: |
+      100% automated — system can typically skip suggesting manual tests here, just verify CI passed.
+
+  - name: "Launch in Attentive Mode"
+    test_count: 9
+    automated: 4
+    modules:
+      - { path: firefox-ios/Client/Application, confidence: medium }
+    notes: |
+      Likely lifecycle / scene-delegate behavior. Verify.
+
+  - name: "Settings - Account"
+    test_count: 9
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+      - { path: firefox-ios/Account, confidence: medium }
+      - { path: firefox-ios/RustFxA, confidence: medium }
+
+  - name: "Find In Page"
+    test_count: 9
+    automated: 9
+    modules:
+      - { path: firefox-ios/Client/Frontend/Browser, confidence: medium }
+    notes: |
+      100% automated. Verify FindInPageBar path.
+
+  - name: "Default Zoom Settings"
+    test_count: 9
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+      - { path: BrowserKit/Sources/WebEngine, confidence: medium }
+
+  - name: "Domain Autocomplete"
+    test_count: 8
+    automated: 8
+    modules:
+      - { path: BrowserKit/Sources/UnifiedSearchKit, confidence: medium }
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: medium }
+
+  - name: "Security"
+    test_count: 8
+    automated: 8
+    modules:
+      - { path: firefox-ios/Client/Frontend/AuthenticationManager, confidence: medium }
+      - { path: firefox-ios/CredentialProvider, confidence: medium }
+    notes: |
+      Vague section. May need to look at individual cases to refine. 100% automated.
+
+  - name: "Desktop mode"
+    test_count: 7
+    automated: 6
+    modules:
+      - { path: BrowserKit/Sources/WebEngine, confidence: high }
+    notes: |
+      User-Agent switching.
+
+  - name: "Firefox Accounts"
+    test_count: 6
+    automated: 3
+    modules:
+      - { path: firefox-ios/Account, confidence: high }
+      - { path: firefox-ios/RustFxA, confidence: high }
+      - { path: firefox-ios/Client/Frontend/AuthenticationManager, confidence: medium }
+
+  - name: "Zooming & panning"
+    test_count: 6
+    automated: 5
+    modules:
+      - { path: BrowserKit/Sources/WebEngine, confidence: medium }
+
+  - name: "Toast notifications"
+    test_count: 4
+    automated: 3
+    modules:
+      - { path: BrowserKit/Sources/ComponentLibrary, confidence: medium }
+
+  - name: "Navigation"
+    test_count: 4
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Coordinators, confidence: medium }
+      - { path: BrowserKit/Sources/WebEngine, confidence: low }
+    notes: |
+      Ambiguous — could be in-app navigation (coordinators) or web navigation (WebEngine). Verify.
+
+  - name: "Mobile Microsurvey"
+    test_count: 4
+    automated: 4
+    modules:
+      - { path: firefox-ios/Client/Frontend/Microsurvey, confidence: high }
+      - { path: firefox-ios/Client/Frontend/SurveySurface, confidence: medium }
+
+  - name: "Integration between deeplinks and mobile Apps"
+    test_count: 4
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Coordinators, confidence: high }
+      - { path: firefox-ios/Client/Application, confidence: medium }
+
+  - name: "Clipboard"
+    test_count: 3
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Helpers, confidence: low }
+      - { path: firefox-ios/Client/Frontend/TabToolbar, confidence: low }
+    notes: |
+      Verify ClipboardBarDisplayHandler or similar.
+
+  - name: "iPad MultiWindows"
+    test_count: 3
+    automated: 3
+    modules:
+      - { path: firefox-ios/Client/Coordinators, confidence: high }
+      - { path: firefox-ios/Client/Application, confidence: medium }
+
+  - name: "Settings - About"
+    test_count: 2
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/Settings, confidence: high }
+
+  - name: "Session Restore"
+    test_count: 2
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/TabManagement, confidence: high }
+      - { path: BrowserKit/Sources/TabDataStore, confidence: high }
+
+  - name: "Database Fixtures"
+    test_count: 2
+    automated: 2
+    modules:
+      - { path: BrowserKit/Sources/TestKit, confidence: medium }
+      - { path: firefox-ios/firefox-ios-tests, confidence: medium }
+    notes: |
+      Likely test infrastructure, not a product feature.
+
+  - name: "Update"
+    test_count: 1
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Application, confidence: medium }
+    notes: |
+      App-update / migration flow. Hard to trigger from a code diff alone — almost always exploratory.
+
+  - name: "SSL Certificate Error"
+    test_count: 1
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Frontend/NativeErrorPage, confidence: high }
+      - { path: BrowserKit/Sources/WebEngine, confidence: medium }
+
+  - name: "Authentication"
+    test_count: 1
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Frontend/AuthenticationManager, confidence: high }
+
+  # -----------------------------------------------------------------------------
+  # Sections added 2026-07-14 from drift findings on release/v153.0.
+  # See commit message for the run that produced the drift report.
+  # -----------------------------------------------------------------------------
+
+  - name: "Current Homepage Structure"
+    test_count: 54
+    automated: 0     # to be re-checked from next export
+    modules:
+      - { path: firefox-ios/Client/Frontend/Home, confidence: high }
+    notes: |
+      Added 2026-07-14. Rename of the old "Homepage" section. Same code
+      module. Automated Test Name(s) still reference XCUITests/ActivityStream*.
+
+  - name: "Homescreen redesign V2 - not applicable anymore"
+    test_count: 10
+    automated: 1
+    modules:
+      - { path: firefox-ios/Client/Frontend/Home, confidence: high }
+    notes: |
+      Added 2026-07-14. Rename of the old "Homescreen redesign V2". Section
+      name now signals the feature is deprecated in product but tests are
+      still catalogued. Consider low priority unless Home module changes.
+
+  - name: "Google Lens 🔍"
+    test_count: 25
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/GoogleLens, confidence: high }
+    notes: |
+      Added 2026-07-14. New feature landing in v153.0 (PR #34604 telemetry,
+      #34561 hide in private, #34567 setting).
+
+  - name: "Quick Answers"
+    test_count: 32
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/QuickAnswers, confidence: high }
+      - { path: BrowserKit/Sources/QuickAnswersKit, confidence: high }
+    notes: |
+      Added 2026-07-14. Voice AI feature landing in v153.0 (PR #34483,
+      largest PR in the release). Both the Frontend/QuickAnswers UI and
+      BrowserKit/QuickAnswersKit service layer trigger this section.
+
+  - name: "Webcompat Reporting Tool"
+    test_count: 19
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Frontend/WebCompatReporter, confidence: high }
+      - { path: BrowserKit/Sources/WebCompatReporterKit, confidence: high }
+    notes: |
+      Added 2026-07-14. New feature landing in v153.0 (PR #34499 UI shell,
+      #34309 Glean ping).
+
+  - name: "Ad Blocker V1"
+    test_count: 21
+    automated: 0
+    modules:
+      - { path: firefox-ios/Client/Application/RemoteSettings/Application Services/, confidence: medium }
+      - { path: firefox-ios/Client/Frontend/Browser/FirefoxTabContentBlocker.swift, confidence: medium }
+    notes: |
+      Added 2026-07-14. The AS-prefixed remote-settings ad-blocker service
+      files live under Client/Application/RemoteSettings/Application Services/.
+      The tab content blocker file handles the actual blocking. The Settings
+      toggle UI is BrowsingSettingsViewController.swift but that file is
+      shared with other browsing prefs — not mapped here to avoid false
+      positives on unrelated Settings changes.
+
+  - name: "HTTPS First Mode"
+    test_count: 21
+    automated: 0
+    modules: []
+    notes: |
+      Added 2026-07-14 as a placeholder — no HTTPS-First code found in the
+      repo under this name yet. TestRail cases likely written ahead of the
+      feature landing.
+
+      ⚠️  With `modules: []`, these 21 tests are INVISIBLE to the recommender
+      until at least one module path is added — they will not appear as
+      candidates for any release regardless of what code changes. Drift
+      detection does NOT flag this either (the section IS in the YAML,
+      just with no code links), so the gap is silent.
+
+      Revisit once the code ships and identify the correct module(s).
+
+# -----------------------------------------------------------------------------
+# Modules that exist in code but have NO clear TestRail section mapping
+# (worth knowing — these are blind spots in the catalog)
+# -----------------------------------------------------------------------------
+modules_without_clear_section:
+  - BrowserKit/Sources/Redux                  # State management — affects everything indirectly
+  - BrowserKit/Sources/Common                 # Shared utilities — affects everything indirectly
+  - BrowserKit/Sources/Shared                 # AUTO-ADDED 2026-06-12 (drift): general shared utilities, cross-cutting
+  - BrowserKit/Sources/SiteImageView          # Favicon/screenshot rendering
+  - BrowserKit/Sources/JWTKit                 # Auth tokens (Sync/Account adjacent)
+  - BrowserKit/Sources/MLPAKit                # Machine learning / personalization?
+  # BrowserKit/Sources/QuickAnswersKit — REMOVED 2026-07-14, now mapped to "Quick Answers" section
+  - BrowserKit/Sources/ActionExtensionKit
+  - firefox-ios/Client/Configuration          # AUTO-ADDED 2026-06-12 (drift): app config files, cross-cutting
+  - firefox-ios/Client/Extensions             # AUTO-ADDED 2026-06-12 (drift): Swift extensions (String, UIView, …), cross-cutting
+  - firefox-ios/Client/Glean                  # Telemetry
+  - firefox-ios/Client/Telemetry
+  - firefox-ios/Client/Nimbus                 # Feature flags wiring
+  - firefox-ios/Client/FeatureFlags
+  - firefox-ios/Client/Experiments
+  - firefox-ios/Client/Frontend/InternalSchemeHandler  # AUTO-ADDED 2026-06-12 (drift): about:home, reader://, error pages — product-facing, NO TestRail section covers it directly (cobertura gap)
+  - firefox-ios/Client/Frontend/UserContent   # AUTO-ADDED 2026-06-12 (drift): user-scripts injected into web views (reader-mode JS, content scripts)
+  - firefox-ios/Client/Frontend/Reader        # Reader mode — no section found
+  # firefox-ios/Client/Frontend/QuickAnswers — REMOVED 2026-07-14, now mapped to "Quick Answers" section
+  - firefox-ios/Client/Frontend/Wayback       # AUTO-ADDED 2026-07-14 (drift): no dedicated TestRail section yet
+  - firefox-ios/Client/Frontend/ContextualHint
+  - firefox-ios/Client/Frontend/ShortcutsLibrary
+  # firefox-ios/Client/Frontend/PasswordGenerator — REMOVED 2026-07-17: already
+  # mapped under "Logins", so the "no clear section" label was contradictory.
+  - firefox-ios/Providers                     # AUTO-ADDED 2026-06-12 (drift): Profile, FxA Account providers — foundational for Account/Sync/Logins
+  - firefox-ios/Storage                       # Persistence layer — affects Library, Logins, Autofill indirectly
+  - firefox-ios/MozillaRustComponents         # Rust bindings — affect Sync, Logins, Autofill
+
+# -----------------------------------------------------------------------------
+# Special handling rules — DESCRIPTIVE DOCUMENTATION ONLY.
+#
+# These entries document behaviour hardcoded inside recommend.py (see
+# LOW_IMPACT_TITLE_KEYWORDS, DEPENDENCY_PATHS, NIMBUS_PATHS, and the
+# Mergify backport handling in fetch_prs_for_commits). This YAML block
+# is NOT parsed at runtime — a reader can consult it to understand what
+# the pipeline does with special cases without grepping the source.
+#
+# If you change a rule here, update recommend.py to match. Nothing keeps
+# them in sync automatically.
+# -----------------------------------------------------------------------------
+special_rules:
+  - paths: [firefox-ios/nimbus-features/, firefox-ios/initial_experiments.json]
+    handling: "Always flag in risk section: behavior may flip server-side without code diff in product."
+  - paths: [Package.swift, Package.resolved, Podfile.lock, firefox-ios/MozillaRustComponents/**]
+    handling: "Flag as dependency change. List bumped versions. Suggest smoke test on affected areas (Sync/Logins/Autofill for Rust components)."
+  - paths: ["**/*.lproj/**", "**/Localizable.strings"]
+    handling: "Auto-classify as low-impact (string import). No test suggestion unless paired with code change in same PR."
+  - pr_titles_starting_with: ["String Import", "Strings Import"]
+    handling: "Auto-skip from analysis."
+  - branch_patterns: ["mergify/bp/**"]
+    handling: "Dedup against the main-branch PR these backport. Don't re-suggest tests for already-shipped backports."
+
+# -----------------------------------------------------------------------------
+# Drift detection — DESCRIPTIVE DOCUMENTATION OF INTENT.
+#
+# recommend.py currently implements two of the checks below (see detect_drift):
+#   - `new_section_in_testrail` (TestRail sections not present in this YAML)
+#   - `new_module_in_repo` (touched paths without a YAML mapping)
+#
+# The rest of this block — rename detection strategies (fuzzy/id-set/section-id),
+# the pending_mapping_review workflow, LLM-proposed mappings — is planned but
+# not yet wired. This YAML block is NOT parsed at runtime; it documents the
+# design goals for align.py (TBD) and the direction of drift detection.
+# -----------------------------------------------------------------------------
+drift_detection:
+
+  testrail_side:
+    # Compare the TestRail export against the `sections:` block above.
+    checks:
+      - id: new_section_in_testrail
+        description: "Top-level Section Hierarchy value present in export but not in this YAML."
+        action: |
+          - Emit warning: "N new TestRail sections without mapping: [...]".
+          - For each, LLM proposes initial mapping using:
+              * section name
+              * sample of 5 random test titles + steps from that section
+              * current repo module list (BrowserKit/Sources/*, firefox-ios/Client/**)
+          - Write proposal to pending_mapping_review.yaml with confidence: auto-generated.
+          - Tests from unmapped sections appear in the report flagged "AUTO-MAPPED — verify".
+
+      - id: yaml_section_no_longer_in_testrail
+        description: "Section listed in this YAML but not found in the latest export."
+        action: |
+          - Emit warning: "N YAML sections no longer in TestRail: [...]".
+          - Attempt rename detection (see rename_detection below) before assuming deletion.
+          - If no rename match, mark entry as stale in the report; await human removal.
+
+      - id: rename_detection
+        description: "Detect TestRail section renames so the mapping survives them."
+        strategies_in_order:
+          - fuzzy_name_match:
+              method: "Levenshtein distance on section name, threshold ≤ 3 chars or ≥ 0.85 similarity"
+              confidence: low
+              notes: "Cheap, catches typos and minor edits. Many false positives possible."
+          - id_set_match:
+              method: |
+                Compare the set of TestRail case IDs (C-numbers) under each section between
+                the previous export and the new export. If section X (old) and section Y (new)
+                share ≥ 80% of their case IDs, treat as rename X → Y.
+              confidence: high
+              notes: "Requires storing the previous export's section→case-ID map alongside the YAML."
+          - testrail_section_id:
+              method: "Use stable TestRail Section ID (NOT name) as the mapping key."
+              confidence: highest
+              notes: |
+                NOT AVAILABLE YET in the current export — needs TestRail admin to add
+                Section ID column to the export. Once added, this becomes the primary
+                key and renames stop being a problem entirely.
+                ACTION: ask TestRail admin to enable Section ID export.
+
+  repo_side:
+    # Compare the diff's touched file paths against the modules referenced anywhere in this YAML.
+    checks:
+      - id: new_module_in_repo
+        description: |
+          A file path in the release diff doesn't fall under any module listed in any section's
+          `modules:` block, nor in `modules_without_clear_section`.
+        action: |
+          - Emit warning: "N new/unclassified modules touched in diff: [...]".
+          - LLM proposes which TestRail section(s) these probably belong to, using:
+              * module path + sample of file names inside it
+              * any README/PR description for the module
+              * existing section list
+          - Proposal goes to pending_mapping_review.yaml.
+          - Changes to unclassified modules still appear in the report under "Unclassified changes
+            — needs mapping" so they aren't silently dropped from QA consideration.
+
+      - id: dead_module_path
+        description: "Module path referenced in this YAML no longer exists in the repo."
+        action: |
+          - Emit warning at runtime (cheap check via `gh api repos/.../contents/<path>`).
+          - Mark entry as stale; await human update.
+
+  output:
+    drift_report_location: pending_mapping_review.yaml
+    fail_behavior: |
+      The pipeline does NOT block on drift — it produces the report anyway, but with a
+      prominent "⚠️ Mapping drift detected" header listing what's unmapped and what was
+      auto-proposed. Rationale: a release shouldn't be held up by a mapping gap, but the
+      gap must be loudly visible so it gets fixed before the next run.
+    review_workflow: |
+      1. Open pending_mapping_review.yaml after each run.
+      2. For each proposal: accept, edit, or reject.
+      3. Move accepted entries into this YAML's `sections:` block (or
+         `modules_without_clear_section` if the module legitimately has no TestRail home).
+      4. Delete the entry from pending_mapping_review.yaml.
+
+  open_action_items:
+    - "Ask TestRail admin to add stable Section ID to the export — eliminates rename ambiguity."
+    - "First time the pipeline runs, snapshot the current section→case-ID map for future id_set_match comparisons."


### PR DESCRIPTION
# Test Recommender

LLM-assisted tool that suggests which TestRail tests to run for each
Firefox release (for now only iOS), by cross-referencing the code diff against the
manual + automated test catalogue. Produces a prioritized Markdown
report with P0/P1/P2 test picks, risks, and exploratory focus areas.

## Highlights

- Two-stage LLM pipeline (Sonnet 4.6 rerank + Sonnet 5 synthesize)
  with a deterministic pre-filter, and a full fallback if the API
  is unavailable — never fails closed.
- ~$0.30 per release run.
- 78 unit tests across the deterministic modules.
- Full docs in [README.md](./README.md); tuning history in
  `metrics_baseline.md`.

## Not included (intentional)

- `testrail_export_ios.xlsx` — contains QA-team  Personally Identifiable Information; supplied locally by the operator via `--testrail`.
- `align.py` — planned interactive mapping-curation tool; design in
  the README Roadmap.

## Security review

Completed pre-push: no keys, no hardcoded personal paths, no  Personally Identifiable Information, no internal URLs. See `.gitignore` for excluded patterns.
