### PR TITLE
Tae conversion toolchain fixes

### DIFF
--- a/tae-conversion/README.md
+++ b/tae-conversion/README.md
@@ -47,7 +47,7 @@ Optional environment, all with sane fallbacks:
 
 | Tool | Who runs it | Does |
 |---|---|---|
-| `effnext.py` | agent | Next unconverted candidate from the local pool minus the done-ledger. Local only, no network. `--json`. |
+| `effnext.py` | agent | Next unconverted candidate from the local pool minus the done-ledger, minus skips, minus anything already in the efficiency tests package. Local only, no network. `--skip`/`--unskip`/`--skips`, `--json`. |
 | `effscaffold.py` | agent | Front-loads a conversion: legacy body, TestRail id, already-converted check, robots + selector lines, existing coverage. |
 | `effcheck.py` | agent | Static pre-flight, no device. Resolution, empty nav paths, inline selectors, missing verbs, test-class boilerplate. Exit ≠ 0 = fix something. |
 | `effbuild.py` | agent | Gradle log → one-line verdict plus only the compile errors. `--json`. |
@@ -78,8 +78,22 @@ If both work, the host side is wired. Then attach a device and start `effwatch.s
 - `conversion-runs/testrail_smoke_pool.txt` — prioritized candidates, one `Class.method` per line.
 - `tools/converted_rows.csv` — the done-ledger.
 
-`effnext` returns the first pool entry absent from the ledger. Replace both files to point
-the toolchain at a different project.
+- `conversion-runs/skiplist.tsv` — candidates deliberately passed over, with reasons. Created on first
+  `--skip`; advisory only, and a skip never marks a test converted.
+
+`effnext` returns the first pool entry that is absent from the ledger, not skipped, and whose method does not
+already exist in the efficiency tests package (the ledger lags the tree — that last check is what stops it
+proposing work that is already done; `--no-tree-check` disables it, `--repo`/`$REPO` points it at a checkout).
+Replace the pool and ledger to point the toolchain at a different project.
+
+Skipping a candidate:
+
+```bash
+python3 tools/effnext.py --skip CustomTabsTest.verifyLoginSaveInCustomTabTest \
+        --reason "needs save-login capability first"
+python3 tools/effnext.py --skips      # what's parked, and why
+python3 tools/effnext.py --unskip CustomTabsTest.verifyLoginSaveInCustomTabTest
+```
 
 ## Docs
 

--- a/tae-conversion/docs/CONVERSION-LESSONS.md
+++ b/tae-conversion/docs/CONVERSION-LESSONS.md
@@ -20,6 +20,15 @@ Legend for **Tooling status**: ✅ enforced by a tool · 🛠️ candidate for a
   check which screens are already modeled before committing to a candidate.
 - Tooling: 🛠️ `effscaffold` surfaces the body/coverage; a coverage-aware scorer could rank the P0 pool.
 
+**A2. "Not converted" means not converted *on main*, not absent from your tree (2026-08-04).**
+- Assumed: if the efficiency package in your checkout has no such test, it needs converting.
+- Reality: a branch that predates someone else's landing cannot see their work. Bug 2060292 converted
+  `AddressAutofillTest.deleteSavedAddressTest` while bug 2060174 had already landed the same test from
+  someone else — the duplicate only surfaced as a rebase conflict, after review and submission.
+- Rule: fetch and check main before picking, not just the working tree. `effnext`'s tree check and
+  `effscaffold`'s already-converted check both read your checkout, so both are blind to this.
+- Tooling: 🛠️ the tree check could compare against `origin/main` rather than the working tree.
+
 ## B. Authoring (compile-time — cheap to catch statically)
 
 **B1. `mockWebServer` isn't on BaseTest.**
@@ -266,6 +275,16 @@ this single pattern. See gotcha A12.
   comment 0 can only be corrected by a human in the web UI.
 - Rule: get the mechanism right before filing, or expect to hand a human the corrected text. Prefer filing
   after the diagnosis is confirmed, not while it is still a theory.
+
+**I4. Rebasing a submitted stack: dropping a commit leaves its revision in the graph (2026-08-04).**
+- Reality: abandoning a revision does not remove it from the stack's dependency graph. After dropping a
+  duplicate commit mid-stack, the next revision still recorded the abandoned one as its parent, and its
+  diff still pointed at the dropped commit's hash as its base.
+- Rule: resubmit the **whole** range, not just the commits whose content changed — the re-parenting is
+  what clears the stale edge. Expect every revision to get a new diff (the rebase changed every hash),
+  and expect already-accepted revisions to reset to needs-review; tell the reviewers why before they see
+  it. If avoiding a resubmit matters more, leave commit messages alone — editing one forces the upload
+  you were trying to avoid.
 
 ## Open gaps (unresolved — pick up on next attempt)
 

--- a/tae-conversion/docs/CONVERSION-LESSONS.md
+++ b/tae-conversion/docs/CONVERSION-LESSONS.md
@@ -129,6 +129,14 @@ selector (e.g. the trust-panel website tag), re-verify the WHOLE class, not just
 - Reality: the Sheet is systems-of-record for status, but round-tripping it to *pick* is slow and burns tokens.
   The working queue is local: `testrail_smoke_pool.txt` (prioritized) minus `converted_rows.csv` (done).
 - Rule: `effnext --json` for the next candidate; reconcile the Sheet in a batch after landing, not per-pick.
+- Correction (2026-08-03): `converted_rows.csv` lags the tree badly — it proposed a test that was already
+  converted and committed, and 11 of its top 30 candidates were already in-tree. `effnext` now greps the
+  efficiency tests package itself and drops those (`--no-tree-check` opts out). Note `effscaffold`'s
+  `already_converted` does NOT cover this: it lists matching *files*, not methods.
+- Rule (2026-08-03): a candidate you decide not to take — too complex for whoever is picking it up, blocked
+  on a harness gap, deliberately deferred — gets recorded with `effnext --skip Class.method --reason "…"`
+  rather than mentally stepped over, so the next caller gets a different pick and the reason survives.
+  Skips are advisory and reversible (`--unskip`, `--skips`); they never mark a test converted.
 
 ## D3. Settings sub-pages need a back-edge to Home to load a URL after a settings change.
 - Assumed: navigateToPage(BrowserPage) works from any page.
@@ -211,6 +219,53 @@ the bottom navigation bar, only a content-description. A Compose exact/merged co
 also fails where the device-level one succeeds. Three of four test failures debugged on 2026-07-28 were
 this single pattern. See gotcha A12.
 
+
+## H. Acting on a control vs. finding it (2026-08-03, translations sheet + credit cards)
+
+**H1. "Clicked" in the report does not mean the app acted.**
+- Assumed: if `mozClick` reports success, the click did something.
+- Reality: a Compose button rendered `enabled = false` still accepts the gesture and silently skips
+  `onClick`. The failure then surfaces wherever the effect was expected — 25s and several steps away from
+  the cause.
+- Rule: when a control's enabled state depends on async work, wait for enabled before clicking, and make
+  sure the gate really blocks (a gate returning in tens of ms is not gating). See gotchas A16/A17.
+- Tooling: 🛠️ `mozWaitUntilEnabled` was written for this and is not landed yet; a check that flags
+  `mozClick` on a `COMPOSE_BY_TEXT` selector would catch the no-op-gate variant statically.
+
+**H2. Selector strategy decides whether you can even observe actionability.**
+- Assumed: text selectors are interchangeable for reading and for clicking.
+- Reality: `COMPOSE_BY_TEXT` resolves the text node inside the button (unmerged tree), which reports
+  enabled while the button is disabled. `COMPOSE_BY_TEXT_MERGED` resolves the button.
+- Rule: read with `COMPOSE_BY_TEXT`, act with `COMPOSE_BY_TEXT_MERGED`.
+
+**H3. A default 5s locate is not a synchronisation primitive.**
+- Reality: three separate defects found in one 2026-08-03 sweep (bugs 2060405, 2060414, 2060415) were all a
+  default `mozVerify` timeout standing in for a readiness signal that never came.
+- Rule: gate on the thing that means "ready" (the detected language rendered, the sheet gone, the toolbar
+  usable again), and prefer a positive assertion over waiting for something to disappear — absence cannot
+  distinguish "it worked" from "the click was dropped".
+
+## I. Paperwork that is part of the conversion, not after it (2026-08-03)
+
+**I1. The `@Converted` annotation belongs in the conversion commit.**
+- Reality: the burndown keys off that marker, so a conversion that lands without it reads as unconverted.
+  Two conversions in one stack were caught missing it during a pre-submit audit, requiring a mid-stack
+  rewrite that would have been free if written at the time.
+- Rule: annotate the legacy method in the same commit; use `notes` for any deliberate deviation (e.g. local
+  mockWebServer asset instead of an external URL).
+- Tooling: 🛠️ a pre-submit check ("every conversion commit touches a legacy test and adds `@Converted`")
+  would make this mechanical.
+
+**I2. Conversion bugs must block the tracking meta; harness bugs must not.**
+- Reality: the meta (bug 2030727) tracks the campaign through `depends_on`. A conversion bug that is never
+  linked is invisible in the burndown; a tooling/harness bug that *is* linked pollutes it.
+- Rule: set `blocks` at filing time, and only for test-conversion bugs.
+
+**I3. Bugzilla descriptions cannot be edited via the API.**
+- Reality: `PUT /rest/bug/comment/<id>` returns 404 (code 32614); only comment *tags* are writable. A wrong
+  comment 0 can only be corrected by a human in the web UI.
+- Rule: get the mechanism right before filing, or expect to hand a human the corrected text. Prefer filing
+  after the diagnosis is confirmed, not while it is still a theory.
 
 ## Open gaps (unresolved — pick up on next attempt)
 

--- a/tae-conversion/docs/CONVERSION-LOOP.md
+++ b/tae-conversion/docs/CONVERSION-LOOP.md
@@ -23,13 +23,25 @@ The end-to-end loop for landing a legacy→efficiency conversion. Who runs what:
 ## The 5 steps
 
 ### 1. Do the conversion work (Claude, sandbox)
-Pick the next test with **`effnext --json`** (local pool minus done — never the Google Sheet). Convert it onto
+Pick the next test with **`effnext --json`** (local pool minus done minus skipped, and minus anything whose
+method already exists in the efficiency tests package — never the Google Sheet). If the pick is not one you
+should take — too complex for who is picking it up, blocked on a harness gap, deliberately deferred — record
+that instead of stepping over it: `effnext --skip Class.method --reason "…"` writes it to
+`conversion-runs/skiplist.tsv` and prints the new next pick. Skips are advisory and reversible
+(`--unskip`, `--skips`, `--include-skipped`); they never mark a test converted. Convert it onto
 ui/efficiency; `effcheck.py` (static pre-flight) then the build-run via `effwatch`, reading **only** the JSON
 verdicts (`effbuild --json`, `effverify --json`) — never the raw run report. Iterate until `clean`=true (or
 "good enough + notes"). Log lessons to CONVERSION-LESSONS.md.
 
+### 1b. Close out the conversion before you leave it (Claude, sandbox)
+Annotate the legacy method `@Converted(replacedBy = [...], bug = NNNNN, since = "YYYY-MM")` **in the same
+commit as the conversion** — the burndown keys off that marker, so a conversion landing without it reads as
+unconverted. Record deliberate deviations in `notes`.
+
 ### 2. Create the Bugzilla bug → get the number (Claude → bridge → `effbug`)
-Claude drops `conversion-runs/_queue/<id>.request.json`:
+Claude drops `conversion-runs/_queue/<id>.request.json`. Test-conversion bugs must `blocks` the tracking
+meta (2030727); tooling/harness/docs bugs must not. Get the mechanism right *before* filing — BMO has no API
+for editing a description, so a wrong comment 0 needs a human in the web UI.
 ```json
 { "bug": "create",
   "summary": "[efficiency] Convert <Test>.<method> to ui/efficiency",
@@ -88,6 +100,7 @@ trailers. Note: base landed on **autoland** (callsign `FIREFOXAUTOLAND`), which 
 web UI after submit. Submitting/landing stays with you: the bridge refuses submit and Claude never runs it.
 
 ## After landing
-Run the repo-side reconcile (see the tae-conversion README) so the tracker's physical/in-review counts and the
-`@Converted` annotations catch up, and annotate the converted legacy methods with
-`@Converted(replacedBy = [...], bug = NNNNN, since = "YYYY-MM")` once green + landed.
+Run the repo-side reconcile (see the tae-conversion README) so the tracker's physical/in-review counts catch
+up with what landed. The `@Converted` annotations are **not** part of this step — they ship in the conversion
+commit itself (step 1b). Annotating after the fact leaves a window where the burndown reads the conversion as
+missing, and in practice it is simply forgotten.

--- a/tae-conversion/docs/CONVERSION-LOOP.md
+++ b/tae-conversion/docs/CONVERSION-LOOP.md
@@ -23,7 +23,9 @@ The end-to-end loop for landing a legacy→efficiency conversion. Who runs what:
 ## The 5 steps
 
 ### 1. Do the conversion work (Claude, sandbox)
-Pick the next test with **`effnext --json`** (local pool minus done minus skipped, and minus anything whose
+Fetch main first — a branch that predates someone else's landing cannot see their conversion, and the
+duplicate then surfaces as a rebase conflict after review (bug 2060292 vs 2060174). Then pick the next
+test with **`effnext --json`** (local pool minus done minus skipped, and minus anything whose
 method already exists in the efficiency tests package — never the Google Sheet). If the pick is not one you
 should take — too complex for who is picking it up, blocked on a harness gap, deliberately deferred — record
 that instead of stepping over it: `effnext --skip Class.method --reason "…"` writes it to
@@ -98,6 +100,13 @@ trailers. Note: base landed on **autoland** (callsign `FIREFOXAUTOLAND`), which 
 `main`/central — that's fine; moz-phab keys off the commit trailers, not what's in central. Tag
 **testing-exception-unchanged**: no moz-phab CLI flag exists (checked at runtime), so add it in the Phabricator
 web UI after submit. Submitting/landing stays with you: the bridge refuses submit and Claude never runs it.
+
+## If you rebase a stack that is already submitted
+Dropping a commit does not remove its revision from the stack graph: abandoning D-nnn leaves the next
+revision still recording it as a parent, with a diff based on the commit you dropped. Resubmit the whole
+range so moz-phab re-parents everything — submitting only the changed commits leaves the abandoned
+revision wedged in the chain. Every revision gets a fresh diff either way, and accepted ones reset to
+needs-review, so warn the reviewers first.
 
 ## After landing
 Run the repo-side reconcile (see the tae-conversion README) so the tracker's physical/in-review counts catch

--- a/tae-conversion/docs/HARNESS-GOTCHAS.md
+++ b/tae-conversion/docs/HARNESS-GOTCHAS.md
@@ -6,12 +6,12 @@ catch them. Use it two ways: (1) a **review checklist** against new page objects
 
 Each entry: **symptom → cause → check**. Add new ones as we find them; link the Jira/bug where relevant.
 
-Last updated: 2026-07-28.
+Last updated: 2026-08-03.
 
 > The distilled, landed subset of this catalog lives in-tree at
 > `<fenix>/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/docs/gotchas.md`.
 > This file runs ahead of it: entries land here first and are folded in-tree once confirmed.
-> At the time of writing, in-tree carries A1–A8 and B1–B8; A9–A15 and B9–B11 are here only.
+> At the time of writing, in-tree carries A1–A8 and B1–B8; A9–A19 and B9–B13 are here only.
 
 ---
 
@@ -279,3 +279,55 @@ Last updated: 2026-07-28.
   — a detail easy to miss when porting, because it lives in the robot, not the test.
 - **Check:** use `BrowserPage.verifyPageContentWithReload(url, text)`. When porting, read the legacy *robot*
   helper, not just the test body — retry/refresh semantics hide there.
+
+### A16. A disabled Compose button accepts the click and drops it (2026-08-03, translations sheet)
+- **Symptom:** `mozClick`/`mozClickIfPresent` reports success, nothing happens, and the test fails much
+  later at whatever was supposed to follow — e.g. `'Translation bottom sheet translate button' was expected
+  to disappear after 25000ms`.
+- **Cause:** a Compose button rendered with `enabled = false` still receives the click gesture; only
+  `onClick` is skipped. `mozClick` resolves and clicks — it never asserts actionability — so "clicked" in
+  the report means "the gesture was delivered", not "the app acted on it".
+- **Check:** for any control whose enabled state is driven by async work (a fetch, a detection), gate on
+  enabled before clicking. Confirm the gate actually blocks: a real gate takes measurable time. See A17 for
+  why the obvious gate silently does not.
+
+### A17. An enabled-check on a COMPOSE_BY_TEXT selector is a no-op (2026-08-03)
+- **Symptom:** a wait-until-enabled gate returns in ~30 ms and the click is still dropped (A16).
+- **Cause:** `COMPOSE_BY_TEXT` resolves on the unmerged tree, which yields the *text node inside* the
+  button. Disabled semantics live on the button, so the text node reports enabled while the button is not.
+- **Check:** use `COMPOSE_BY_TEXT_MERGED` for anything you interact with rather than merely read —
+  it resolves the button itself. A gate that returns in tens of milliseconds is the tell.
+
+### A18. A failed attempt's HomeActivity blocks the retry's launch (2026-08-03, bug 2060347)
+- **Symptom:** the retry never runs its steps; it dies after 45 s with
+  `Could not launch intent … HomeActivity within 45000 milliseconds`, naming HomeActivity instead of
+  whatever actually failed.
+- **Cause:** the previous attempt's `HomeActivity` is still RESUMED when the retry rule relaunches (the
+  activity rule's teardown has not finished it). `HomeActivity` is `launchMode="singleTask"`, so the intent
+  goes to the existing instance and `MonitoringInstrumentation` never sees a new activity reach RESUMED.
+- **Check:** `BaseTest` now finishes every non-destroyed activity between attempts. When a retry dies at
+  activity launch, log `ActivityLifecycleMonitorRegistry.getActivitiesInStage()` for every `Stage` in the
+  catch block before theorising — it names the resident activity in one run. Note a leftover *custom tab*
+  is harmless; the next test launches over one fine.
+
+### A19. ESPRESSO_BY_ID cannot address framework ids (2026-08-03)
+- **Symptom:** `IllegalArgumentException` (not "element not found") the moment a selector resolves, e.g. on
+  the "Later" button of the secure-your-cards system dialog.
+- **Cause:** `ESPRESSO_BY_ID` looks the name up in the *app's* `R.id`, so `android:id/button2` cannot
+  resolve at all.
+- **Check:** for platform/system-UI ids use `UIAUTOMATOR_WITH_RAW_RES_ID` with the fully-qualified id
+  (`android:id/button2`, `com.android.systemui:id/notification_stack_scroller`).
+
+### B12. Compose's waitUntil raises a Throwable, so `catch (e: Exception)` misses it (2026-08-03)
+- **Symptom:** a helper with a retry loop does not retry; the first timeout escapes.
+- **Cause:** `ComposeTimeoutException` extends `Throwable` directly, not `Exception`.
+- **Check:** retry loops around `composeRule.waitUntil` must catch `Throwable`.
+
+### B13. A helper that opens a system window must close it on the failure path (2026-08-03, bug 2060345)
+- **Symptom:** one failure inside the notification shade turns every later step — and the retry — into an
+  unrelated error; Espresso cannot even dump (`has-window-focus=false`).
+- **Cause:** the shade holds window focus, and `openNotificationTray()` left it open when its verify threw.
+- **Check:** wrap the post-open verification, close on the failure path, then rethrow the original error.
+  Confirm the close rather than assuming it: `pressBack()` does dismiss the shade, but a close helper should
+  re-probe and escalate (`pressHome()`) rather than trust it.
+

--- a/tae-conversion/tools/effbug.py
+++ b/tae-conversion/tools/effbug.py
@@ -19,6 +19,8 @@ Request JSON (dropped by Claude into conversion-runs/_queue/<id>.request.json):
 
   { "bug": "update", "ids": [2057407, …], "self_assign": true }   # or "assigned_to","summary","status",…
       → assigns/edits existing bugs. self_assign (default on) sets the assignee to the API key's owner.
+      `dupe_of` marks the bug(s) a duplicate: it fills in RESOLVED/DUPLICATE for you, and DUPLICATE
+      without it is rejected rather than sent for Bugzilla to refuse.
 
   Assignee on create/update resolves as: explicit `assigned_to` → env BUGZILLA_ASSIGNEE → self (BMO whoami,
   the key owner) unless `self_assign` is false.
@@ -198,6 +200,17 @@ def run(req):
         for k in ("summary", "status", "resolution", "keywords", "whiteboard", "priority", "severity"):
             if req.get(k):
                 fields[k] = req[k]
+        # Marking a duplicate: Bugzilla rejects resolution=DUPLICATE without dupe_of, and setting dupe_of
+        # implies RESOLVED/DUPLICATE, so fill in whichever half the caller left out.
+        if req.get("dupe_of"):
+            dupe = str(req["dupe_of"]).strip()
+            if not dupe.isdigit():
+                raise RuntimeError(f"update: dupe_of must be a bug number, got {req['dupe_of']!r}")
+            fields["dupe_of"] = int(dupe)
+            fields.setdefault("status", "RESOLVED")
+            fields.setdefault("resolution", "DUPLICATE")
+        elif str(req.get("resolution", "")).upper() == "DUPLICATE":
+            raise RuntimeError("update: resolution=DUPLICATE also needs dupe_of=<bug number>")
         # Relations take an add/remove object on update (unlike create, which takes a plain list) —
         # a bare list would REPLACE the existing set, which on a meta bug would silently drop every
         # other bug it tracks. Accept a list for convenience and wrap it as {"add": [...]}.

--- a/tae-conversion/tools/effbug.py
+++ b/tae-conversion/tools/effbug.py
@@ -198,6 +198,13 @@ def run(req):
         for k in ("summary", "status", "resolution", "keywords", "whiteboard", "priority", "severity"):
             if req.get(k):
                 fields[k] = req[k]
+        # Relations take an add/remove object on update (unlike create, which takes a plain list) —
+        # a bare list would REPLACE the existing set, which on a meta bug would silently drop every
+        # other bug it tracks. Accept a list for convenience and wrap it as {"add": [...]}.
+        for k in ("depends_on", "blocks", "see_also"):
+            v = req.get(k)
+            if v:
+                fields[k] = {"add": v} if isinstance(v, list) else v
         if not fields:
             raise RuntimeError("update: nothing to change (pass assigned_to/self_assign or a field)")
         updated, failed = [], []

--- a/tae-conversion/tools/effcheck.py
+++ b/tae-conversion/tools/effcheck.py
@@ -49,6 +49,12 @@ def basepage_verbs(eff_root):
     except Exception:
         return set()
 
+def _strip_comments(txt):
+    """Drop // line comments and /* */ blocks, so a placeholder comment cannot masquerade as code."""
+    txt = re.sub(r"/\*.*?\*/", "", txt, flags=re.S)
+    return re.sub(r"//[^\n]*", "", txt)
+
+
 def check_file(path, strings, app_root, eff_root, verbs, tag_cache):
     txt = open(path, encoding="utf-8").read()
     p = path.replace("\\", "/")
@@ -103,12 +109,57 @@ def check_file(path, strings, app_root, eff_root, verbs, tag_cache):
         # CAT (B2): no inline selectors in a page object
         if "SelectorStrategy." in txt:
             add("WARN", "CAT  inline Selector(...) in a page object — move it into the *Selectors catalog (gotcha B2)")
-        # NAV (B1): registered edges must have steps OR a launch config
-        for reg in re.findall(r"NavigationRegistry\.register\((.*?)\)\s*(?:\}|$)", txt, re.S):
-            has_steps = re.search(r"steps\s*=\s*listOf\(\s*[^)\s]", reg)
-            has_launch = "launch" in reg and "LaunchConfig" in reg
-            if not has_steps and not has_launch:
-                add("FAIL", "NAV  page registers an edge with empty steps and no launch=LaunchConfig(...) (gotcha B1)")
+        # NAV (B1): registered edges must have steps OR a launch config.
+        #
+        # Comments are stripped first. The previous check tested `listOf(\s*[^)\s]`, and a `//`
+        # placeholder comment inside an otherwise-empty listOf() satisfied `[^)\s]` — so an edge whose
+        # steps were nothing but a "TODO: add a nav path" comment was reported as having steps. That is
+        # exactly how ShareOverlayPage shipped a no-op edge that made navigateToPage() silently succeed
+        # while never leaving the previous screen (bug 2060297).
+        nav_txt = _strip_comments(txt)
+        is_component = re.search(r"class\s+\w*Component\b", txt) is not None
+        # Match every register block, keyed on the `from`/`to` pair rather than on what follows the
+        # closing paren. The previous pattern required the block to be followed by `}` or end-of-file, so
+        # in a page with several edges only the LAST was ever examined — which is why the legitimate
+        # empty-step edges in HomePage, OnboardingPage and MainMenuPage went unreported while unfinished
+        # forward edges elsewhere did not.
+        for reg in re.finditer(
+            r"NavigationRegistry\.register\(\s*from\s*=\s*([^,]+),\s*to\s*=\s*([^,]+),(.*?)\n\s*\)",
+            nav_txt, re.S,
+        ):
+            src, dst, body = reg.group(1).strip(), reg.group(2).strip(), reg.group(3)
+            has_steps = re.search(r"steps\s*=\s*listOf\(\s*[^)\s]", body)
+            has_launch = "launch" in body and "LaunchConfig" in body
+            if has_steps or has_launch:
+                continue
+            # Empty steps are correct in three cases, so only a forward edge into a distinct screen is a
+            # bug — you cannot arrive somewhere new by performing no actions:
+            #   from = "AppEntry"  the app launches straight into this screen (HomePage, OnboardingPage)
+            #   from = pageName    a return/dismiss edge; leaving the overlay needs no action (MainMenuPage)
+            #   *Component         the component is already on its parent screen (ToolbarComponent)
+            if src == '"AppEntry"' or src == "pageName" or is_component:
+                continue
+            add("FAIL", f"NAV  edge {src} -> {dst} has empty steps and no launch=LaunchConfig(...): "
+                        "a forward edge into a screen cannot be reached by doing nothing (gotcha B1)")
+
+        # ANCHOR (B1b): the page's selector catalog must carry a "requiredForPage" entry, otherwise the
+        # arrival check has nothing to assert and navigateToPage() reports success for any screen. Paired
+        # with the NAV check above: either gap alone silently turns navigation into a no-op, and both
+        # shipped undetected (bugs 2060297 and 2060305) because neither was checked here.
+        # Only demanded of pages that actually register an edge. A page with no edge cannot be navigated
+        # to at all — navigateToPage() fails with "no navigation path found" — so there is no arrival
+        # check to anchor and no bug to prevent. Without this condition the rule pushes you to invent an
+        # unverifiable requiredForPage on unfinished scaffolding, which is worse than leaving it absent.
+        registers_edge = "NavigationRegistry.register(" in nav_txt
+        cat = re.search(r"return\s+([A-Za-z0-9_]+)\.all", txt) if registers_edge else None
+        if cat:
+            cat_path = os.path.join(eff_root, "selectors", cat.group(1) + ".kt")
+            if os.path.isfile(cat_path):
+                if "requiredForPage" not in open(cat_path, encoding="utf-8").read():
+                    add("FAIL", f"ANCHOR {cat.group(1)} has no \"requiredForPage\" selector — "
+                                "the page has no arrival check, so navigateToPage() cannot fail (gotcha B1)")
+            else:
+                add("WARN", f"ANCHOR could not locate {cat.group(1)}.kt to check for requiredForPage")
     # VERB: moz* verbs used exist on BasePage
     if verbs:
         for v in sorted(set(re.findall(r"\.(moz[A-Za-z0-9_]+)\(", txt))):

--- a/tae-conversion/tools/effloop.sh
+++ b/tae-conversion/tools/effloop.sh
@@ -158,3 +158,34 @@ else:
 PY
 
 echo "▶ reports in $OUT"
+
+# ── propagate a real exit code ───────────────────────────────────────────────────────────────────────
+# Previously the script's last command was the echo above, so effloop ALWAYS exited 0 — even when gradle
+# failed or tests failed. effwatch records that as `effloop_exit: 0`, so a red run was reported green to
+# every consumer, and the only way to notice was to open status.json by hand.
+#
+# status.json is the source of truth here: it is parsed from gradle's JUnit XML and already carries the
+# per-test verdict. Gradle's own exit code is deliberately not used as the primary signal — it is
+# non-zero for a failed test AND for unrelated infrastructure problems, and it cannot distinguish
+# "compiled but a test failed" from "did not compile", which callers need to tell apart.
+#
+# Exit codes:
+#   0  compiled, ran, all tests passed
+#   1  compiled and ran, but at least one test failed
+#   2  compile failure (no test verdict possible)
+#   3  compiled but produced no usable test verdict (no JUnit XML) — inconclusive, treat as failure
+#   4  the test filter matched nothing — almost always a mistyped class/method, i.e. a caller error
+#      rather than a red run, so it is worth distinguishing from 1 and 3
+OUTCOME=$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("outcome","unknown"))' \
+    "$OUT/status.json" 2>/dev/null || echo unknown)
+case "$OUTCOME" in
+    pass) exit 0 ;;
+    fail) echo "✗ effloop: tests failed (see $OUT/status.json)"; exit 1 ;;
+    no-tests) echo "✗ effloop: no tests matched '$TEST_CLASS' — check the class/method name"; exit 4 ;;
+    *)
+        if [ "${COMPILE_OK:-1}" != "0" ]; then
+            echo "✗ effloop: compile failure (see $OUT/build-report.txt)"; exit 2
+        fi
+        echo "✗ effloop: no usable test verdict (see $OUT/build-report.txt)"; exit 3
+        ;;
+esac

