### PR TITLE
tae-conversion: lessons from the DownloadFileTypesTest conversion

### DIFF
--- a/tae-conversion/docs/CONVERSION-LESSONS.md
+++ b/tae-conversion/docs/CONVERSION-LESSONS.md
@@ -286,6 +286,52 @@ this single pattern. See gotcha A12.
   it. If avoiding a resubmit matters more, leave commit messages alone — editing one forces the upload
   you were trying to avoid.
 
+## J. Interaction diagnosis and re-baselining (DownloadFileTypesTest, 2026-08-04, 8 device runs)
+
+Section H covers the same family from the translations sheet; these are the additions from a conversion
+where the click problem appeared twice in one test, on two different layers.
+
+**J1. A text selector can resolve a non-interactive TWIN of the target.**
+- Assumed: if a selector resolves an element and the click reports success, the click landed.
+- Reality: hit twice in one conversion. Each download link renders as a PAIR — a clickable node carrying
+  `desc="Download <file>"` and a sibling text node with the same string and no click action. Same shape for
+  the dialog's confirm button (`Button { Text("Download") }`). H1 is the disabled-button version of this;
+  here the node was not disabled, it was never interactive.
+- Rule: for anything you CLICK rather than merely read, the handle must belong to the node owning the click
+  action. A text match is the likeliest to pick the twin, because the text lives on the child and the action
+  on the parent. Gotchas A17 (Compose side) and A20 (device side).
+- Tooling: 🛠️ a check could flag text strategies used as click targets.
+
+**J2. `UiObject.click()` returning false does NOT mean the click failed.**
+- Assumed: `Failed to click UiObject` means the tap missed.
+- Reality: it is `clickAndSync`, which returns false when no window update arrives inside ~5.5 s — routinely
+  exceeded by a click that starts a network download. A dump at one such "failure" showed the link holding
+  input focus; the tap had worked, and the retry then reloaded the page and threw away a dialog that was
+  on its way.
+- Rule: for a control whose reaction is slow, use a UiObject2 strategy — it injects the gesture and leaves
+  the waiting to the caller. Gotcha A22.
+- Tooling: ✅ `UIAUTOMATOR2_BY_DESCRIPTION_CONTAINS` added for this.
+
+**J3. Two identical failures mean the variable you are changing is the wrong one.**
+- Assumed: a click that resolves but does nothing is a selector problem, so try another strategy.
+- Reality: `COMPOSE_BY_TEXT`, a purpose-built `hasText and hasClickAction`, and `COMPOSE_BY_TEXT_MERGED`
+  all resolved a node, reported success, and left the dialog open. Three runs, one hypothesis, no new
+  information. The first run designed to DISCRIMINATE between hypotheses (Compose injection vs. the app not
+  acting) settled it immediately.
+- Rule: after the second identical failure, stop varying the same dimension and design a run whose possible
+  outcomes point at different causes. Write down what each outcome would mean before starting it.
+- Tooling: 📖 judgment.
+
+**J4. Swapping a remote page for a local asset is a change to the system under test.**
+- Assumed: serving the same page from mockWebServer only removes network flakiness.
+- Reality: localhost returns a `content-length`, so Fenix rendered the known-size download dialog (with a
+  rename field) instead of the unknown-size one — a dialog carrying the J1 confirm-button problem, which
+  the remote page never surfaced. A run that was 5/9 green went to 0/9, and four runs went into debugging a
+  failure the change itself had introduced.
+- Rule: re-baseline immediately after a determinism change. If results get worse, suspect the change before
+  suspecting the code under test. Gotcha B14.
+- Tooling: 📖 judgment.
+
 ## Open gaps (unresolved — pick up on next attempt)
 
 - **Address-autofill suggestion not offered on-device.** With the stylus overlay removed AND stylus disabled,

--- a/tae-conversion/docs/HARNESS-GOTCHAS.md
+++ b/tae-conversion/docs/HARNESS-GOTCHAS.md
@@ -6,7 +6,7 @@ catch them. Use it two ways: (1) a **review checklist** against new page objects
 
 Each entry: **symptom → cause → check**. Add new ones as we find them; link the Jira/bug where relevant.
 
-Last updated: 2026-08-03.
+Last updated: 2026-08-04.
 
 > The distilled, landed subset of this catalog lives in-tree at
 > `<fenix>/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/docs/gotchas.md`.