--- a/tae-conversion/tools/effnext.py
+++ b/tae-conversion/tools/effnext.py
@@ -5,22 +5,36 @@ effnext — pick the next legacy test(s) to convert, from LOCAL files only. No G
 Source of truth for "what to do next":
   - candidate pool : conversion-runs/testrail_smoke_pool.txt  (prioritized `Class.method<TAB>method` lines)
   - already done   : tools/converted_rows.csv                 (Class,Method,...,Converted,... rows)
-The next candidate = first pool entry not marked Converted in converted_rows.csv.
+  - skipped        : conversion-runs/skiplist.tsv             (`Class.method<TAB>reason<TAB>date` lines)
+The next candidate = first pool entry that is neither marked Converted nor skipped.
 
 converted_rows.csv is a fast snapshot and can lag reality (the campaign notes warn the "Converted" column is
-not authoritative). This tool is only for cheaply *proposing* candidates; gate 1 (`effscaffold`) does the
-authoritative "already exists in the efficiency package?" grep before you actually convert.
+not authoritative), so by default effnext also greps the efficiency tests package for `fun <method>(` and
+drops anything already present in-tree. Point it at a checkout with --repo or $REPO; pass --no-tree-check to
+turn the grep off (it is skipped automatically when the checkout cannot be found).
+
+Skipping: a candidate you do not want — too complex for who is picking it up, blocked on a harness gap,
+deliberately deferred — should be recorded rather than mentally stepped over, so the next caller (and the
+next person) gets a different pick. Skips are advisory and reversible; they never mark a test converted.
 
 Usage:
-  effnext.py [-n N] [--json]      # print the next N (default 1) unconverted candidates
-Exit 0 always (unless files are missing).
+  effnext.py [-n N] [--json]                     # print the next N (default 1) candidates
+  effnext.py --skip Class.method [--reason "…"]  # record a skip, then show the new next pick
+  effnext.py --unskip Class.method               # remove a skip
+  effnext.py --skips                             # list what is currently skipped
+  effnext.py --include-skipped                   # ignore the skiplist for this call
+Exit 0 always (unless files are missing, or --skip/--unskip names something not in the pool).
 """
-import csv, json, os, sys
+import csv, datetime, json, os, re, sys
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.dirname(HERE)
 POOL = os.path.join(ROOT, "conversion-runs", "testrail_smoke_pool.txt")
 DONE = os.path.join(HERE, "converted_rows.csv")
+SKIPS = os.path.join(ROOT, "conversion-runs", "skiplist.tsv")
+
+DEFAULT_REPO = os.path.expanduser(os.environ.get("REPO", "~/Workspace/firefox"))
+EFF_TESTS = "mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/tests"
 
 
 def load_done():
@@ -49,41 +63,159 @@ def load_pool():
     return out
 
 
+def load_skips():
+    """fq -> reason. Missing file is normal (nothing skipped yet)."""
+    skips = {}
+    if not os.path.isfile(SKIPS):
+        return skips
+    with open(SKIPS, encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line.strip() or line.startswith("#"):
+                continue
+            parts = line.split("\t")
+            skips[parts[0].strip()] = parts[1].strip() if len(parts) > 1 else ""
+    return skips
+
+
+def write_skips(skips):
+    os.makedirs(os.path.dirname(SKIPS), exist_ok=True)
+    existing_dates = {}
+    if os.path.isfile(SKIPS):
+        with open(SKIPS, encoding="utf-8", errors="ignore") as f:
+            for line in f:
+                parts = line.rstrip("\n").split("\t")
+                if len(parts) > 2:
+                    existing_dates[parts[0].strip()] = parts[2].strip()
+    today = datetime.date.today().isoformat()
+    with open(SKIPS, "w", encoding="utf-8") as f:
+        f.write("# Candidates deliberately passed over by effnext. Advisory only — a skip never marks a\n")
+        f.write("# test converted. Remove a line (or run `effnext.py --unskip <Class.method>`) to requeue it.\n")
+        f.write("# Class.method\treason\tdate\n")
+        for fq in sorted(skips):
+            f.write(f"{fq}\t{skips[fq]}\t{existing_dates.get(fq, today)}\n")
+
+
+def converted_in_tree(repo):
+    """Method names with a `fun <name>(` in the efficiency tests package. Empty set if the repo isn't there."""
+    tests_dir = os.path.join(repo, EFF_TESTS)
+    if not os.path.isdir(tests_dir):
+        return None
+    names = set()
+    pattern = re.compile(r"\bfun\s+([A-Za-z0-9_]+)\s*\(")
+    for entry in os.listdir(tests_dir):
+        if not entry.endswith(".kt"):
+            continue
+        with open(os.path.join(tests_dir, entry), encoding="utf-8", errors="ignore") as f:
+            names.update(pattern.findall(f.read()))
+    return names
+
+
+def emit(payload, as_json, lines):
+    print(json.dumps(payload) if as_json else "\n".join(lines))
+
+
 def main():
     args = sys.argv[1:]
     as_json = "--json" in args
     args = [a for a in args if a != "--json"]