@@ -331,3 +331,75 @@ Last updated: 2026-08-03.
   Confirm the close rather than assuming it: `pressBack()` does dismiss the shade, but a close helper should
   re-probe and escalate (`pressHome()`) rather than trust it.
 
+---
+
+## A. Known harness bugs (continued — 2026-08-04, DownloadFileTypesTest conversion)
+
+### A20. A click can resolve, report success, and do nothing (inert text twin) (2026-08-04)
+- **Symptom:** `mozClick` logs `[OK] ✔ Clicked '<x>'` in ~100 ms and the UI does not change. No exception —
+  the failure surfaces later as a timeout on whatever should have appeared. Same shape as A16, different
+  cause.
+- **Cause:** the text you matched sits on a different node than the click action, and the node you hit is
+  not merely disabled — it is not interactive at all. Each link on the downloads test page is a clickable
+  node with `desc="Download <file>"` PLUS a sibling text node carrying the same string and no click action;
+  a `textContains` match lands on the twin. A17 is the Compose-side instance of this (unmerged text node
+  inside a button); this entry is the device-side one, in web content.
+- **Check:** for a CLICK target prefer a handle owned by the interactive node — testTag, then
+  content-description. The on-failure ScreenDump marks interactive nodes `[clickable]`: if your target
+  prints without it, you are aiming at the twin. Watch the dump's `(N nodes with a handle, of M total)`
+  line too — the interactive parent is often among the hidden ones, having no text of its own.
+
+### A21. A Compose click can resolve the right node and still not actuate it (2026-08-04)
+- **Symptom:** an on-screen Compose button does not respond to `mozClick`, whichever text strategy is used.
+  Seen on the download dialog's confirm button (a `FilledButton` with no testTag in
+  `RenameAndChangeLocationDialogContent.DialogActionButtons`).
+- **Cause:** NOT root-caused. What is established: `COMPOSE_BY_TEXT`, a purpose-built
+  `hasText and hasClickAction`, and `COMPOSE_BY_TEXT_MERGED` all resolved a node and reported a successful
+  click while the dialog stayed open; a device-level `UiObject2` tap worked immediately. Given A16/A17 the
+  leading explanation is timing rather than injection path — the button is briefly disabled while the
+  dialog settles, Compose resolves and clicks within ~150 ms and the gesture is dropped, whereas the
+  device-level query is slower and lands after it is enabled. That was not verified: no enabled-state
+  gate was tried on this dialog.
+- **Check:** before reaching for a different injection path, gate on enabled per A16 — a real gate takes
+  measurable time. If gating fixes it, fold this entry into A16 and delete it.
+
+### A22. `UiObject.click()` returns false for SLOW controls, not just missed ones (2026-08-04)
+- **Symptom:** `AssertionError: Failed to click UiObject` on an element that is present and was tapped.
+- **Cause:** `UiObject.click()` is `clickAndSync`, which reports failure when no window update arrives
+  within ~5.5 s. Anything triggering a network round-trip (starting a download) can exceed that. A dump at
+  one such failure showed the target holding input focus — the tap had landed, and the surrounding retry
+  then reloaded the page and discarded a dialog that was on its way.
+- **Check:** use a `UIAUTOMATOR2_*` strategy for slow-reacting controls; `UiObject2.click()` injects the
+  gesture and lets the caller wait. Read `Failed to click UiObject` as "no window update in time", not as
+  proof the click missed.
+
+### A23. `mozSwipeTo` cannot scroll to a `UiObject` (2026-08-04)
+- **Symptom:** `mozSwipeTo` returns immediately without swiping, and the following click fails anyway.
+- **Cause:** its visibility test for a `UiObject` is `element.exists()`, already true for a node that is in
+  the hierarchy but scrolled off-screen — so it "succeeds" on attempt 0. The Compose and Espresso branches
+  check actual display; the UiObject branch does not.
+- **Check:** don't rely on `mozSwipeTo` for UiObject-based selectors. Worth fixing to check visible bounds.
+
+### A24. effloop can finish without a `run-report.txt`, silently disabling effverify (2026-08-04)
+- **Symptom:** `effverify` returns `{"ok": false, "error": "no run-report.txt (did it compile/run?)"}` for a
+  run that plainly executed, and `status.json` says `"ran": false` while listing per-test results.
+- **Cause:** the `effpretty capture` step produced no report. The consequence beyond effverify is worse: the
+  on-failure ScreenDumps never reach `raw-run.log` either, so diagnostics look absent when they are merely
+  unrouted. This is what led me to conclude "mozClick does not dump on click failure" — it does,
+  `BasePage.kt:478`.
+- **Check:** if `run-report.txt` is missing, take the verdict from `status.json` (the folded JUnit XML) and
+  read dumps straight off the device with `adb logcat -d -s EffScreenDump:I`. logcat rotates — grep the
+  whole buffer rather than tailing it.
+
+## B. Authoring / review checklist (continued — 2026-08-04)
+
+### B14. Serving a page from mockWebServer can change which dialog the app shows (2026-08-04)
+- **Why:** replacing the remote downloads page with the local `downloadPageAsset` made localhost return a
+  `content-length`, so Fenix rendered the KNOWN-SIZE download dialog —
+  `RenameAndChangeLocationDialogContent`, with a rename field and a differently-composed confirm button —
+  instead of the unknown-size variant. The test went from 5/9 to 0/9 on that change alone, and four device
+  runs went into debugging a failure the change had introduced.
+- **Check:** switching a test from a remote page to a local asset changes the system under test, not just
+  its reliability. Re-run immediately and compare against the previous baseline; if results get worse,
+  suspect the switch before suspecting the code under test. Both dialog variants ship in the product, so a
+  selector verified against one is not verified against the other.