+
+    def opt(flag):
+        if flag in args:
+            i = args.index(flag)
+            if i + 1 >= len(args):
+                print(f"✖ {flag} needs a value")
+                sys.exit(2)
+            return args[i + 1]
+        return None
+
     n = 1
     if "-n" in args:
-        i = args.index("-n")
         try:
-            n = int(args[i + 1])
+            n = int(args[args.index("-n") + 1])
         except (IndexError, ValueError):
-            print("usage: effnext.py [-n N] [--json]"); sys.exit(2)
+            print(__doc__.strip())
+            sys.exit(2)
+
+    repo = opt("--repo") or DEFAULT_REPO
+    tree_check = "--no-tree-check" not in args
+    include_skipped = "--include-skipped" in args
+    to_skip = opt("--skip")
+    to_unskip = opt("--unskip")
 
     for p in (POOL, DONE):
         if not os.path.isfile(p):
             msg = f"missing required file: {p}"
-            print(json.dumps({"tool": "effnext", "ok": False, "error": msg}) if as_json else f"✖ {msg}")
+            emit({"tool": "effnext", "ok": False, "error": msg}, as_json, [f"✖ {msg}"])
             sys.exit(1)
 
-    done = load_done()
     pool = load_pool()
-    pending = [(c, m, fq) for (c, m, fq) in pool if (c, m) not in done]
+    pool_fqs = {fq for (_, _, fq) in pool}
+    skips = load_skips()
+
+    if "--skips" in args:
+        payload = {"tool": "effnext", "ok": True, "skipped": [{"fqmethod": k, "reason": v} for k, v in sorted(skips.items())]}
+        lines = [f"effnext — {len(skips)} skipped"] + [f"  ⤳ {k}{('  — ' + v) if v else ''}" for k, v in sorted(skips.items())]
+        emit(payload, as_json, lines or ["effnext — nothing skipped"])
+        sys.exit(0)
+
+    for flag, fq in (("--skip", to_skip), ("--unskip", to_unskip)):
+        if fq and fq not in pool_fqs:
+            msg = f"{fq} is not in the pool ({POOL}); expected Class.method"
+            emit({"tool": "effnext", "ok": False, "error": msg}, as_json, [f"✖ {msg}"])
+            sys.exit(2)
+
+    if to_unskip:
+        skips.pop(to_unskip, None)
+        write_skips(skips)
+    if to_skip:
+        skips[to_skip] = (opt("--reason") or "").strip()
+        write_skips(skips)
+
+    done = load_done()
+    in_tree = converted_in_tree(repo) if tree_check else None
+
+    pending, already_in_tree = [], 0
+    for (c, m, fq) in pool:
+        if (c, m) in done:
+            continue
+        if in_tree is not None and m in in_tree:
+            already_in_tree += 1
+            continue
+        if not include_skipped and fq in skips:
+            continue
+        pending.append((c, m, fq))
     picks = pending[:n]
 
-    if as_json:
-        print(json.dumps({
-            "tool": "effnext", "ok": True,
-            "pool_total": len(pool), "done": len(done), "pending": len(pending),
-            "next": [{"class": c, "method": m, "fqmethod": fq} for (c, m, fq) in picks],
-        }))
-    else:
-        print(f"effnext — {len(pending)} pending / {len(pool)} pool ({len(done)} converted)")
-        for c, m, fq in picks:
-            print(f"  → {fq}")
-        if not picks:
-            print("  (nothing pending — pool exhausted or all marked converted)")
+    payload = {
+        "tool": "effnext", "ok": True,
+        "pool_total": len(pool), "done": len(done), "pending": len(pending),
+        "skipped": len(skips), "already_in_tree": already_in_tree,
+        "tree_checked": in_tree is not None,
+        "next": [{"class": c, "method": m, "fqmethod": fq} for (c, m, fq) in picks],
+    }
+    if to_skip:
+        payload["just_skipped"] = to_skip
+    if to_unskip:
+        payload["just_unskipped"] = to_unskip
+
+    lines = []
+    if to_skip:
+        lines.append(f"⤳ skipped {to_skip}{('  — ' + skips[to_skip]) if skips[to_skip] else ''}")
+    if to_unskip:
+        lines.append(f"↩ unskipped {to_unskip}")
+    summary = f"effnext — {len(pending)} pending / {len(pool)} pool ({len(done)} converted"
+    if already_in_tree:
+        summary += f", {already_in_tree} already in-tree"
+    if skips and not include_skipped:
+        summary += f", {len(skips)} skipped"
+    lines.append(summary + ")")
+    if in_tree is None and tree_check:
+        lines.append(f"  (no checkout at {repo} — tree check skipped; pass --repo or set $REPO)")
+    lines += [f"  → {fq}" for (_, _, fq) in picks]
+    if not picks:
+        lines.append("  (nothing pending — pool exhausted, or everything left is converted or skipped)")
+    emit(payload, as_json, lines)
     sys.exit(0)
 
 