### PR DESCRIPTION
Docs-only. Adds section **H** to `CONVERSION-LESSONS.md` and entries **A16–A20 / B12** to `HARNESS-GOTCHAS.md`, from converting `DownloadFileTypesTest` onto ui/efficiency ([bug 2060521](https://bugzilla.mozilla.org/show_bug.cgi?id=2060521)) — 8 device runs, final result 9/9 green.

### The recurring theme: interaction, not selection

**A16 — a text selector can resolve a non-interactive twin of its target.** Hit twice in one test. Each download link renders as a *pair*: a clickable node carrying `desc="Download <file>"` plus a sibling text node with the same string and no click action. Same shape for the dialog's confirm button. Both times `mozClick` logged `[OK] ✔ Clicked` in ~100 ms and nothing happened — the failure only surfaced later as a timeout somewhere else.

**A18 — `UiObject.click()` returning false means "no window update within ~5.5s", not "the tap missed."** A dump at one such failure showed the target holding input focus; the tap had landed, and the retry then reloaded the page and discarded a dialog that was on its way.

### Two entries record my own process errors

They cost half the runs, so omitting them seemed worse than the mild embarrassment:

- **H3** — cycling through selector strategies after two identical failures instead of designing a run to *discriminate* between hypotheses. Three Compose variants all failed the same way; the first discriminating run settled it immediately.
- **H4 / B12** — swapping the remote test page for a local `mockWebServer` asset without re-baselining. localhost returns a `content-length`, so Fenix renders a *different* download dialog (known-size, with a rename field). That took a 5/9 run down to 0/9, and four runs went into debugging a failure the change itself had introduced.

### Deliberately incomplete

**A17 has no root cause.** Three Compose strategies resolve the confirm button and report a successful click while the dialog stays open; a device-level tap works. The `DialogFragment` window is the obvious suspect but I did not prove it, so it is written as an empirical workaround with a note to update it if someone diagnoses it properly.

### Process corrections

- **H5** — `@Converted` goes on the legacy method in the conversion commit itself. `CONVERSION-LOOP.md` lists it under "After landing", but the team precedent (bug 2060174) does it in-commit. Worth reconciling the doc with the practice.
- **H6** — `effnext` handed me an already-landed candidate (`converted_rows.csv` was stale) and then two that were in a colleague's unpushed diff. Pool said 95 pending; cross-checking against in-tree tests + `@Converted` gave 90.

### Not included

An SSL fix for `effbug.py` is **not** in this PR. On Pythons without a system CA bundle every `effbug` call dies with `CERTIFICATE_VERIFY_FAILED`, which blocks the loop at bug-filing. Left with Jackie to fix in the tool; feedback sent separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)