--- a/tae-conversion/tools/effverify.py
+++ b/tae-conversion/tools/effverify.py
@@ -34,25 +34,51 @@ def main():
         sys.exit(1)
     full = open(rr, encoding="utf-8", errors="ignore").read()
 
-    # --- Scope to the LAST run only. A report can hold several `run started:`..`run finished:`
-    # blocks (retries, or stale buffer bleed if a `logcat -c` didn't fully clear). Summing failures
-    # across all of them caused false negatives (a prior failed attempt inflated the current verdict).
-    # We evaluate the most recent run; earlier blocks only feed the flakiness signal below.
+    # --- Evaluate EVERY run block, not just the last one.
+    #
+    # A single class request legitimately produces many blocks: one for the class run, then one per
+    # test that the retry rule re-ran individually. Scoping to the last block (the previous behaviour)
+    # read the verdict off whichever 1-test re-run happened to land last, which produced three distinct
+    # wrong answers:
+    #   - every test not in that final block was reported "not-run", even though it ran and passed;
+    #   - `failed_total` came from that block alone, so a real failure recorded in an earlier block was
+    #     reported as 0 failures — a green verdict for a red test;
+    #   - `retried` only looked at the last block, so a report with 8 runs of a 7-test class still said
+    #     retried=false.
+    #
+    # Per-test truth comes from the report's own `failed:` / `ignored:` / `started:` markers, aggregated
+    # across all blocks. A test that failed in ANY block is not clean, even if a later re-run passed —
+    # that is precisely the retry-pass the done-gate exists to catch.
     starts = [m.start() for m in re.finditer(r"^run started:", full, re.M)]
-    txt = full[starts[-1]:] if starts else full
+    bounds = starts + [len(full)]
+    blocks = [full[bounds[i]:bounds[i + 1]] for i in range(len(starts))] or [full]
 
-    started = set(re.findall(r"started:\s*([A-Za-z0-9_]+)\s*\(", txt))
-    ignored = set(re.findall(r"ignored:\s*([A-Za-z0-9_]+)\s*\(", txt))
-    # failures reported by the LAST run block (not summed across the whole buffer)
-    fails = [int(f) for f in re.findall(r"run finished:\s*\d+\s*tests?,\s*(\d+)\s*failed", txt)]
-    failed_total = sum(fails)  # normally one finished-line in the last block
+    def names(pattern, text):
+        return set(re.findall(pattern + r":\s*([A-Za-z0-9_]+)\s*\(", text))
 
-    # Flakiness signal — surface a retry WITHIN the current run instead of masking it.
-    # Scope to the last block (txt), NOT the whole file: earlier blocks may be stale buffer bleed
-    # (pre-`logcat -c`-fix artifacts) and their retries are not this run's. A `Started try #2+` inside
-    # the current run means "passed on retry" = green-but-flaky. n_runs is informational only (whole-file).
+    started, ignored, failed_names = set(), set(), set()
+    passed_in_some_block = set()
+    for b in blocks:
+        b_started, b_ignored, b_failed = names("started", b), names("ignored", b), names("failed", b)
+        started |= b_started
+        ignored |= b_ignored
+        failed_names |= b_failed
+        # Ran in this block and this block did not record it failing → it passed here.
+        passed_in_some_block |= (b_started - b_failed - b_ignored)
+
+    # Count actual per-test failures observed anywhere in the report, not one block's summary line.
+    failed_total = len(failed_names)
+
     n_runs = len(starts)
-    retried = bool(re.search(r"Started try #(?:[2-9]|\d\d)", txt))
+    # Retried if the harness logged a second attempt anywhere, or a test both failed and later passed.
+    #
+    # Deliberately NOT keyed on n_runs > 1: effloop emits one block per test after the class run as
+    # normal behaviour, so a clean 6-test class legitimately reports 7 blocks. Treating that as a retry
+    # marked every multi-test run flaky.
+    retried = (
+        bool(re.search(r"Started try #(?:[2-9]|\d\d)", full)) or
+        bool(failed_names & passed_in_some_block)
+    )
 
     # gradle raw cross-check (authoritative per-test SKIPPED/FAILED)
     raw_txt = open(raw, encoding="utf-8", errors="ignore").read() if os.path.isfile(raw) else ""
@@ -79,17 +105,27 @@ def main():
     tests = []
     for name in expected:
         rs = raw_status(name)
+        # Order matters. The report's own `failed:` marker is checked BEFORE falling through to
+        # "started and not otherwise flagged → passed": previously a test whose gradle line did not
+        # match raw_status() but which appeared in `started` was reported passed outright, so a genuine
+        # failure came back green whenever that regex missed.
         if name in ignored or rs == "SKIPPED":
             status, passed = "skipped", False
-        elif rs == "FAILED":
-            status, passed = "failed", False
+        elif name in failed_names or rs == "FAILED":
+            # Failed at least once. If a later block ran it green, it is a retry-pass: usable but flaky,
+            # never "clean". Kept out of `passed` so `ok` stays false and the caller cannot mistake it
+            # for done.
+            if name in passed_in_some_block:
+                status, passed = "retry-pass", False
+            else:
+                status, passed = "failed", False
         elif name not in started:
             status, passed = "not-run", False
         else:
             status, passed = "passed", True
         ok = ok and passed
         entry = {"name": name, "status": status, "passed": passed, "gradle": rs}
-        if not passed and status in ("failed", "not-run"):
+        if not passed and status in ("failed", "not-run", "retry-pass"):
             exc = failure_excerpt(name)
             if exc:
                 entry["failure_excerpt"] = exc
@@ -107,7 +143,8 @@ def main():
             if t["passed"]:
                 print(f"  ✔ {t['name']}: executed" + (f" (gradle:{t['gradle']})" if t["gradle"] else ""))
             else:
-                lbl = {"skipped": "SKIPPED/ignored — NOT a pass", "failed": "FAILED in gradle log",
+                lbl = {"skipped": "SKIPPED/ignored — NOT a pass", "failed": "FAILED",
+                       "retry-pass": "FAILED then passed on a re-run — flaky, NOT done",
                        "not-run": "never executed (no 'started:' line)"}[t["status"]]
                 print(f"  ✖ {t['name']}: {lbl}")
         if failed_total > 0:


### PR DESCRIPTION
# tae-conversion: fix three false-green defects in the loop, and let effnext skip a candidate

Five follow-ups to the initial `tae-conversion` import, all found by running the conversion loop for real rather than by reading the code. Three of them were reporting success where there wasn't any, which is the worst failure mode a done-gate can have.

## The verdict was not trustworthy

**`effverify` read the verdict off the wrong run.** It scoped its whole analysis to the last `run started:` block in the report — but `effloop` emits one block per test *after* the class run, so it was reading whichever single-test re-run happened to land last. Consequences: tests that passed reported as `not-run`, tests that genuinely failed reported `failed_total: 0`, and `retried` came back `false` across a run containing eight of them. It also fell through to "appears in `started` → passed" whenever its gradle-log regex missed.

It now aggregates every block and keys off the report's own `started:` / `ignored:` / `failed:` markers, with a distinct `retry-pass` status (`passed: false`) for failed-then-passed. That distinction is the point: a test that only passes on the second attempt is flaky, not done, and the old behaviour let those through as green.

One deliberate non-change: `retried` is not keyed on `n_runs > 1`. One block per test is normal, so that would mark every class run flaky.

**`effloop` always exited 0**, because its last command was an `echo`. `effloop_exit` in `<id>.done.json` therefore carried no signal at all, and any caller branching on it was branching on a constant. It now distinguishes green (0), test failure (1), compile failure (2), no verdict (3), and filter-matched-nothing (4) — that last one matters because a typo'd class name previously looked like a clean pass.

Together these two are why the loop can be trusted to gate a stack: the recent four-commit Firefox stack was landed on these verdicts, including a full-suite sweep of 42 efficiency classes / 137 tests where the difference between "passed" and "passed on retry" was exactly what needed reporting.

## Two smaller correctness fixes

**`effcheck` now catches page objects with no reachable navigation path.** Previously the static pre-flight would pass a page object that no test could ever route to, and you found out on a device build.

**`effbug` can update bug relations**, wrapping list fields as `{"add": [...]}`. This is a small diff with a sharp edge behind it: Bugzilla treats a bare list on `depends_on` as *replace*, so PUTting one to the campaign meta (2030727) would silently drop every other bug it tracks. Accepting a list for convenience and wrapping it is what makes the convenient form safe.

## effnext: opting out of a pick

Whoever picks up the queue may not be in a position to take the next candidate — too complex for them, blocked on a harness gap, or deliberately deferred by whoever is sequencing the campaign. There was no way to express that, so the decision lived in someone's head and the next caller got handed the same pick.

```bash
effnext.py --skip Class.method --reason "needs save-login capability first"
effnext.py --skips        # what's parked, and why
effnext.py --unskip Class.method
effnext.py --include-skipped   # ignore the skiplist for one call
```

`--skip` records it and prints the new next pick in the same run. Skips live in `conversion-runs/skiplist.tsv` (`Class.method`, reason, date) beside the pool they refer to. Two properties make this safe to use casually: **a skip never marks a test converted**, so parking something can't inflate the burndown; and skips are advisory and reversible, with the reason recorded so the next person can re-judge instead of guess. Unknown names are rejected (exit 2) rather than silently written.

## effnext: not proposing work that's already done

The done-ledger (`converted_rows.csv`) lags the tree, and the campaign notes already warned its `Converted` column isn't authoritative — but the tool still trusted it, and a warning in a doc doesn't prevent a wasted pick. It handed me a test that was already converted *and committed*, and 11 of its top 30 candidates were already in-tree.

`effnext` now greps the efficiency tests package for `fun <method>(` and drops those. On the current checkout that is still 11 candidates the ledger hasn't caught up with:

```
effnext — 84 pending / 166 pool (89 converted, 11 already in-tree)
```

`--no-tree-check` opts out; `--repo` or `$REPO` locates the checkout, and the check is skipped with a note when none is found, so the tool still works standalone. Note `effscaffold`'s `already_converted` does **not** cover this — it lists matching *files*, not methods — which is how the stale pick got through gate 1.

## Docs

- `HARNESS-GOTCHAS.md` — A16–A19, B12–B13: a disabled Compose button accepts the click and skips `onClick`; an enabled-check on a `COMPOSE_BY_TEXT` selector is a no-op because it resolves the text node inside the button; retries blocked by the previous attempt's still-resumed `HomeActivity` (`launchMode="singleTask"`, so the relaunch intent goes to the existing instance and no new activity ever reaches RESUMED); `ESPRESSO_BY_ID` cannot address framework ids like `android:id/button2`; `ComposeTimeoutException` extends `Throwable`, so `catch (e: Exception)` misses it; a helper that opens a system window must close it on the failure path.
- `CONVERSION-LESSONS.md` — new sections on acting-vs-finding a control and on conversion paperwork, plus the `effnext` correction.
- `CONVERSION-LOOP.md` — the skip flow, a step 1b for `@Converted`, the meta-linking rule, and a note that BMO has no API for editing a description.
- `README.md` — tools table, the skiplist file, a worked skip example.

One correction rather than an addition: `CONVERSION-LOOP.md` said to add `@Converted` *after landing*, contradicting the in-tree `converting-a-test.md`. That drift cost a mid-stack rewrite on the last stack, so it now says same-commit and explains why.

## Verification

All four Python tools parse and `effloop.sh` passes `bash -n`. `effnext`'s `--skip`, `--unskip`, `--skips`, `--json`, `--include-skipped` and bad-name paths were each exercised by hand against the live pool, and the demo skip was removed afterwards so the branch carries no invented decisions in `skiplist.tsv`. The `effverify`/`effloop` fixes have been in use since they were written — every verdict behind the recent four-commit stack and the 42-class sweep came through them.

## Follow-up

The `tae` plugin skills in `firefox-aidev-plugins` document `effnext`; a companion PR there describes the skip flow. **Land this one first**, so the skills don't reference flags that aren't released yet.
