### PR TITLE
Release test planner

### DIFF
--- a/.github/workflows/release-test-planner-tests.yml
+++ b/.github/workflows/release-test-planner-tests.yml
@@ -1,0 +1,35 @@
+name: release-test-planner-tests
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - "release-test-planner/**"
+  pull_request:
+    paths:
+      - "release-test-planner/**"
+
+jobs:
+  test:
+    name: Run unit tests
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      # No dependency install step: the planner is stdlib-only. The tests do
+      # not need a Firefox checkout either - Kotlin parsing runs against
+      # fixtures and git parsing against a temp repo.
+      - name: Run tests
+        run: python -m unittest discover -s release-test-planner/tests -p '*tests.py' -v

--- a/release-test-planner/.gitignore
+++ b/release-test-planner/.gitignore
@@ -1,0 +1,19 @@
+# Generated reports - regenerate per range
+out/
+*.html
+!examples/*.html
+
+# Local agent answers (examples/answers.example.json is the versioned one)
+answers.json
+
+# Python
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# OS / editor noise
+.DS_Store
+.vscode/
+.idea/
+*.swp

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -7,20 +7,97 @@ automation exists for them, scores the release risk with FMEA, and produces a
 recommended test run, the manual-testing gap, and a configuration matrix sized
 by risk.
 
-> **Status: early prototype (v0.0.1).** Wired to Fenix/Android only, on UI tests
-> only. It is here to be reviewed and argued with, not to gate a release. iOS
-> and other platforms follow once the model is proven — the risk scoring and
-> array generation carry no platform knowledge and are designed to move
-> unchanged.
+> **Status: early prototype (v0.0.2).** Fenix/Android and Firefox iOS, on UI
+> tests only. It is here to be reviewed and argued with, not to gate a release.
+> The risk scoring and array generation carry no platform knowledge and moved to
+> iOS unchanged, as intended — but **iOS has no factory candidate space, so it
+> has no derived coverage denominator.** See
+> [Two platforms, two denominators](#two-platforms-two-denominators) before
+> reading any percentage.
 
 Stdlib Python 3.9+. No install, no dependencies, no API key, no network.
 
 ```bash
 cd release-test-planner
+
+# Android (default)
 ./plan.py analyze --repo /path/to/firefox --range "HEAD~300..HEAD" --budget 240 --open
+
+# Firefox iOS
+./plan.py analyze --platform ios --repo /path/to/firefox-ios \
+  --range "release/v153.0..release/v153.3" --budget 240 --open
+
+# either platform, with TestRail as an assumed denominator
+./plan.py analyze --platform ios --repo /path/to/firefox-ios \
+  --range "HEAD~120..HEAD" --testrail-export cases.json --budget 240 --open
 ```
 
 ---
+
+## Two platforms, two denominators
+
+Everything below the attribution stage is platform-agnostic and always was:
+churn measures, FMEA scoring, the plan builder, the covering arrays. Porting to
+iOS needed a Swift reader, a feature catalog, and one honest admission.
+
+| | Android | iOS |
+|---|---|---|
+| test language | Kotlin, `@Test` | Swift, `func test…()` by convention |
+| suites | `ui/`, `ui/efficiency/tests/` | `XCUITests/` |
+| surface evidence | `on.<pageObject>`, `robots.*` | `navigator.goto/nowAt/performAction` |
+| "does not run" | `@Ignore`, `@Suppress`, `@Manual` | skipped by every `.xctestplan`, `XCTSkip`, `guard #available … else { return }` |
+| candidate space | **3,158**, derived by the generation factories | **none** |
+
+The last row is the load-bearing one. The argument for this tool
+([docs/why-factories.md](docs/why-factories.md)) is that the factories
+*enumerate* a space, which gives coverage a denominator that was computed rather
+than asserted. firefox-ios has no factory framework, so on iOS the tool reports
+counts and gaps, and refuses to print a coverage percentage it cannot justify.
+`factories.empty()` exists to make that refusal explicit rather than a zero that
+looks like a measurement.
+
+### TestRail: an assumed denominator that works on both
+
+`--testrail-export cases.json` supplies the other kind of denominator. Both
+codebases already write the case id above each test, in the same URL form:
+
+```kotlin
+// TestRail link: https://mozilla.testrail.io/index.php?/cases/view/2283299
+@Test fun verifyExpandedCollectionItemsTest() { … }
+```
+```swift
+// https://mozilla.testrail.io/index.php?/cases/view/2306905
+func testBookmarkCanBeAdded() { … }
+```
+
+So the join is an **id match, not a name heuristic** — which matters, because a
+heuristic would be another assumption stacked on an already-assumed denominator.
+
+What it is: the TestRail case set is a deliberate artefact. Someone decided each
+case was worth writing for a release, and unlike the automated suite it was not
+constrained by what was cheap to automate. Taking it as the intended release-test
+plan is defensible.
+
+What it is not: complete. TestRail is also a pile that accumulated — dense where
+bugs were once found, thin where nobody wrote cases. So the number is reported as
+`automated_ratio`, never as `coverage`, and it answers exactly one question:
+**how much of the plan we wrote down will a machine run?** The remainder is the
+manual-testing gap, which is the number a release manager actually needs.
+
+Two rules keep it honest:
+
+- **A case automated only by a test that never runs is manual.** Same rule the
+  corpus applies to `@Ignore` and xctestplan skips. On firefox-ios this is not a
+  rounding error: of 440 case ids referenced by XCUITests, 125 are claimed by a
+  test that no test plan runs.
+- **A referenced id absent from the export is reported, not counted.** A test
+  pointing at another project's case would otherwise inflate the ratio.
+
+Accepted formats are JSON (the raw `get_cases` API response, or a bare list) and
+CSV (what the TestRail UI exports). Not xlsx — that needs a dependency this tool
+deliberately does not have, and
+`testrail/testcases-deduplication/fetch_testrail_export.py` can be pointed at the
+API response instead.
 
 ## Read this first: why this is possible now and wasn't before
 
@@ -101,6 +178,7 @@ action-required with zero UI coverage — which it genuinely has.
 | | |
 |---|---|
 | **[why-factories.md](docs/why-factories.md)** | why generated candidates are the precondition for coverage tooling at scale |
+| **[denominators.md](docs/denominators.md)** | derived vs assumed denominators, why iOS gets no candidate space, and what TestRail does and does not prove |
 | [risk-model.md](docs/risk-model.md) | FMEA, how each factor is derived, the two decisions with regression tests |
 | [matrix.md](docs/matrix.md) | orthogonal vs covering arrays, verification, risk-tiered allocation |
 | [architecture.md](docs/architecture.md) | pipeline stages, config, the agent seam, how to extend |
@@ -150,6 +228,34 @@ about 30 seconds. `git worktree remove ../firefox-beta` when finished.
 
 Other useful ranges: `origin/beta..origin/main` for what is queued for the next
 merge, and `HEAD~300..HEAD` for a rough nightly cycle.
+
+#### On iOS
+
+firefox-ios is its own repository, so there is no sparse-checkout to do and no
+pathspec to scope — but two things differ:
+
+```bash
+# release branches are release/vNNN.N. The bare vNNN.N branches stop at v105
+# and predate the layout move, so their paths will not match the catalog.
+git clone --single-branch --branch release/v153.3 --depth 400 \
+  https://github.com/mozilla-mobile/firefox-ios ~/Workspace/firefox-ios
+
+./plan.py analyze --platform ios --repo ~/Workspace/firefox-ios \
+  --range "HEAD~120..HEAD" --budget 240 --testrail-export cases.json --open
+```
+
+Depth matters: churn is computed by diffing the range, so a `--depth 1` clone
+gives an empty analysis. For the uplift delta between two release branches,
+fetch both and use `release/v153.2..release/v153.3`.
+
+The checkout also contains **focus-ios**, a separate product, and
+`SampleComponentLibraryApp`. Both are in the iOS catalog's `_ignored_globs`; a
+release report for Firefox iOS should not be scored on Focus churn.
+
+Layout note: the catalog's globs follow the current layout (app under
+`firefox-ios/`, shared packages under `BrowserKit/`). `--tests-root` overrides
+the test directory for an older checkout, but the source globs would also need
+adjusting.
 
 Outputs land in `out/` (gitignored):
 
@@ -228,9 +334,19 @@ defines, not runnable tests today.
 - **UI tests only.** Unit, component and service coverage are not modelled, so
   confidence is *understated* for well-unit-tested code. Closing this is worth
   more than any refinement of the existing scoring.
-- **TestRail is read, not integrated.** IDs are parsed from test comments and
-  displayed. The API is not queried and manual effort is not sized against the
-  case catalogue.
+- **TestRail is joined from an export, not queried.** Pass `--testrail-export`;
+  the tool does not talk to the API, and the export can be stale. Manual effort
+  is counted in cases, not sized in minutes.
+- **The iOS feature catalog is hand-written and unreviewed by the iOS team.**
+  Severities were carried over from the Android catalog where the feature exists,
+  which assumes user impact is the same on both platforms. The globs are fitted
+  to `release/v153.3` — 0 of 973 changed files unmapped on that branch, but that
+  is a fit to one branch, not a guarantee.
+- **iOS surface binding relies on the MappaMundi screen graph.** A test that
+  drives the app without `navigator` calls binds by class name alone, which is
+  the weaker of the two signals.
+- **No iOS candidate space.** Coverage on iOS is counts and gaps only, unless a
+  TestRail export supplies an assumed denominator.
 - **Factory candidates are counted, not selected.** They are attributed to
   features but do not yet feed the run plan.
 - Occurrence is churn-only — no cyclomatic complexity, no historical defect
@@ -247,11 +363,14 @@ defines, not runnable tests today.
 ## Layout
 
 ```
-plan.py                  entry point
-config/features.json     feature catalog: severity, source globs, page objects
-config/environment.json  matrix factors and the risk -> strength policy
-docs/                    the reasoning
-examples/                a worked agent-answers file
-testplanner/             one module per pipeline stage
-tests/                   69 unit tests, no checkout required
+plan.py                     entry point
+config/features.json        Android feature catalog: severity, globs, page objects
+config/features-ios.json    iOS feature catalog, plus its own _ignored_globs
+config/environment.json     matrix factors and the risk -> strength policy
+docs/                       the reasoning
+examples/                   a worked agent-answers file
+testplanner/                one module per pipeline stage
+  platforms.py              where the tests live, what language, factories or not
+  testrail.py               the assumed denominator and its join rules
+tests/                      108 unit tests, no checkout required
 ```

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -1,13 +1,17 @@
-# Fenix Release Test Planner
+# Release Test Planner
 
-**Status: early prototype (v0.0.1). Not wired into anything, not producing
-numbers anyone should act on yet.** It is here so it can be reviewed and poked
-at rather than described in the abstract.
+**Risk-based release test planning, driven by what actually changed.**
 
-Takes a git range, works out which Fenix features the changes touch, checks what
-UI automation exists for those features, scores the risk with FMEA, and produces
-a recommended test run plus the manual-testing gap — with a combinatorial
-configuration matrix sized by risk.
+Takes a git range. Works out which features the changes touch, checks what test
+automation exists for them, scores the release risk with FMEA, and produces a
+recommended test run, the manual-testing gap, and a configuration matrix sized
+by risk.
+
+> **Status: early prototype (v0.0.1).** Wired to Fenix/Android only, on UI tests
+> only. It is here to be reviewed and argued with, not to gate a release. iOS
+> and other platforms follow once the model is proven — the risk scoring and
+> array generation carry no platform knowledge and are designed to move
+> unchanged.
 
 Stdlib Python 3.9+. No install, no dependencies, no API key, no network.
 
@@ -16,33 +20,101 @@ cd release-test-planner
 ./plan.py analyze --repo /path/to/firefox --range "HEAD~300..HEAD" --budget 240 --open
 ```
 
-Or `export FENIX_REPO=/path/to/firefox` and drop the `--repo`.
+---
 
-## Relationship to `test-recommender`
+## Read this first: why this is possible now and wasn't before
 
-They solve adjacent problems from opposite directions, and both should probably
-exist:
+Risk-based test selection is an old idea that mostly doesn't work in practice,
+for two reasons that are rarely stated plainly.
 
-| | `test-recommender` | `release-test-planner` (this) |
+**Selection only matters when supply exceeds budget.** If your release window
+fits 200 tests and your suite has 200 tests, the optimal plan is "run
+everything." Scoring machinery adds nothing.
+
+**A hand-written suite has no denominator.** You cannot claim "60% coverage of
+tabs" when nobody enumerated what 100% would be. The suite isn't a sample of a
+defined space — it's a pile of files that accumulated as people found time.
+Percentages against a pile are theater.
+
+The **test factories** in the Fenix efficiency harness break both constraints.
+They don't write tests; they *enumerate a space* and emit a case per point in
+it. From a model of ~50 page objects and 58 selector catalogs, the current
+candidate space is **3,158 cases** — and it grows superlinearly, because
+registering one new page object adds a reachability case, ~100 pair candidates,
+and one interaction candidate per selector, automatically, discovered by
+reflection.
+
+That is what makes this tool worth building. Supply now genuinely exceeds
+budget, so selection is a real question with a non-obvious answer. And the space
+is *enumerable*, so coverage percentages have a denominator and stop being
+aspirational.
+
+**→ [docs/why-factories.md](docs/why-factories.md) — the full argument, including
+the parts I'm not overselling.**
+
+---
+
+## What it produces
+
+On a sample range of 43 commits touching Fenix:
+
+| | |
+|---|---|
+| Release confidence | **51.1%** of inherent risk removed by the planned run |
+| Recommended run | **73 tests, 2.46 h** — with **244** bound tests skipped as removing no additional risk |
+| Action required | **3** features at RPN ≥ 200 — all three with **zero** UI automation |
+| Across the matrix | **458 executions, 21.7 device-hours**, 8.8x the single-config run |
+| Open questions | **44** typed judgement calls emitted for review |
+
+Plus the diminishing-returns curve a release manager actually needs:
+
+| budget | tests | confidence |
 |---|---|---|
-| platform | Firefox iOS | Fenix / Android |
-| starting point | the TestRail manual catalogue | the code, and the automation that exists |
-| method | LLM-assisted ranking, deterministic fallback | deterministic scoring, LLM only for named judgement calls |
-| output | prioritized Markdown report of tests to run | risk register, selected run, coverage gap, config matrix |
-| risk basis | heuristic signals (hotspots, big PRs, flag flips) | FMEA RPN with churn-derived Occurrence |
+| 15 min | 9 | 29.1% |
+| 45 min | 24 | 43.3% |
+| 240 min | 73 | 51.1% |
 
-The interesting overlap is the risk model. If the scoring here proves out, it
-would slot under `test-recommender` too — `risk.py` and `matrix.py` are
-self-contained and have no Fenix knowledge in them.
+**45 minutes buys 85% of what 147 minutes buys.**
+
+## Two things it found on its first real run
+
+**Coverage was being massively overstated.** The first pass credited Home Screen
+with **502** covering tests. Only **16** actually verify it — the rest import
+`homeScreen` to *navigate somewhere else*. Overstated coverage is more dangerous
+than none: it suppresses the risk score that should have triggered manual
+testing. Bindings are now graded, and pass-through ones count zero.
+
+This also produced the strongest unplanned argument for the efficiency refactor:
+**the legacy suite is not analyzable and the efficiency suite is.** In the legacy
+robot DSL, navigation and verification are the same gesture, so what a test
+covers isn't recoverable from its source. `on.<page>` makes it machine-readable.
+You cannot compute risk-weighted coverage over a suite you cannot parse.
+
+**A new feature was hiding inside "infrastructure."** Answering the
+`assess-change-semantics` question by reading the diffs revealed that 342 of 690
+lines filed under App Infrastructure were a new **Google Lens integration** (bug
+2028573) under `components/lens/`. It is now its own catalog entry, and lands as
+action-required with zero UI coverage — which it genuinely has.
+
+## Docs
+
+| | |
+|---|---|
+| **[why-factories.md](docs/why-factories.md)** | why generated candidates are the precondition for coverage tooling at scale |
+| [risk-model.md](docs/risk-model.md) | FMEA, how each factor is derived, the two decisions with regression tests |
+| [matrix.md](docs/matrix.md) | orthogonal vs covering arrays, verification, risk-tiered allocation |
+| [architecture.md](docs/architecture.md) | pipeline stages, config, the agent seam, how to extend |
 
 ## Run it
 
 ```bash
 ./plan.py analyze --repo ~/src/firefox --range "HEAD~300..HEAD" --budget 240
 ./plan.py analyze --range v146..v147 --answers examples/answers.example.json
-./plan.py serve --live --open          # iterate: refresh re-runs the pipeline
+./plan.py serve --live --open          # iterate: a browser refresh re-runs the pipeline
 python -m unittest discover -s tests -p '*tests.py'
 ```
+
+`export FENIX_REPO=/path/to/firefox` to skip `--repo`.
 
 Outputs land in `out/` (gitignored):
 
@@ -52,151 +124,87 @@ Outputs land in `out/` (gitignored):
 | `report.json` | the full analysis |
 | `agent-tasks.json` | the questions the pipeline refused to answer on its own |
 
-`report.html` prefers a `report.json` sitting next to it and falls back to a
-copy embedded in itself, so the same file works both served and mailed around.
-The header says which it used. Note the CSS/JS are inline, so a host with a
-strict CSP and no `'unsafe-inline'` would render it blank.
+`report.html` prefers a `report.json` next to it and falls back to a copy
+embedded in itself, so the same file works served *and* mailed around. The
+header says which. CSS/JS are inline, so a host with a strict CSP and no
+`'unsafe-inline'` would render it blank.
 
-## Pipeline
+## The pipeline
 
 ```
   git range
       |
-  [1] changes    git log --numstat -> per-file churn        deterministic
-  [2] featuremap path globs -> features                     deterministic + agent for misses
-  [3] corpus     parse androidTest Kotlin -> test inventory deterministic
-  [4] coverage   bind tests to features, score depth        deterministic + agent for weak bindings
-  [5] risk       FMEA: RPN = S x O x D                      deterministic + agent for S and O
-  [6] plan       greedy budgeted selection -> gaps          deterministic + agent for manual cases
-  [7] factories  generated-case candidate space             deterministic
-  [8] matrix     risk-tiered covering arrays                deterministic
-      report     static HTML
+  [1] changes     git log --numstat -> per-file churn          deterministic
+  [2] featuremap  path globs -> features                       + agent for misses
+  [3] corpus      parse androidTest Kotlin -> test inventory   deterministic
+  [4] coverage    bind tests to features, score depth          + agent for weak bindings
+  [5] risk        FMEA: RPN = S x O x D                        + agent for S and O
+  [6] plan        greedy budgeted selection -> gaps            + agent for manual cases
+  [7] factories   generated-case candidate space               deterministic
+  [8] matrix      risk-tiered covering arrays                  deterministic
+      report      static HTML
 ```
 
-## Risk model
+**The pipeline never calls a model.** It runs deterministically and emits typed
+questions for what genuinely needs judgement. Answers feed back as auditable
+overrides, so every AI-influenced number traces to a question, an answer, and a
+rationale. You can always run the whole thing with no AI and get a complete
+answer.
 
-FMEA (IEC 60812), the scheme ISTQB's risk-based testing material builds on:
+## Relationship to `test-recommender`
 
-```
-RPN = Severity x Occurrence x Detection      1 .. 1000
-```
+Adjacent problems from opposite directions; both should exist.
 
-- **Severity** — blast radius if the feature breaks. From `config/features.json`,
-  where every value carries a written rationale (enforced by a test).
-- **Occurrence** — likelihood this cycle's change broke it. Derived from
-  *relative* churn (churned LOC / total LOC), following Nagappan & Ball, *Use of
-  Relative Code Churn Measures to Predict System Defect Density* (ICSE 2005).
-  Modified by change breadth, author count, and backout involvement.
-- **Detection** — likelihood a defect **escapes** to release. Inverted coverage.
-  This is the only factor a test plan can move, which is why FMEA fits the
-  problem at all.
-
-Derived: **Criticality** (S x O, the risk you can only code away, not test away),
-**inherent RPN** (S x O x 10), **residual RPN** after the planned run, and
-**release confidence** = `1 - residual / inherent`. Bands follow conventional
-AIAG practice: 200+ action required, 100+ review.
-
-### Two decisions that are load-bearing
-
-**Detection is a curve, not a lookup table.** A tiered table was tried first and
-was wrong: it made the second test added to a feature worth exactly zero, so the
-greedy planner stalled on the plateau and picked 3 tests out of 769. The
-continuous decay is also the honest shape — the fifth test on a feature really
-does buy less than the first. `test_every_added_test_still_gains_something`
-guards this.
-
-**"Incidental" coverage counts for nothing.** Almost every legacy test imports
-`homeScreen` / `navigationToolbar` in order to *navigate somewhere else*.
-Counting that as coverage credited the Home Screen feature with 502 tests when
-only 16 actually verify it. Overstated coverage is worse than none — it
-suppresses the RPN that should have triggered a manual test.
-
-| binding | meaning | weight |
+| | `test-recommender` | `release-test-planner` (this) |
 |---|---|---|
-| `strong` | class name **and** page object match | 1.0 |
-| `name-only` | class name matches | 0.8 |
-| `incidental` | only passes through the surface | 0.0, and never scheduled |
+| platform | Firefox iOS | Fenix / Android |
+| starts from | the TestRail manual catalogue | the code, and the automation that exists |
+| method | LLM-assisted ranking, deterministic fallback | deterministic scoring, LLM for named judgement calls |
+| output | prioritized Markdown report | risk register, selected run, coverage gap, config matrix |
+| risk basis | heuristic signals | FMEA RPN with churn-derived Occurrence |
 
-Incidental bindings are still recorded and each becomes a question for review.
-
-## The matrix
-
-Two standard reductions of the configuration cross product, both implemented,
-both verified (`matrix.verify()` re-derives every t-tuple, so a generation bug
-fails loudly instead of quietly under-testing):
-
-**Orthogonal array** — every pair of levels appears *exactly* equally often.
-Balance is what lets you attribute an effect to a factor: a design for
-**analysis**. Built with the Rao-Hamming construction; four 3-level factors
-gives the textbook L9. Mixed level counts fall back to the dummy-level
-technique, which the output flags because it breaks the balance that was the
-reason to choose an OA.
-
-**Covering array** — every pair appears *at least* once. Smaller, accepts any
-mix of level counts: a design for **detection**. Built with IPOG, the algorithm
-behind NIST's ACTS.
-
-On the review-band factor set: 96 full factorial, 23 orthogonal, **13 covering**.
-Same pairwise coverage, 43% fewer runs.
-
-Strength is allocated by risk band — 3-way for action-required, 2-way for
-review, one baseline config for acceptable. Uniform 3-way everywhere is how a
-matrix becomes unaffordable. Where an action-required feature has *no*
-automation, its matrix is not a test run at all; it is the manual scope, and the
-report labels it that way.
-
-## The agent seam
-
-The pipeline never calls a model. It runs deterministically and emits typed
-questions for what genuinely needs judgement, each with the evidence attached
-and a schema for the answer:
-
-| task type | the judgement call |
-|---|---|
-| `classify-unmapped-path` | changed code that matched no feature |
-| `assess-change-semantics` | churn cannot tell a rename from a behaviour change |
-| `review-severity` | catalog severity is a static average |
-| `review-weak-binding` | does this test really exercise the feature |
-| `author-manual-tests` | turn residual risk into manual cases |
-
-Answers go in a JSON file (`examples/answers.example.json` is a worked one) and
-are fed back with `--answers`. Every override is recorded in
-`meta.agent_overrides_applied`, so an AI contribution to a risk number always
-traces to a question, an answer, and a rationale.
+The interesting overlap is the risk model. `risk.py` and `matrix.py` are
+self-contained and carry no Fenix knowledge, so they could slot under
+`test-recommender` too — and should, if the scoring proves out.
 
 ## What is real and what is stubbed
 
-Parsed from the tree: git churn, the UI test corpus (629 legacy + 140
-efficiency), 466 selectors, 50 page objects, the behavior capability and
-template catalogs, and the `BrowserMode / Account / DeviceClass / Pocket /
-RecentlyVisited / UnifiedTrustPanel` context factors out of
+**Parsed from the tree:** git churn; the UI test corpus (629 legacy + 140
+efficiency); 466 selectors across 58 catalogs; 50 page objects; the behavior
+capability and template catalogs; and the `BrowserMode / Account / DeviceClass /
+Pocket / RecentlyVisited / UnifiedTrustPanel` context factors read out of
 `BehaviorContextMatrix.kt`.
 
-Stubbed, and labelled as such in both the UI and `config/environment.json`:
-`ApiLevel` values (real minSdk/targetSdk are computed in mach's Python build
-config; the shipping matrix should come from Play Console distribution data),
-`BuildVariant`, `Network`, `Theme`, the `Foldable` device class, per-config cost
-multipliers, and the behavior-factory projection. Feature severities are
-hand-assigned judgement.
+**Stubbed**, and labelled as such in the UI and config: `ApiLevel` values (real
+minSdk/targetSdk are computed in mach's Python build config; the shipping matrix
+should come from Play Console distribution data), `BuildVariant`, `Network`,
+`Theme`, the `Foldable` device class, per-config cost multipliers, and the
+behavior-factory projection. Feature severities are hand-assigned judgement,
+each with a written rationale that a unit test enforces.
+
+**Factory status** is as the in-tree architecture doc states: Reachability is
+production-ready and auto-covers every registered page; Interaction is
+bookmarks-only; Behavior's context matrix is largely unimplemented; Pairs is
+unproven. Candidate counts describe the size of the space the model already
+defines, not runnable tests today.
 
 ## Known limits
 
 - **UI tests only.** Unit, component and service coverage are not modelled, so
-  confidence is *understated* for well-unit-tested code. This is the biggest
-  gap and the next thing worth building.
-- **TestRail is read, not integrated.** The parser picks up TestRail IDs from
-  comments in test files and displays them. It does not query the TestRail API
-  or size manual effort against the case catalogue. Doing that is a next step.
-- **Factory candidates are counted, not selected.** The 3,158 generated-case
-  candidates are attributed to features but do not yet feed the run plan.
+  confidence is *understated* for well-unit-tested code. Closing this is worth
+  more than any refinement of the existing scoring.
+- **TestRail is read, not integrated.** IDs are parsed from test comments and
+  displayed. The API is not queried and manual effort is not sized against the
+  case catalogue.
+- **Factory candidates are counted, not selected.** They are attributed to
+  features but do not yet feed the run plan.
 - Occurrence is churn-only — no cyclomatic complexity, no historical defect
   density to calibrate against.
-- Test cost is a flat per-suite estimate, not measured runtime, and every test
-  is assumed to cost the same in every configuration.
+- Test cost is a flat per-suite estimate, not measured runtime.
 - Flaky tests count as full detection, which is generous.
-- Test-to-feature binding is name and surface matching, not execution tracing.
-- The matrix assumes every test can run in every configuration; real constraints
-  (tablet-only, online-only) need forbidden-tuple support in the generator.
+- Binding is name and surface matching, not execution tracing.
+- The matrix assumes every test runs in every configuration; real constraints
+  need forbidden-tuple support in the generator.
 
 ## Layout
 
@@ -204,6 +212,7 @@ hand-assigned judgement.
 plan.py                  entry point
 config/features.json     feature catalog: severity, source globs, page objects
 config/environment.json  matrix factors and the risk -> strength policy
+docs/                    the reasoning
 examples/                a worked agent-answers file
 testplanner/             one module per pipeline stage
 tests/                   69 unit tests, no checkout required

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -116,6 +116,41 @@ python -m unittest discover -s tests -p '*tests.py'
 
 `export FENIX_REPO=/path/to/firefox` to skip `--repo`.
 
+### Analysing a release branch
+
+`--range` is handed straight to `git log`, so any revision expression works.
+`origin/release..origin/beta` *is* the release candidate — everything in beta
+that has not shipped yet.
+
+**Analyse a branch from a worktree of that branch.** Churn comes from the range,
+but the test corpus comes from the checked-out tree. Point `--repo` at a `main`
+checkout while analysing beta and you score beta's changes against main's tests,
+which silently overstates coverage — on a real beta cycle the two corpora
+differed by 44 tests. The tool detects this and warns, in the terminal and in a
+banner on the report itself, but the fix is to check out the right tree:
+
+```bash
+# one-time: sparse worktree, ~65MB, a couple of seconds
+cd /path/to/firefox
+git worktree add --no-checkout ../firefox-beta origin/beta
+cd ../firefox-beta && git sparse-checkout set mobile/android/fenix && git checkout
+
+# each run
+cd /path/to/firefox && git fetch origin beta release
+cd ../firefox-beta && git checkout origin/beta
+
+cd /path/to/testops-tools/release-test-planner
+./plan.py analyze --repo ../../firefox-beta \
+  --range "origin/release..origin/beta" --budget 480 --out beta-report
+```
+
+Sparse-checkout keeps it to `mobile/android/fenix`, which is all the tool reads.
+A full beta cycle — 477 commits, 924 files, ~107k lines churned — analyses in
+about 30 seconds. `git worktree remove ../firefox-beta` when finished.
+
+Other useful ranges: `origin/beta..origin/main` for what is queued for the next
+merge, and `HEAD~300..HEAD` for a rough nightly cycle.
+
 Outputs land in `out/` (gitignored):
 
 | file | what it is |
@@ -203,6 +238,9 @@ defines, not runnable tests today.
 - Test cost is a flat per-suite estimate, not measured runtime.
 - Flaky tests count as full detection, which is generous.
 - Binding is name and surface matching, not execution tracing.
+- The corpus is read from the checked-out tree, not from the range. Analysing
+  a branch you have not checked out is detected and warned about, but not
+  corrected automatically — see *Analysing a release branch*.
 - The matrix assumes every test runs in every configuration; real constraints
   need forbidden-tuple support in the generator.
 

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -1,0 +1,210 @@
+# Fenix Release Test Planner
+
+**Status: early prototype (v0.0.1). Not wired into anything, not producing
+numbers anyone should act on yet.** It is here so it can be reviewed and poked
+at rather than described in the abstract.
+
+Takes a git range, works out which Fenix features the changes touch, checks what
+UI automation exists for those features, scores the risk with FMEA, and produces
+a recommended test run plus the manual-testing gap — with a combinatorial
+configuration matrix sized by risk.
+
+Stdlib Python 3.9+. No install, no dependencies, no API key, no network.
+
+```bash
+cd release-test-planner
+./plan.py analyze --repo /path/to/firefox --range "HEAD~300..HEAD" --budget 240 --open
+```
+
+Or `export FENIX_REPO=/path/to/firefox` and drop the `--repo`.
+
+## Relationship to `test-recommender`
+
+They solve adjacent problems from opposite directions, and both should probably
+exist:
+
+| | `test-recommender` | `release-test-planner` (this) |
+|---|---|---|
+| platform | Firefox iOS | Fenix / Android |
+| starting point | the TestRail manual catalogue | the code, and the automation that exists |
+| method | LLM-assisted ranking, deterministic fallback | deterministic scoring, LLM only for named judgement calls |
+| output | prioritized Markdown report of tests to run | risk register, selected run, coverage gap, config matrix |
+| risk basis | heuristic signals (hotspots, big PRs, flag flips) | FMEA RPN with churn-derived Occurrence |
+
+The interesting overlap is the risk model. If the scoring here proves out, it
+would slot under `test-recommender` too — `risk.py` and `matrix.py` are
+self-contained and have no Fenix knowledge in them.
+
+## Run it
+
+```bash
+./plan.py analyze --repo ~/src/firefox --range "HEAD~300..HEAD" --budget 240
+./plan.py analyze --range v146..v147 --answers examples/answers.example.json
+./plan.py serve --live --open          # iterate: refresh re-runs the pipeline
+python -m unittest discover -s tests -p '*tests.py'
+```
+
+Outputs land in `out/` (gitignored):
+
+| file | what it is |
+|---|---|
+| `report.html` | self-contained dashboard — no CDN, no webfonts, works from `file://` |
+| `report.json` | the full analysis |
+| `agent-tasks.json` | the questions the pipeline refused to answer on its own |
+
+`report.html` prefers a `report.json` sitting next to it and falls back to a
+copy embedded in itself, so the same file works both served and mailed around.
+The header says which it used. Note the CSS/JS are inline, so a host with a
+strict CSP and no `'unsafe-inline'` would render it blank.
+
+## Pipeline
+
+```
+  git range
+      |
+  [1] changes    git log --numstat -> per-file churn        deterministic
+  [2] featuremap path globs -> features                     deterministic + agent for misses
+  [3] corpus     parse androidTest Kotlin -> test inventory deterministic
+  [4] coverage   bind tests to features, score depth        deterministic + agent for weak bindings
+  [5] risk       FMEA: RPN = S x O x D                      deterministic + agent for S and O
+  [6] plan       greedy budgeted selection -> gaps          deterministic + agent for manual cases
+  [7] factories  generated-case candidate space             deterministic
+  [8] matrix     risk-tiered covering arrays                deterministic
+      report     static HTML
+```
+
+## Risk model
+
+FMEA (IEC 60812), the scheme ISTQB's risk-based testing material builds on:
+
+```
+RPN = Severity x Occurrence x Detection      1 .. 1000
+```
+
+- **Severity** — blast radius if the feature breaks. From `config/features.json`,
+  where every value carries a written rationale (enforced by a test).
+- **Occurrence** — likelihood this cycle's change broke it. Derived from
+  *relative* churn (churned LOC / total LOC), following Nagappan & Ball, *Use of
+  Relative Code Churn Measures to Predict System Defect Density* (ICSE 2005).
+  Modified by change breadth, author count, and backout involvement.
+- **Detection** — likelihood a defect **escapes** to release. Inverted coverage.
+  This is the only factor a test plan can move, which is why FMEA fits the
+  problem at all.
+
+Derived: **Criticality** (S x O, the risk you can only code away, not test away),
+**inherent RPN** (S x O x 10), **residual RPN** after the planned run, and
+**release confidence** = `1 - residual / inherent`. Bands follow conventional
+AIAG practice: 200+ action required, 100+ review.
+
+### Two decisions that are load-bearing
+
+**Detection is a curve, not a lookup table.** A tiered table was tried first and
+was wrong: it made the second test added to a feature worth exactly zero, so the
+greedy planner stalled on the plateau and picked 3 tests out of 769. The
+continuous decay is also the honest shape — the fifth test on a feature really
+does buy less than the first. `test_every_added_test_still_gains_something`
+guards this.
+
+**"Incidental" coverage counts for nothing.** Almost every legacy test imports
+`homeScreen` / `navigationToolbar` in order to *navigate somewhere else*.
+Counting that as coverage credited the Home Screen feature with 502 tests when
+only 16 actually verify it. Overstated coverage is worse than none — it
+suppresses the RPN that should have triggered a manual test.
+
+| binding | meaning | weight |
+|---|---|---|
+| `strong` | class name **and** page object match | 1.0 |
+| `name-only` | class name matches | 0.8 |
+| `incidental` | only passes through the surface | 0.0, and never scheduled |
+
+Incidental bindings are still recorded and each becomes a question for review.
+
+## The matrix
+
+Two standard reductions of the configuration cross product, both implemented,
+both verified (`matrix.verify()` re-derives every t-tuple, so a generation bug
+fails loudly instead of quietly under-testing):
+
+**Orthogonal array** — every pair of levels appears *exactly* equally often.
+Balance is what lets you attribute an effect to a factor: a design for
+**analysis**. Built with the Rao-Hamming construction; four 3-level factors
+gives the textbook L9. Mixed level counts fall back to the dummy-level
+technique, which the output flags because it breaks the balance that was the
+reason to choose an OA.
+
+**Covering array** — every pair appears *at least* once. Smaller, accepts any
+mix of level counts: a design for **detection**. Built with IPOG, the algorithm
+behind NIST's ACTS.
+
+On the review-band factor set: 96 full factorial, 23 orthogonal, **13 covering**.
+Same pairwise coverage, 43% fewer runs.
+
+Strength is allocated by risk band — 3-way for action-required, 2-way for
+review, one baseline config for acceptable. Uniform 3-way everywhere is how a
+matrix becomes unaffordable. Where an action-required feature has *no*
+automation, its matrix is not a test run at all; it is the manual scope, and the
+report labels it that way.
+
+## The agent seam
+
+The pipeline never calls a model. It runs deterministically and emits typed
+questions for what genuinely needs judgement, each with the evidence attached
+and a schema for the answer:
+
+| task type | the judgement call |
+|---|---|
+| `classify-unmapped-path` | changed code that matched no feature |
+| `assess-change-semantics` | churn cannot tell a rename from a behaviour change |
+| `review-severity` | catalog severity is a static average |
+| `review-weak-binding` | does this test really exercise the feature |
+| `author-manual-tests` | turn residual risk into manual cases |
+
+Answers go in a JSON file (`examples/answers.example.json` is a worked one) and
+are fed back with `--answers`. Every override is recorded in
+`meta.agent_overrides_applied`, so an AI contribution to a risk number always
+traces to a question, an answer, and a rationale.
+
+## What is real and what is stubbed
+
+Parsed from the tree: git churn, the UI test corpus (629 legacy + 140
+efficiency), 466 selectors, 50 page objects, the behavior capability and
+template catalogs, and the `BrowserMode / Account / DeviceClass / Pocket /
+RecentlyVisited / UnifiedTrustPanel` context factors out of
+`BehaviorContextMatrix.kt`.
+
+Stubbed, and labelled as such in both the UI and `config/environment.json`:
+`ApiLevel` values (real minSdk/targetSdk are computed in mach's Python build
+config; the shipping matrix should come from Play Console distribution data),
+`BuildVariant`, `Network`, `Theme`, the `Foldable` device class, per-config cost
+multipliers, and the behavior-factory projection. Feature severities are
+hand-assigned judgement.
+
+## Known limits
+
+- **UI tests only.** Unit, component and service coverage are not modelled, so
+  confidence is *understated* for well-unit-tested code. This is the biggest
+  gap and the next thing worth building.
+- **TestRail is read, not integrated.** The parser picks up TestRail IDs from
+  comments in test files and displays them. It does not query the TestRail API
+  or size manual effort against the case catalogue. Doing that is a next step.
+- **Factory candidates are counted, not selected.** The 3,158 generated-case
+  candidates are attributed to features but do not yet feed the run plan.
+- Occurrence is churn-only — no cyclomatic complexity, no historical defect
+  density to calibrate against.
+- Test cost is a flat per-suite estimate, not measured runtime, and every test
+  is assumed to cost the same in every configuration.
+- Flaky tests count as full detection, which is generous.
+- Test-to-feature binding is name and surface matching, not execution tracing.
+- The matrix assumes every test can run in every configuration; real constraints
+  (tablet-only, online-only) need forbidden-tuple support in the generator.
+
+## Layout
+
+```
+plan.py                  entry point
+config/features.json     feature catalog: severity, source globs, page objects
+config/environment.json  matrix factors and the risk -> strength policy
+examples/                a worked agent-answers file
+testplanner/             one module per pipeline stage
+tests/                   69 unit tests, no checkout required
+```

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -84,7 +84,7 @@ bugs were once found, thin where nobody wrote cases. So the number is reported a
 **how much of the plan we wrote down will a machine run?** The remainder is the
 manual-testing gap, which is the number a release manager actually needs.
 
-Two rules keep it honest:
+Three rules keep it honest:
 
 - **A case automated only by a test that never runs is manual.** Same rule the
   corpus applies to `@Ignore` and xctestplan skips. On firefox-ios this is not a
@@ -92,12 +92,64 @@ Two rules keep it honest:
   test that no test plan runs.
 - **A referenced id absent from the export is reported, not counted.** A test
   pointing at another project's case would otherwise inflate the ratio.
+- **Cases triaged `Unsuitable` leave the denominator.** They are deliberately
+  manual forever, so counting them as an automation gap makes the gap
+  unshrinkable and the ratio meaningless.
+
+### Which export to ask TestRail for
+
+Two exports, two different jobs, and the tool merges several by case id because
+neither is sufficient alone:
+
+| | a **run** export | a **case/suite** export |
+|---|---|---|
+| e.g. | `full_functional_153.3_rc_1.csv` | `firefox_for_ios.csv` |
+| cases | only what that run selected (737) | the whole suite (1,779) |
+| has | `Section`, `Section Depth`, `Status`, `Priority` | `Automation`, `Automation Coverage`, `Automated Test Name(s)` |
+| gives | feature attribution, and what was actually executed | the real denominator, and TestRail's own triage |
+| overlap with automation | 35 of 440 ids | **417 of 440** |
+
+```bash
+./plan.py analyze --platform ios --repo ~/Workspace/firefox-ios \
+  --range "HEAD~120..HEAD" \
+  --testrail-export firefox_for_ios.csv full_functional_153.3_rc_1.csv
+```
+
+**A run export alone is the wrong denominator** and the tool now says so instead
+of printing the number. A run is a *manual* plan: the automated tests reference
+case ids that mostly are not in it, so the ratio comes out at 3.4% and means
+nothing. Where overlap is under half, the report leads with the warning.
+
+**Watch the id column.** A run export has both `ID` (the test-instance id,
+`T9474971`) and `Case ID` (`C2306813`). Only the case id appears in the source
+tree. The loader prefers case-id spellings for exactly this reason — reading `ID`
+joins nothing and reports 0–3% automated with no error at all.
 
 Accepted formats are JSON (the raw `get_cases` API response, or a bare list) and
 CSV (what the TestRail UI exports). Not xlsx — that needs a dependency this tool
 deliberately does not have, and
 `testrail/testcases-deduplication/fetch_testrail_export.py` can be pointed at the
-API response instead.
+API response instead. Rows whose columns have shifted (rich text in a case field
+pushes CSS fragments into the automation column) are detected by shape and not
+trusted.
+
+### What it said about Firefox iOS on release/v153.3
+
+| | |
+|---|---|
+| cases in the merged export | 1,775 |
+| automated by a test that actually runs | **308 (17.3%)** |
+| …of the 1,440 *addressable* cases | **21.4%** |
+| triaged manual forever (`Unsuitable`) | 335 |
+| triaged automatable, not yet done | 26 |
+| never triaged either way | 1,001 |
+| triaged automated but no test links to them | 22 |
+| linked by a test but not triaged as automated | 26 |
+| in the 153.3 RC1 run, left untested | 244 of 737 |
+
+The 1,001 untriaged cases are the largest number on that list, and they are the
+reason the automation ratio is hard to act on: over half the suite has no
+decision recorded about whether it *should* be automated.
 
 ## Read this first: why this is possible now and wasn't before
 
@@ -372,5 +424,5 @@ examples/                   a worked agent-answers file
 testplanner/                one module per pipeline stage
   platforms.py              where the tests live, what language, factories or not
   testrail.py               the assumed denominator and its join rules
-tests/                      108 unit tests, no checkout required
+tests/                      121 unit tests, no checkout required
 ```

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -308,22 +308,38 @@ merge, and `HEAD~300..HEAD` for a rough nightly cycle.
 
 #### On iOS
 
-firefox-ios is its own repository, so there is no sparse-checkout to do and no
-pathspec to scope — but two things differ:
+firefox-ios is its own repository, so there is no pathspec to scope. Release
+branches are `release/vNNN.N` — the bare `vNNN.N` names stop at v105 and predate
+the layout move, so their paths will not match the catalog.
 
 ```bash
-# release branches are release/vNNN.N. The bare vNNN.N branches stop at v105
-# and predate the layout move, so their paths will not match the catalog.
+# clone the release branch you want to report on, so the corpus IS that branch
 git clone --single-branch --branch release/v153.3 --depth 400 \
   https://github.com/mozilla-mobile/firefox-ios ~/Workspace/firefox-ios
 
+# the previous release, to diff against. --single-branch sets a narrow refspec,
+# so a bare `git fetch origin release/v153.2` silently creates no ref.
+cd ~/Workspace/firefox-ios
+git fetch --depth 400 origin \
+  release/v153.2:refs/remotes/origin/release/v153.2
+
+cd /path/to/testops-tools/release-test-planner
 ./plan.py analyze --platform ios --repo ~/Workspace/firefox-ios \
-  --range "HEAD~120..HEAD" --budget 240 --testrail-export cases.json --open
+  --range "origin/release/v153.2..release/v153.3" --budget 240 \
+  --testrail-export ~/Workspace/firefox_for_ios.csv \
+  --out out/ios-v153.3 --open
 ```
 
-Depth matters: churn is computed by diffing the range, so a `--depth 1` clone
-gives an empty analysis. For the uplift delta between two release branches,
-fetch both and use `release/v153.2..release/v153.3`.
+That is 83 commits, 878 files and ~23k churned lines for 153.2 → 153.3, and runs
+in about 16 seconds.
+
+Depth matters twice: churn is computed by diffing the range, so a `--depth 1`
+clone gives an empty analysis, and both branches need enough history for a merge
+base to exist. `--depth 400` is comfortable for a dot release; deepen for a
+whole cycle.
+
+Simpler ranges also work — `HEAD~120..HEAD` for a rough window on the branch you
+have checked out.
 
 The checkout also contains **focus-ios**, a separate product, and
 `SampleComponentLibraryApp`. Both are in the iOS catalog's `_ignored_globs`; a

--- a/release-test-planner/README.md
+++ b/release-test-planner/README.md
@@ -246,6 +246,31 @@ python -m unittest discover -s tests -p '*tests.py'
 
 `export FENIX_REPO=/path/to/firefox` to skip `--repo`.
 
+### Checking a change did not move the other platform
+
+Unit tests say the pieces behave; they cannot say "the Android report is still
+the report it was". `tests/ab_check.py` runs the pipeline at two revisions over
+the same range and compares the *decisions* — risk, selection and order, matrix,
+gaps — tolerating additive fields and failing on changed values. It uses git
+worktrees, so your working tree is untouched.
+
+```bash
+# did the iOS port change the Android analysis? (~10s)
+tests/ab_check.py --before 94ad20f --repo ~/Workspace/firefox --range "HEAD~300..HEAD"
+```
+
+```
+new top-level keys: ['testrail']
+meta        added ['has_factories', 'platform', ...]   changed none
+changes     identical: True
+attribution identical: True
+risk        identical: True
+matrix      identical: True
+plan        selected  same tests, same order: True (73)
+plan        redundant same tests, same order: True (244)
+SAME - every decision matches; differences are additive only.
+```
+
 ### Analysing a release branch
 
 `--range` is handed straight to `git log`, so any revision expression works.
@@ -425,4 +450,5 @@ testplanner/                one module per pipeline stage
   platforms.py              where the tests live, what language, factories or not
   testrail.py               the assumed denominator and its join rules
 tests/                      121 unit tests, no checkout required
+  ab_check.py               prove a change did not alter the other platform's report
 ```

--- a/release-test-planner/config/environment.json
+++ b/release-test-planner/config/environment.json
@@ -1,0 +1,69 @@
+{
+  "_comment": "Execution-environment factors for the combinatorial test matrix, plus the policy that decides how much of the matrix each risk band earns. Factors marked source='real' are parsed out of BehaviorContextMatrix.kt in the tree; those marked 'stubbed' are plausible placeholders for the PoC.",
+
+  "_stub_note": "Real minSdk/targetSdk are computed in mach's Python build config rather than declared in the gradle files, and the device pool would come from Firebase Test Lab / the Autophone config. Both are stubbed here.",
+
+  "infrastructure_factors": [
+    {
+      "name": "ApiLevel",
+      "levels": ["23", "28", "33", "36"],
+      "source": "stubbed",
+      "origin": "Placeholder. Real values live in mach build config; the shipping matrix should come from the Play Console API-level distribution.",
+      "rationale": "Android behaviour changes at API boundaries (scoped storage at 29, notification permission at 33, foreground service types at 34) break features asymmetrically."
+    },
+    {
+      "name": "DeviceClass",
+      "levels": ["Phone", "Tablet", "Foldable"],
+      "source": "partly-real",
+      "origin": "Phone and Tablet are real levels in BehaviorContextMatrix.kt; Foldable is a stub.",
+      "rationale": "Layout and navigation diverge by form factor; tablets use a different toolbar and tabs-tray presentation."
+    },
+    {
+      "name": "BuildVariant",
+      "levels": ["Nightly", "Beta", "Release"],
+      "source": "stubbed",
+      "origin": "Placeholder for the real product flavors.",
+      "rationale": "Secret settings, debug menus and some Nimbus defaults differ by variant, so a Nightly-only pass can miss a Release-only path."
+    },
+    {
+      "name": "Network",
+      "levels": ["Online", "Offline"],
+      "source": "stubbed",
+      "origin": "Placeholder.",
+      "rationale": "Offline paths are a common source of unhandled states in downloads, sync and search."
+    },
+    {
+      "name": "Theme",
+      "levels": ["Light", "Dark"],
+      "source": "stubbed",
+      "origin": "Placeholder.",
+      "rationale": "Cheap to vary and catches contrast and drawable-tint regressions."
+    }
+  ],
+
+  "_allocation_comment": "How much matrix a feature earns is a function of its FMEA band. Spending 3-way coverage on an acceptable-band feature is how a test matrix becomes unaffordable; spending only the default config on an action-required feature is how a release ships broken.",
+
+  "allocation_policy": {
+    "action-required": {
+      "strength": 3,
+      "factors": ["ApiLevel", "DeviceClass", "BrowserMode", "Account", "BuildVariant", "Network", "Theme"],
+      "rationale": "High severity and high churn. 3-way catches interaction faults that pairwise provably cannot, and the empirical fault-detection literature puts 3-way in the 90%+ range."
+    },
+    "review": {
+      "strength": 2,
+      "factors": ["ApiLevel", "DeviceClass", "BrowserMode", "Account", "Theme"],
+      "rationale": "Pairwise. Most reported combinatorial faults are 2-way, so this is the standard value-for-money point."
+    },
+    "acceptable": {
+      "strength": 0,
+      "factors": ["ApiLevel", "DeviceClass"],
+      "rationale": "Baseline configuration only. Enough to notice a total break, not enough to characterise it. Strength 0 means one representative config rather than a combinatorial array."
+    }
+  },
+
+  "_cost_comment": "Device-minutes multipliers, stubbed. Real numbers would come from Firebase Test Lab billing or Treeherder task durations.",
+  "config_cost_multiplier": {
+    "DeviceClass": { "Phone": 1.0, "Tablet": 1.3, "Foldable": 1.6 },
+    "Network": { "Online": 1.0, "Offline": 1.15 }
+  }
+}

--- a/release-test-planner/config/features-ios.json
+++ b/release-test-planner/config/features-ios.json
@@ -71,6 +71,26 @@
         "DomainAutocompleteTests",
         "CopiedLinksTests",
         "ClipBoardTests"
+      ],
+      "testrail_keywords": [
+        "load bar",
+        "website view",
+        "pdf",
+        "web page",
+        "page load",
+        "reload",
+        "external link",
+        "open link",
+        "deeplink",
+        "deep link",
+        "url bar",
+        "address bar",
+        "navigation",
+        "progress bar",
+        "context menu",
+        "long press link",
+        "zoom",
+        "print"
       ]
     },
     {
@@ -100,6 +120,18 @@
         "NewTabSettingsTest",
         "StoryTests",
         "A11yHomePageTests"
+      ],
+      "testrail_keywords": [
+        "homepage",
+        "home page",
+        "stories",
+        "jump back in",
+        "recently visited",
+        "top site",
+        "shortcut on homepage",
+        "customize homepage",
+        "pocket",
+        "wallpaper"
       ]
     },
     {
@@ -126,6 +158,17 @@
         "ThirdPartySearchTest",
         "FirefoxSuggestTest",
         "A11ySearchTest"
+      ],
+      "testrail_keywords": [
+        "search engine",
+        "suggestion",
+        "sponsored suggestion",
+        "firefox suggest",
+        "awesomebar",
+        "quick search",
+        "search bar",
+        "search widget",
+        "autocomplete"
       ]
     },
     {
@@ -156,6 +199,18 @@
         "A11yTabTrayTests",
         "TabsTestsIpad",
         "TabsTestsIphone"
+      ],
+      "testrail_keywords": [
+        "tab tray",
+        "top tabs",
+        "tab counter",
+        "new tab",
+        "private tab",
+        "inactive tab",
+        "tab group",
+        "close tab",
+        "undo close",
+        "tab bar"
       ]
     },
     {
@@ -180,6 +235,12 @@
         "PrivateBrowsingTest",
         "PrivateBrowsingTestIpad",
         "PrivateBrowsingTestIphone"
+      ],
+      "testrail_keywords": [
+        "private browsing",
+        "private mode",
+        "private tab",
+        "incognito"
       ]
     },
     {
@@ -202,6 +263,15 @@
       "test_patterns": [
         "TrackingProtectionTests",
         "SecurityTests"
+      ],
+      "testrail_keywords": [
+        "etp",
+        "tracking protection",
+        "content blocking",
+        "shield",
+        "cookie protection",
+        "total cookie protection",
+        "trackers"
       ]
     },
     {
@@ -222,6 +292,11 @@
       ],
       "test_patterns": [
         "DownloadsTests"
+      ],
+      "testrail_keywords": [
+        "download",
+        "downloaded file",
+        "download manager"
       ]
     },
     {
@@ -243,6 +318,11 @@
       "test_patterns": [
         "BookmarksTests",
         "LibraryTests"
+      ],
+      "testrail_keywords": [
+        "bookmark",
+        "bookmark folder",
+        "reading list bookmark"
       ]
     },
     {
@@ -263,6 +343,12 @@
       ],
       "test_patterns": [
         "HistoryTests"
+      ],
+      "testrail_keywords": [
+        "history",
+        "recently closed",
+        "clear history",
+        "browsing history"
       ]
     },
     {
@@ -286,6 +372,16 @@
       "test_patterns": [
         "LoginTest",
         "AuthenticationTest"
+      ],
+      "testrail_keywords": [
+        "password",
+        "login",
+        "credential",
+        "password generator",
+        "autofill password",
+        "face id",
+        "touch id",
+        "passcode"
       ]
     },
     {
@@ -308,6 +404,13 @@
         "CreditCardsTests",
         "AddressesTests",
         "O_AddressesTests"
+      ],
+      "testrail_keywords": [
+        "credit card",
+        "address autofill",
+        "autofill address",
+        "saved card",
+        "payment method"
       ]
     },
     {
@@ -330,6 +433,13 @@
       ],
       "test_patterns": [
         "DataManagementTests"
+      ],
+      "testrail_keywords": [
+        "clear private data",
+        "data management",
+        "website data",
+        "delete browsing data",
+        "clear cookies"
       ]
     },
     {
@@ -355,6 +465,16 @@
         "PhotonActionSheetTests",
         "ToolbarMenuTests",
         "ShareMenuTests"
+      ],
+      "testrail_keywords": [
+        "main menu",
+        "hamburger",
+        "menu option",
+        "photon",
+        "action sheet",
+        "homepage menu",
+        "browser menu",
+        "more menu"
       ]
     },
     {
@@ -376,6 +496,14 @@
       "test_patterns": [
         "ToolbarTests",
         "ShareToolbarTests"
+      ],
+      "testrail_keywords": [
+        "toolbar",
+        "url toolbar",
+        "top placement",
+        "bottom placement",
+        "tab toolbar",
+        "navigation toolbar"
       ]
     },
     {
@@ -401,6 +529,16 @@
         "ModernKitOnboardingTests",
         "ModernOrangeAndBlueOnboardingTests",
         "A11yOnboardingTests"
+      ],
+      "testrail_keywords": [
+        "onboarding",
+        "first run",
+        "intro",
+        "default browser card",
+        "set as default browser",
+        "welcome",
+        "upgrade card",
+        "tour"
       ]
     },
     {
@@ -419,6 +557,12 @@
       "page_objects": [],
       "test_patterns": [
         "PerformanceTests"
+      ],
+      "testrail_keywords": [
+        "startup",
+        "launch time",
+        "performance",
+        "cold start"
       ]
     },
     {
@@ -435,7 +579,12 @@
         "firefox-ios/Client/Frontend/Settings/**/CrashReport*/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "crash",
+        "crash report",
+        "sentry"
+      ]
     },
     {
       "id": "sync",
@@ -466,6 +615,18 @@
         "IntegrationTests",
         "PairingTests",
         "DatabaseFixtureTest"
+      ],
+      "testrail_keywords": [
+        "sync",
+        "firefox account",
+        "fxa",
+        "account management",
+        "desktop app",
+        "pairing",
+        "signed in",
+        "sign in",
+        "send tab",
+        "synced tab"
       ]
     },
     {
@@ -487,6 +648,12 @@
         "ShareLongPressTests",
         "ShareToolbarTests",
         "PrintTests"
+      ],
+      "testrail_keywords": [
+        "share",
+        "share sheet",
+        "share extension",
+        "send to device"
       ]
     },
     {
@@ -508,6 +675,14 @@
       ],
       "test_patterns": [
         "TodayWidgetTests"
+      ],
+      "testrail_keywords": [
+        "widget",
+        "today widget",
+        "home screen shortcut",
+        "add to home screen",
+        "siri",
+        "shortcut"
       ]
     },
     {
@@ -523,7 +698,12 @@
         "firefox-ios/Client/Frontend/GoogleLens/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "lens",
+        "google lens",
+        "visual search"
+      ]
     },
     {
       "id": "reader-view",
@@ -542,6 +722,11 @@
       ],
       "test_patterns": [
         "ReadingListTests"
+      ],
+      "testrail_keywords": [
+        "reader view",
+        "reading list",
+        "reader mode"
       ]
     },
     {
@@ -560,6 +745,10 @@
       ],
       "test_patterns": [
         "FindInPageTests"
+      ],
+      "testrail_keywords": [
+        "find in page",
+        "find on page"
       ]
     },
     {
@@ -575,7 +764,11 @@
         "firefox-ios/Client/Frontend/Translations/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "translation",
+        "translate"
+      ]
     },
     {
       "id": "summarization",
@@ -596,7 +789,14 @@
       "page_objects": [
         "SummarizeSettings"
       ],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "summarize",
+        "summarization",
+        "summary",
+        "quick answer",
+        "shake to summarize"
+      ]
     },
     {
       "id": "messaging-nimbus",
@@ -619,6 +819,16 @@
       "test_patterns": [
         "FeatureFlaggedTestSuite",
         "EngagementNotificationTests"
+      ],
+      "testrail_keywords": [
+        "nimbus",
+        "experiment",
+        "messaging",
+        "notification surface",
+        "re-engagement",
+        "reengagement",
+        "feature flag",
+        "microsurvey card"
       ]
     },
     {
@@ -636,7 +846,16 @@
         "firefox-ios/SyncTelemetry/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "telemetry",
+        "glean",
+        "dau",
+        "ping",
+        "data collection",
+        "usage data",
+        "studies"
+      ]
     },
     {
       "id": "accessibility",
@@ -658,6 +877,13 @@
         "A11ySearchTest",
         "A11ySettingsTests",
         "A11yTabTrayTests"
+      ],
+      "testrail_keywords": [
+        "accessibility",
+        "voiceover",
+        "dynamic type",
+        "a11y",
+        "screen reader"
       ]
     },
     {
@@ -674,7 +900,14 @@
         "firefox-ios/Client/Frontend/TabContentsScripts/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "autoplay",
+        "video",
+        "media",
+        "picture in picture",
+        "audio"
+      ]
     },
     {
       "id": "notifications",
@@ -693,6 +926,11 @@
       ],
       "test_patterns": [
         "EngagementNotificationTests"
+      ],
+      "testrail_keywords": [
+        "notification",
+        "push notification",
+        "engagement notification"
       ]
     },
     {
@@ -714,6 +952,15 @@
       "test_patterns": [
         "DisplaySettingTests",
         "NightModeTests"
+      ],
+      "testrail_keywords": [
+        "dark mode",
+        "light mode",
+        "theme",
+        "app icon",
+        "appearance",
+        "night mode",
+        "display setting"
       ]
     },
     {
@@ -729,7 +976,12 @@
         "BrowserKit/Sources/WebCompatReporterKit/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "web compat",
+        "report broken site",
+        "webcompat"
+      ]
     },
     {
       "id": "microsurvey",
@@ -745,7 +997,13 @@
         "firefox-ios/Client/RatingPromptManager.swift"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "microsurvey",
+        "survey",
+        "review prompt",
+        "rating prompt"
+      ]
     },
     {
       "id": "desktop-mode",
@@ -766,6 +1024,12 @@
       "test_patterns": [
         "DesktopModeTestsIpad",
         "DesktopModeTestsIphone"
+      ],
+      "testrail_keywords": [
+        "desktop site",
+        "desktop mode",
+        "request desktop",
+        "mobile site"
       ]
     },
     {
@@ -782,6 +1046,13 @@
       "page_objects": [],
       "test_patterns": [
         "AuthenticationTest"
+      ],
+      "testrail_keywords": [
+        "authentication",
+        "face id",
+        "touch id",
+        "passcode",
+        "biometric"
       ]
     },
     {
@@ -796,7 +1067,11 @@
         "firefox-ios/Client/Frontend/Wayback/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "wayback",
+        "archive"
+      ]
     },
     {
       "id": "contextual-hints",
@@ -810,7 +1085,12 @@
         "firefox-ios/Client/Frontend/ContextualHint/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "contextual hint",
+        "tooltip",
+        "cfr"
+      ]
     },
     {
       "id": "settings-general",
@@ -832,6 +1112,13 @@
       "test_patterns": [
         "SettingsTests",
         "A11ySettingsTests"
+      ],
+      "testrail_keywords": [
+        "setting",
+        "preference",
+        "about firefox",
+        "mail app",
+        "siri shortcut"
       ]
     },
     {
@@ -863,6 +1150,16 @@
       "test_patterns": [
         "ScreenGraphTest",
         "FxScreenGraphTests"
+      ],
+      "testrail_keywords": [
+        "keyboard shortcut",
+        "ipad",
+        "multitasking",
+        "split view",
+        "stage manager",
+        "screen graph",
+        "state restoration",
+        "memory"
       ]
     },
     {
@@ -903,6 +1200,13 @@
       "page_objects": [],
       "test_patterns": [
         "L10nSnapshotTests"
+      ],
+      "testrail_keywords": [
+        "localization",
+        "locale",
+        "language",
+        "rtl",
+        "translation string"
       ]
     },
     {
@@ -919,7 +1223,13 @@
         "firefox-ios/Client/Frontend/Settings/**/TermsOfService*/**"
       ],
       "page_objects": [],
-      "test_patterns": []
+      "test_patterns": [],
+      "testrail_keywords": [
+        "terms of use",
+        "tos",
+        "privacy notice",
+        "distribution"
+      ]
     }
   ]
 }

--- a/release-test-planner/config/features-ios.json
+++ b/release-test-planner/config/features-ios.json
@@ -1,0 +1,925 @@
+{
+  "_comment": "Feature catalog for Firefox iOS. Each entry binds a user-facing feature to (a) the production source it lives in, (b) the MappaMundi navigator screens that drive it, and (c) XCUITest class name patterns. Feature ids match config/features.json wherever the same feature exists on Android, so the two platforms' reports are comparable; iOS-only features are marked in their rationale. Severity is the FMEA S factor, 1-10, judged on blast radius if the feature breaks in a release build - it describes user impact, not platform, so it carries over from the Android catalog unchanged where the feature does.",
+  "_platform": "ios",
+  "_severity_scale": {
+    "10": "Silent data loss, privacy/security leak, or app unusable. Ships = chemspill.",
+    "9": "Core journey broken or trust boundary weakened. Ships = dot release.",
+    "8": "Major feature broken for all users.",
+    "7": "Feature broken, workaround exists.",
+    "6": "Degraded but usable.",
+    "5": "Visible defect, no functional loss.",
+    "4": "Cosmetic or narrow-audience defect.",
+    "3": "Trivial.",
+    "2": "Barely observable.",
+    "1": "Invisible to users."
+  },
+  "_source_root": "firefox-ios/Client",
+  "_ignored_globs": [
+    "**/firefox-ios-tests/**",
+    "**/BrowserKit/Tests/**",
+    "**/*Tests/**",
+    "**/*Test.swift",
+    "**/*Tests.swift",
+    "**/XCUITests/**",
+    "**/Assets/**",
+    "**/*.xcassets/**",
+    "**/docs/**",
+    "**/*.md",
+    ".github/**",
+    "**/Dangerfile.swift",
+    "bitrise.yml",
+    "**/*.yml",
+    "package-lock.json",
+    "**/latest_acorn_release.json",
+    "**/sync_acorn_icons.py",
+    "focus-ios/**",
+    "SampleComponentLibraryApp/**",
+    "**/Package.resolved",
+    "version.txt",
+    "**/*.xcodeproj/**"
+  ],
+  "_layout_note": "Paths follow the current firefox-ios layout (release/v106 onwards), where the app lives under firefox-ios/ and the shared Swift packages under BrowserKit/. Release branches named vNNN.N without the release/ prefix predate that move and are flat; these globs will not match them.",
+  "features": [
+    {
+      "id": "browser-core",
+      "name": "Core Browsing & Navigation",
+      "severity": 10,
+      "severity_rationale": "Every session passes through it; a break makes the app unusable.",
+      "iso25010": [
+        "functional_suitability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Browser/**",
+        "firefox-ios/Client/Coordinators/**",
+        "firefox-ios/Client/Frontend/InternalSchemeHandler/**",
+        "firefox-ios/Client/Frontend/NativeErrorPage/**",
+        "BrowserKit/Sources/WebEngine/**"
+      ],
+      "page_objects": [
+        "BrowserTab",
+        "URLBarOpen",
+        "NewTabScreen"
+      ],
+      "test_patterns": [
+        "NavigationTest",
+        "SiteLoadTest",
+        "URLValidationTests",
+        "UrlBarTests",
+        "OpeningScreenTests",
+        "BrowsingPDFTests",
+        "DomainAutocompleteTests",
+        "CopiedLinksTests",
+        "ClipBoardTests"
+      ]
+    },
+    {
+      "id": "home",
+      "name": "Home Screen",
+      "severity": 9,
+      "severity_rationale": "First screen of every launch; a break is immediately visible to everyone.",
+      "iso25010": [
+        "functional_suitability",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Home/**",
+        "firefox-ios/Client/Frontend/StoriesFeed/**"
+      ],
+      "page_objects": [
+        "HomePanelsScreen",
+        "NewTabScreen",
+        "HomeSettings",
+        "NewTabSettings"
+      ],
+      "test_patterns": [
+        "ActivityStreamTest",
+        "JumpBackInTests",
+        "HomeButtonTests",
+        "HomePageSettingsUITests",
+        "NewTabSettingsTest",
+        "StoryTests",
+        "A11yHomePageTests"
+      ]
+    },
+    {
+      "id": "search",
+      "name": "Search & Suggestions",
+      "severity": 9,
+      "severity_rationale": "Primary entry point for navigation; breakage blocks the core journey.",
+      "iso25010": [
+        "functional_suitability",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Browser/SearchViewController/**",
+        "firefox-ios/Client/Frontend/Browser/Search/**",
+        "BrowserKit/Sources/UnifiedSearchKit/**"
+      ],
+      "page_objects": [
+        "SearchSettings",
+        "URLBarOpen"
+      ],
+      "test_patterns": [
+        "SearchTests",
+        "SearchSettingsUITests",
+        "ThirdPartySearchTest",
+        "FirefoxSuggestTest",
+        "A11ySearchTest"
+      ]
+    },
+    {
+      "id": "tabs",
+      "name": "Tabs & Tab Tray",
+      "severity": 9,
+      "severity_rationale": "Tab loss is data loss from the user's point of view.",
+      "iso25010": [
+        "functional_suitability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Browser/TabManagement/**",
+        "firefox-ios/Client/Frontend/Browser/Tabs/**",
+        "BrowserKit/Sources/TabDataStore/**",
+        "firefox-ios/Client/TabManagement/**"
+      ],
+      "page_objects": [
+        "TabTray",
+        "CloseTabMenu"
+      ],
+      "test_patterns": [
+        "TabsTests",
+        "TabCounterTests",
+        "SwipingTabsTests",
+        "MultiWindowTests",
+        "DragAndDropTest",
+        "A11yTabTrayTests",
+        "TabsTestsIpad",
+        "TabsTestsIphone"
+      ]
+    },
+    {
+      "id": "private-browsing",
+      "name": "Private Browsing",
+      "severity": 10,
+      "severity_rationale": "A leak between private and normal sessions is a privacy incident.",
+      "iso25010": [
+        "security",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/FeltPrivacy/**",
+        "firefox-ios/Client/PrivacyWindowHelper.swift",
+        "firefox-ios/Client/PrivacyNoticeHelper.swift"
+      ],
+      "page_objects": [
+        "NewTabScreen",
+        "TabTray"
+      ],
+      "test_patterns": [
+        "PrivateBrowsingTest",
+        "PrivateBrowsingTestIpad",
+        "PrivateBrowsingTestIphone"
+      ]
+    },
+    {
+      "id": "tracking-protection",
+      "name": "Enhanced Tracking Protection",
+      "severity": 10,
+      "severity_rationale": "The product's central privacy promise; silent failure is a trust breach.",
+      "iso25010": [
+        "security",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/TrackingProtection/**",
+        "firefox-ios/Client/ContentBlocker/**",
+        "BrowserKit/Sources/ContentBlockingGenerator/**"
+      ],
+      "page_objects": [
+        "TrackingProtectionSettings"
+      ],
+      "test_patterns": [
+        "TrackingProtectionTests",
+        "SecurityTests"
+      ]
+    },
+    {
+      "id": "downloads",
+      "name": "Downloads",
+      "severity": 8,
+      "severity_rationale": "A failed download loses user data with no recovery path.",
+      "iso25010": [
+        "functional_suitability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Library/Downloads/**",
+        "firefox-ios/Client/Frontend/Browser/DownloadQueue.swift"
+      ],
+      "page_objects": [
+        "LibraryPanel_Downloads"
+      ],
+      "test_patterns": [
+        "DownloadsTests"
+      ]
+    },
+    {
+      "id": "bookmarks",
+      "name": "Bookmarks",
+      "severity": 7,
+      "severity_rationale": "User-created data; corruption is unrecoverable but the journey survives.",
+      "iso25010": [
+        "functional_suitability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Library/Bookmarks/**"
+      ],
+      "page_objects": [
+        "LibraryPanel_Bookmarks",
+        "HomePanel_Library"
+      ],
+      "test_patterns": [
+        "BookmarksTests",
+        "LibraryTests"
+      ]
+    },
+    {
+      "id": "history",
+      "name": "History",
+      "severity": 7,
+      "severity_rationale": "User data, and the surface most affected by deletion bugs.",
+      "iso25010": [
+        "functional_suitability",
+        "security"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Library/History/**"
+      ],
+      "page_objects": [
+        "LibraryPanel_History",
+        "HistoryRecentlyClosed"
+      ],
+      "test_patterns": [
+        "HistoryTests"
+      ]
+    },
+    {
+      "id": "logins-passwords",
+      "name": "Logins & Passwords",
+      "severity": 9,
+      "severity_rationale": "Credential loss or exposure is the highest-consequence data class in the app.",
+      "iso25010": [
+        "security",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/PasswordManagement/**",
+        "firefox-ios/Client/Frontend/PasswordGenerator/**",
+        "firefox-ios/CredentialProvider/**"
+      ],
+      "page_objects": [
+        "LoginsSettings",
+        "AutofillPasswordSettings"
+      ],
+      "test_patterns": [
+        "LoginTest",
+        "AuthenticationTest"
+      ]
+    },
+    {
+      "id": "autofill",
+      "name": "Address & Credit Card Autofill",
+      "severity": 8,
+      "severity_rationale": "Handles payment and identity data; wrong values are worse than none.",
+      "iso25010": [
+        "security",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Autofill/**"
+      ],
+      "page_objects": [
+        "CreditCardsSettings",
+        "AddressesSettings"
+      ],
+      "test_patterns": [
+        "CreditCardsTests",
+        "AddressesTests",
+        "O_AddressesTests"
+      ]
+    },
+    {
+      "id": "delete-browsing-data",
+      "name": "Delete Browsing Data",
+      "severity": 8,
+      "severity_rationale": "If deletion silently fails the user believes data is gone when it is not.",
+      "iso25010": [
+        "security",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Settings/Clearables.swift",
+        "firefox-ios/Client/Frontend/Settings/ClearPrivateData*/**",
+        "firefox-ios/Client/Frontend/Settings/DataManagement/**"
+      ],
+      "page_objects": [
+        "ClearPrivateDataSettings",
+        "WebsiteDataSettings"
+      ],
+      "test_patterns": [
+        "DataManagementTests"
+      ]
+    },
+    {
+      "id": "main-menu",
+      "name": "Main Menu & Action Sheets",
+      "severity": 7,
+      "severity_rationale": "Gateway to most features; a break hides them all without breaking them.",
+      "iso25010": [
+        "usability",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "BrowserKit/Sources/MenuKit/**",
+        "firefox-ios/Client/Frontend/Browser/MainMenu/**"
+      ],
+      "page_objects": [
+        "BrowserTabMenu",
+        "BrowserTabMenuMore",
+        "SaveBrowserTabMenu",
+        "ReloadLongPressMenu"
+      ],
+      "test_patterns": [
+        "PhotonActionSheetTests",
+        "ToolbarMenuTests",
+        "ShareMenuTests"
+      ]
+    },
+    {
+      "id": "toolbar",
+      "name": "Toolbar",
+      "severity": 8,
+      "severity_rationale": "Always on screen and the control surface for navigation. iOS-specific feature: the toolbar is its own package here.",
+      "iso25010": [
+        "usability",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "BrowserKit/Sources/ToolbarKit/**",
+        "firefox-ios/Client/Frontend/TabToolbar/**"
+      ],
+      "page_objects": [
+        "ToolbarSettings"
+      ],
+      "test_patterns": [
+        "ToolbarTests",
+        "ShareToolbarTests"
+      ]
+    },
+    {
+      "id": "onboarding",
+      "name": "Onboarding",
+      "severity": 8,
+      "severity_rationale": "First impression for every new install and the hardest thing to hotfix.",
+      "iso25010": [
+        "usability",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Onboarding/**",
+        "firefox-ios/Client/Frontend/DefaultBrowserOnboarding/**",
+        "BrowserKit/Sources/OnboardingKit/**",
+        "firefox-ios/Client/IntroScreenManager.swift"
+      ],
+      "page_objects": [
+        "Intro_FxASignin"
+      ],
+      "test_patterns": [
+        "LegacyOnboardingTests",
+        "ModernKitOnboardingTests",
+        "ModernOrangeAndBlueOnboardingTests",
+        "A11yOnboardingTests"
+      ]
+    },
+    {
+      "id": "startup-perf",
+      "name": "Startup & Performance",
+      "severity": 9,
+      "severity_rationale": "Regressions here affect every user on every launch and rarely trip functional tests.",
+      "iso25010": [
+        "performance_efficiency",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Application/**",
+        "firefox-ios/Client/AppDelegate*.swift"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "PerformanceTests"
+      ]
+    },
+    {
+      "id": "crash-reporting",
+      "name": "Crash Reporting",
+      "severity": 9,
+      "severity_rationale": "If this breaks, every other failure becomes invisible.",
+      "iso25010": [
+        "reliability",
+        "maintainability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/CrashTracker.swift",
+        "firefox-ios/Client/Frontend/Settings/**/CrashReport*/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "sync",
+      "name": "Firefox Account & Sync",
+      "severity": 7,
+      "severity_rationale": "Cross-device data movement; failures can duplicate or drop records.",
+      "iso25010": [
+        "functional_suitability",
+        "compatibility"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Settings/SearchBarSettings/**",
+        "firefox-ios/RustFxA/**",
+        "firefox-ios/FxA/**",
+        "firefox-ios/Storage/**",
+        "firefox-ios/Sync/**",
+        "firefox-ios/Account/**",
+        "firefox-ios/Storage/**",
+        "firefox-ios/RustFxA/**",
+        "firefox-ios/FxA/**"
+      ],
+      "page_objects": [
+        "FxASigninScreen",
+        "Intro_FxASignin"
+      ],
+      "test_patterns": [
+        "SyncUITests",
+        "IntegrationTests",
+        "PairingTests",
+        "DatabaseFixtureTest"
+      ]
+    },
+    {
+      "id": "share",
+      "name": "Share",
+      "severity": 6,
+      "severity_rationale": "Frequently used but failures are visible and recoverable.",
+      "iso25010": [
+        "functional_suitability",
+        "compatibility"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Share/**",
+        "firefox-ios/Extensions/**"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "ShareMenuTests",
+        "ShareLongPressTests",
+        "ShareToolbarTests",
+        "PrintTests"
+      ]
+    },
+    {
+      "id": "pwa-shortcuts",
+      "name": "Shortcuts & Widgets",
+      "severity": 6,
+      "severity_rationale": "Entry points outside the app; breakage is confusing but non-blocking.",
+      "iso25010": [
+        "compatibility",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/ShortcutsLibrary/**",
+        "firefox-ios/Client/Frontend/Widgets/**",
+        "firefox-ios/WidgetKit/**"
+      ],
+      "page_objects": [
+        "Shortcuts"
+      ],
+      "test_patterns": [
+        "TodayWidgetTests"
+      ]
+    },
+    {
+      "id": "lens",
+      "name": "Google Lens Integration",
+      "severity": 7,
+      "severity_rationale": "Third-party integration with camera and network permissions attached.",
+      "iso25010": [
+        "functional_suitability",
+        "security"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/GoogleLens/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "reader-view",
+      "name": "Reader View & Reading List",
+      "severity": 5,
+      "severity_rationale": "Optional reading surface; failure degrades rather than blocks.",
+      "iso25010": [
+        "functional_suitability",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Reader/**"
+      ],
+      "page_objects": [
+        "LibraryPanel_ReadingList"
+      ],
+      "test_patterns": [
+        "ReadingListTests"
+      ]
+    },
+    {
+      "id": "find-in-page",
+      "name": "Find in Page",
+      "severity": 5,
+      "severity_rationale": "Self-contained; failure is obvious and has an easy workaround.",
+      "iso25010": [
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Browser/FindInPage/**"
+      ],
+      "page_objects": [
+        "FindInPage"
+      ],
+      "test_patterns": [
+        "FindInPageTests"
+      ]
+    },
+    {
+      "id": "translations",
+      "name": "Translations",
+      "severity": 5,
+      "severity_rationale": "Newer surface, opt-in, degrades to untranslated content.",
+      "iso25010": [
+        "functional_suitability",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Translations/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "summarization",
+      "name": "Page Summarization & Quick Answers",
+      "severity": 4,
+      "severity_rationale": "New, opt-in, and clearly attributable when wrong.",
+      "iso25010": [
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Summarizer/**",
+        "firefox-ios/Client/Frontend/QuickAnswers/**",
+        "BrowserKit/Sources/SummarizeKit/**",
+        "BrowserKit/Sources/QuickAnswersKit/**",
+        "BrowserKit/Sources/LLMKit/**",
+        "BrowserKit/Sources/MLPAKit/**"
+      ],
+      "page_objects": [
+        "SummarizeSettings"
+      ],
+      "test_patterns": []
+    },
+    {
+      "id": "messaging-nimbus",
+      "name": "Nimbus Experiments & Messaging",
+      "severity": 6,
+      "severity_rationale": "Can change behaviour for a cohort after ship, so a bug is remotely triggerable.",
+      "iso25010": [
+        "reliability",
+        "maintainability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Experiments/**",
+        "firefox-ios/Client/Nimbus/**",
+        "firefox-ios/Client/FeatureFlags/**",
+        "firefox-ios/Client/Frontend/NotificationSurface/**",
+        "firefox-ios/nimbus-features/**",
+        "firefox-ios/nimbus.fml.yaml"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "FeatureFlaggedTestSuite",
+        "EngagementNotificationTests"
+      ]
+    },
+    {
+      "id": "telemetry",
+      "name": "Telemetry & Data Collection",
+      "severity": 5,
+      "severity_rationale": "Data-quality and compliance risk rather than user-visible breakage.",
+      "iso25010": [
+        "compliance",
+        "maintainability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Glean/**",
+        "firefox-ios/Client/Telemetry/**",
+        "firefox-ios/SyncTelemetry/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "accessibility",
+      "name": "Accessibility",
+      "severity": 7,
+      "severity_rationale": "A regression locks out users who have no workaround at all.",
+      "iso25010": [
+        "usability",
+        "compliance"
+      ],
+      "source_globs": [
+        "BrowserKit/Sources/Common/Extensions/**",
+        "firefox-ios/Client/Frontend/Settings/**/Accessibility*/**"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "A11yHomePageTests",
+        "A11yOnboardingTests",
+        "A11ySearchTest",
+        "A11ySettingsTests",
+        "A11yTabTrayTests"
+      ]
+    },
+    {
+      "id": "media",
+      "name": "Media Playback & Autoplay",
+      "severity": 6,
+      "severity_rationale": "Playback failures are highly visible; autoplay policy is a privacy setting.",
+      "iso25010": [
+        "functional_suitability",
+        "security"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/AutoplayAccessors.swift",
+        "firefox-ios/Client/Frontend/TabContentsScripts/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "notifications",
+      "name": "Push & Notifications",
+      "severity": 5,
+      "severity_rationale": "Out-of-app surface; failures are annoying rather than blocking.",
+      "iso25010": [
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/NotificationManager.swift",
+        "firefox-ios/Push/**"
+      ],
+      "page_objects": [
+        "NotificationsSettings"
+      ],
+      "test_patterns": [
+        "EngagementNotificationTests"
+      ]
+    },
+    {
+      "id": "theme-customization",
+      "name": "Theming & Display",
+      "severity": 4,
+      "severity_rationale": "Cosmetic, but a broken dark mode is visible to everyone using it.",
+      "iso25010": [
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Theme/**",
+        "BrowserKit/Sources/ComponentLibrary/**"
+      ],
+      "page_objects": [
+        "DisplaySettings",
+        "PageZoom"
+      ],
+      "test_patterns": [
+        "DisplaySettingTests",
+        "NightModeTests"
+      ]
+    },
+    {
+      "id": "webcompat",
+      "name": "Web Compat Reporter",
+      "severity": 4,
+      "severity_rationale": "Reporting channel; breakage costs signal, not user function.",
+      "iso25010": [
+        "maintainability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/WebCompatReporter/**",
+        "BrowserKit/Sources/WebCompatReporterKit/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "microsurvey",
+      "name": "Microsurveys & Review Prompt",
+      "severity": 3,
+      "severity_rationale": "Low blast radius, but shows up unprompted so a bug is very visible.",
+      "iso25010": [
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Microsurvey/**",
+        "firefox-ios/Client/Frontend/SurveySurface/**",
+        "firefox-ios/Client/RatingPromptManager.swift"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "desktop-mode",
+      "name": "Desktop Mode",
+      "severity": 6,
+      "severity_rationale": "Changes the rendered page for the whole session; iOS-specific surface with its own tests.",
+      "iso25010": [
+        "compatibility",
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Browser/**UserAgent**"
+      ],
+      "page_objects": [
+        "RequestDesktopSite",
+        "RequestMobileSite"
+      ],
+      "test_patterns": [
+        "DesktopModeTestsIpad",
+        "DesktopModeTestsIphone"
+      ]
+    },
+    {
+      "id": "authentication",
+      "name": "Device Authentication",
+      "severity": 9,
+      "severity_rationale": "Guards passwords and private tabs behind Face ID / passcode. iOS-specific feature.",
+      "iso25010": [
+        "security"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/AuthenticationManager/**"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "AuthenticationTest"
+      ]
+    },
+    {
+      "id": "wayback",
+      "name": "Wayback Machine",
+      "severity": 4,
+      "severity_rationale": "Narrow recovery feature for dead pages. iOS-specific.",
+      "iso25010": [
+        "functional_suitability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Wayback/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "contextual-hints",
+      "name": "Contextual Hints",
+      "severity": 4,
+      "severity_rationale": "Overlays on top of working features; a stuck hint can block interaction.",
+      "iso25010": [
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/ContextualHint/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "settings-general",
+      "name": "Settings (General & Shell)",
+      "severity": 7,
+      "severity_rationale": "Every preference the user has set flows through it.",
+      "iso25010": [
+        "functional_suitability",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Frontend/Settings/**"
+      ],
+      "page_objects": [
+        "SettingsScreen",
+        "BrowsingSettings",
+        "MailAppSettings"
+      ],
+      "test_patterns": [
+        "SettingsTests",
+        "A11ySettingsTests"
+      ]
+    },
+    {
+      "id": "app-infrastructure",
+      "name": "App Infrastructure & Components",
+      "severity": 8,
+      "severity_rationale": "Shared foundations: a defect here surfaces as unrelated failures elsewhere.",
+      "iso25010": [
+        "maintainability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/Redux/**",
+        "BrowserKit/Sources/Redux/**",
+        "BrowserKit/Sources/Common/**",
+        "BrowserKit/Sources/Shared/**",
+        "firefox-ios/Client/Helpers/**",
+        "firefox-ios/Client/Protocols/**",
+        "firefox-ios/Client/Utils/**",
+        "MozillaRustComponents/**",
+        "firefox-ios/Client/BookmarkItemsHelper.swift",
+        "firefox-ios/Shared/**",
+        "firefox-ios/Providers/**",
+        "firefox-ios/Client/Extensions/**",
+        "BrowserKit/Sources/SiteImageView/**",
+        "firefox-ios/Client/UserNotificationCenterProtocol.swift"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "ScreenGraphTest",
+        "FxScreenGraphTests"
+      ]
+    },
+    {
+      "id": "build-config",
+      "name": "Build, Project & Entitlements",
+      "severity": 8,
+      "severity_rationale": "A signing or capability mistake can make a build unshippable or unlaunchable.",
+      "iso25010": [
+        "portability",
+        "reliability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client.xcodeproj/**",
+        "firefox-ios/Client/Configuration/**",
+        "firefox-ios/Client/Entitlements/**",
+        "firefox-ios/Client/Info.plist",
+        "*.xcconfig",
+        "Package.swift",
+        "**/Package.swift"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    },
+    {
+      "id": "localization",
+      "name": "Strings & Localization",
+      "severity": 3,
+      "severity_rationale": "Wide but shallow: a bad string is visible everywhere and fixes cheaply.",
+      "iso25010": [
+        "usability",
+        "compliance"
+      ],
+      "source_globs": [
+        "**/*.lproj/**",
+        "firefox-ios/Shared/Strings.swift",
+        "BrowserKit/Sources/Shared/Strings*.swift"
+      ],
+      "page_objects": [],
+      "test_patterns": [
+        "L10nSnapshotTests"
+      ]
+    },
+    {
+      "id": "terms-distribution",
+      "name": "Terms of Use & Distribution",
+      "severity": 5,
+      "severity_rationale": "Legal-consent surface: wrong behaviour here is a compliance problem rather than a functional one.",
+      "iso25010": [
+        "compliance",
+        "usability"
+      ],
+      "source_globs": [
+        "firefox-ios/Client/TermsOfServiceManager.swift",
+        "firefox-ios/Client/Frontend/Settings/**/TermsOfService*/**"
+      ],
+      "page_objects": [],
+      "test_patterns": []
+    }
+  ]
+}

--- a/release-test-planner/config/features.json
+++ b/release-test-planner/config/features.json
@@ -1,0 +1,463 @@
+{
+  "_comment": "Feature catalog for the Fenix release test planner PoC. Each entry binds a user-facing feature to (a) the production source it lives in, (b) the efficiency-framework page objects that drive it, and (c) test class name patterns. Severity is the FMEA S factor, 1-10, judged on blast radius if the feature breaks in a release build.",
+  "_severity_scale": {
+    "10": "Silent data loss, privacy/security leak, or app unusable. Ships = chemspill.",
+    "9": "Core journey broken or trust boundary weakened. Ships = dot release.",
+    "8": "Major feature broken for all users of it. Highly visible.",
+    "7": "Major feature degraded, or broken on a common path.",
+    "6": "Secondary feature broken. Noticeable, has workarounds.",
+    "5": "Secondary feature degraded.",
+    "4": "Cosmetic or low-traffic surface.",
+    "3": "Peripheral / opt-in surface.",
+    "2": "Internal or debug-only surface.",
+    "1": "No user-visible impact."
+  },
+  "_source_root": "mobile/android/fenix/app/src/main/java/org/mozilla/fenix",
+
+  "features": [
+    {
+      "id": "browser-core",
+      "name": "Core Browsing & Navigation",
+      "severity": 10,
+      "severity_rationale": "Every session passes through it; a break makes the app unusable.",
+      "iso25010": ["functional_suitability", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/browser/**", "**/org/mozilla/fenix/session/**", "**/org/mozilla/fenix/intent/**"],
+      "page_objects": ["browserPage", "toolbar"],
+      "test_patterns": ["BrowserTest", "NavigationToolbar", "DeepLink", "AboutURI", "BrowsingErrorPages"]
+    },
+    {
+      "id": "home",
+      "name": "Home Screen",
+      "severity": 9,
+      "severity_rationale": "First surface on every cold start; breakage blocks all entry points.",
+      "iso25010": ["functional_suitability", "usability"],
+      "source_globs": ["**/org/mozilla/fenix/home/**", "**/org/mozilla/fenix/historymetadata/**"],
+      "page_objects": ["home"],
+      "test_patterns": ["HomeScreen", "HomeTest", "Pocket", "SponsoredShortcuts"]
+    },
+    {
+      "id": "search",
+      "name": "Search & Suggestions",
+      "severity": 9,
+      "severity_rationale": "Primary navigation mechanism and a revenue surface.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/search/**"],
+      "page_objects": ["searchBar", "settingsSearch", "settingsSearchDefaultSearchEngine"],
+      "test_patterns": ["SearchTest", "SettingsSearch", "FirefoxSuggest"]
+    },
+    {
+      "id": "tabs",
+      "name": "Tabs & Tabs Tray",
+      "severity": 9,
+      "severity_rationale": "Session state lives here; failures can lose user tabs.",
+      "iso25010": ["functional_suitability", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/tabstray/**", "**/org/mozilla/fenix/tabgroups/**", "**/org/mozilla/fenix/tabhistory/**"],
+      "page_objects": ["tabDrawer", "tabHistory", "settingsTabs"],
+      "test_patterns": ["TabbedBrowsing", "TabsTray", "SettingsTabs", "RecentlyClosedTabs"]
+    },
+    {
+      "id": "private-browsing",
+      "name": "Private Browsing & PBM Lock",
+      "severity": 10,
+      "severity_rationale": "Trust boundary. A leak of private state is a privacy incident.",
+      "iso25010": ["security", "functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/pbmlock/**", "**/org/mozilla/fenix/biometricauthentication/**"],
+      "page_objects": ["settingsPrivateBrowsing"],
+      "test_patterns": ["PrivateBrowsing", "SettingsPrivateBrowsing"]
+    },
+    {
+      "id": "tracking-protection",
+      "name": "Enhanced Tracking Protection",
+      "severity": 10,
+      "severity_rationale": "Core brand promise and a security control; silent failure is worst case.",
+      "iso25010": ["security"],
+      "source_globs": ["**/org/mozilla/fenix/trackingprotection/**"],
+      "page_objects": ["settingsEnhancedTrackingProtection", "settingsEnhancedTrackingProtectionExceptions", "unifiedTrustPanel"],
+      "test_patterns": ["EnhancedTrackingProtection", "TrackingProtection", "GlobalPrivacyControl"]
+    },
+    {
+      "id": "ip-protection",
+      "name": "IP Protection / VPN",
+      "severity": 9,
+      "severity_rationale": "Security feature where silent failure misleads users about their protection.",
+      "iso25010": ["security"],
+      "source_globs": ["**/org/mozilla/fenix/ipprotection/**"],
+      "page_objects": [],
+      "test_patterns": ["IPProtection", "Vpn"]
+    },
+    {
+      "id": "downloads",
+      "name": "Downloads",
+      "severity": 8,
+      "severity_rationale": "Touches storage and permissions; failures can lose user files.",
+      "iso25010": ["functional_suitability", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/downloads/**"],
+      "page_objects": ["downloads"],
+      "test_patterns": ["Download"]
+    },
+    {
+      "id": "bookmarks",
+      "name": "Bookmarks",
+      "severity": 7,
+      "severity_rationale": "User-generated data; corruption is unrecoverable without sync.",
+      "iso25010": ["functional_suitability", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/bookmarks/**", "**/org/mozilla/fenix/library/bookmarks/**"],
+      "page_objects": ["bookmarks", "bookmarkSearch"],
+      "test_patterns": ["Bookmark"]
+    },
+    {
+      "id": "history",
+      "name": "History",
+      "severity": 7,
+      "severity_rationale": "User data plus a privacy surface when deletion fails.",
+      "iso25010": ["functional_suitability", "security"],
+      "source_globs": ["**/org/mozilla/fenix/library/history/**"],
+      "page_objects": ["history"],
+      "test_patterns": ["HistoryTest"]
+    },
+    {
+      "id": "logins-passwords",
+      "name": "Logins & Passwords",
+      "severity": 9,
+      "severity_rationale": "Credential store. Data loss or exposure is a security incident.",
+      "iso25010": ["security", "functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/settings/logins/**", "**/org/mozilla/fenix/settings/biometric/**"],
+      "page_objects": ["settingsPasswords", "settingsSavePasswords", "settingsSavedPasswords"],
+      "test_patterns": ["Logins", "Password"]
+    },
+    {
+      "id": "autofill",
+      "name": "Address & Credit Card Autofill",
+      "severity": 8,
+      "severity_rationale": "Stores PII and payment data; incorrect fill can leak between fields.",
+      "iso25010": ["security", "functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/autofill/**", "**/org/mozilla/fenix/settings/address/**", "**/org/mozilla/fenix/settings/creditcards/**"],
+      "page_objects": ["settingsAutofill"],
+      "test_patterns": ["AddressAutofill", "CreditCardAutofill", "Autofill"]
+    },
+    {
+      "id": "delete-browsing-data",
+      "name": "Delete Browsing Data",
+      "severity": 8,
+      "severity_rationale": "Privacy control. Failing to actually delete is a trust violation.",
+      "iso25010": ["security"],
+      "source_globs": ["**/org/mozilla/fenix/settings/deletebrowsingdata/**"],
+      "page_objects": ["settingsDeleteBrowsingData", "settingsDeleteBrowsingDataOnQuit"],
+      "test_patterns": ["DeleteBrowsingData"]
+    },
+    {
+      "id": "site-permissions",
+      "name": "Site Permissions",
+      "severity": 8,
+      "severity_rationale": "Gates camera, mic and location. Over-granting is a security bug.",
+      "iso25010": ["security"],
+      "source_globs": ["**/org/mozilla/fenix/settings/sitepermissions/**"],
+      "page_objects": ["settingsSiteSettings", "settingsSiteSettingsExceptions"],
+      "test_patterns": ["SitePermissions", "SiteSettings"]
+    },
+    {
+      "id": "https-only",
+      "name": "HTTPS-Only Mode",
+      "severity": 8,
+      "severity_rationale": "Transport security control; silent downgrade is a security bug.",
+      "iso25010": ["security"],
+      "source_globs": ["**/org/mozilla/fenix/settings/HttpsOnly**"],
+      "page_objects": ["settingsHTTPSOnlyMode"],
+      "test_patterns": ["HTTPSOnly"]
+    },
+    {
+      "id": "custom-tabs",
+      "name": "Custom Tabs",
+      "severity": 7,
+      "severity_rationale": "Third-party app integration surface; breakage affects external partners.",
+      "iso25010": ["functional_suitability", "compatibility"],
+      "source_globs": ["**/org/mozilla/fenix/customtabs/**"],
+      "page_objects": ["customTabs"],
+      "test_patterns": ["CustomTabs"]
+    },
+    {
+      "id": "main-menu",
+      "name": "Main Menu",
+      "severity": 7,
+      "severity_rationale": "Entry point to most secondary features; breakage blocks many journeys.",
+      "iso25010": ["functional_suitability", "usability"],
+      "source_globs": ["**/org/mozilla/fenix/components/menu/**"],
+      "page_objects": ["mainMenu"],
+      "test_patterns": ["MainMenu"]
+    },
+    {
+      "id": "onboarding",
+      "name": "Onboarding",
+      "severity": 8,
+      "severity_rationale": "Every new user sees it; a break damages activation and is highly visible.",
+      "iso25010": ["usability", "functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/onboarding/**"],
+      "page_objects": ["onboarding"],
+      "test_patterns": ["Onboarding"]
+    },
+    {
+      "id": "startup-perf",
+      "name": "Startup & Performance",
+      "severity": 9,
+      "severity_rationale": "Startup regressions affect 100% of sessions and are release blockers.",
+      "iso25010": ["performance_efficiency", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/perf/**", "**/org/mozilla/fenix/splashscreen/**", "**/org/mozilla/fenix/lifecycle/**"],
+      "page_objects": [],
+      "test_patterns": ["Startup", "NoNetworkAccess"]
+    },
+    {
+      "id": "crash-reporting",
+      "name": "Crash Reporting",
+      "severity": 9,
+      "severity_rationale": "Loss of crash telemetry blinds the release team during the cycle.",
+      "iso25010": ["reliability", "maintainability"],
+      "source_globs": ["**/org/mozilla/fenix/crashes/**", "**/org/mozilla/fenix/startupCrash/**"],
+      "page_objects": [],
+      "test_patterns": ["CrashReporting"]
+    },
+    {
+      "id": "sync",
+      "name": "Firefox Account & Sync",
+      "severity": 7,
+      "severity_rationale": "Cross-device data movement; failures can duplicate or drop records.",
+      "iso25010": ["functional_suitability", "reliability"],
+      "source_globs": ["**/org/mozilla/fenix/sync/**"],
+      "page_objects": ["settingsTurnOnSync"],
+      "test_patterns": ["Sync", "TurnOnSync"]
+    },
+    {
+      "id": "addons-extensions",
+      "name": "Add-ons & Extensions",
+      "severity": 6,
+      "severity_rationale": "Opt-in surface, but broken add-ons draw loud community feedback.",
+      "iso25010": ["functional_suitability", "compatibility"],
+      "source_globs": ["**/org/mozilla/fenix/addons/**", "**/org/mozilla/fenix/extension/**"],
+      "page_objects": ["settingsAddonsManager"],
+      "test_patterns": ["Addons", "Extension"]
+    },
+    {
+      "id": "share",
+      "name": "Share",
+      "severity": 6,
+      "severity_rationale": "Common outbound action; integrates with the system share sheet.",
+      "iso25010": ["functional_suitability", "compatibility"],
+      "source_globs": ["**/org/mozilla/fenix/share/**"],
+      "page_objects": ["shareOverlay"],
+      "test_patterns": ["ShareTest", "Share"]
+    },
+    {
+      "id": "pwa-shortcuts",
+      "name": "PWAs & Home Screen Shortcuts",
+      "severity": 6,
+      "severity_rationale": "Installed shortcuts persist on the device; breakage is sticky.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/shortcut/**", "**/org/mozilla/fenix/widget/**"],
+      "page_objects": ["addToHomescreen", "shortcuts"],
+      "test_patterns": ["Pwa", "Shortcut", "AddToHomeScreen"]
+    },
+    {
+      "id": "lens",
+      "name": "Google Lens Integration",
+      "severity": 7,
+      "severity_rationale": "New entry flow that takes camera permission; a failure is both a broken feature and a permissions surface.",
+      "iso25010": ["functional_suitability", "security"],
+      "source_globs": ["**/org/mozilla/fenix/components/lens/**", "**/LensCameraActivity*"],
+      "page_objects": [],
+      "test_patterns": ["Lens"]
+    },
+    {
+      "id": "collections",
+      "name": "Collections",
+      "severity": 5,
+      "severity_rationale": "User-generated grouping; lower traffic than bookmarks.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/collections/**"],
+      "page_objects": ["collections"],
+      "test_patterns": ["Collection"]
+    },
+    {
+      "id": "reader-view",
+      "name": "Reader View",
+      "severity": 5,
+      "severity_rationale": "Secondary reading surface with an accessibility dimension.",
+      "iso25010": ["functional_suitability", "usability"],
+      "source_globs": ["**/org/mozilla/fenix/readermode/**"],
+      "page_objects": ["readerView"],
+      "test_patterns": ["ReaderView"]
+    },
+    {
+      "id": "find-in-page",
+      "name": "Find in Page",
+      "severity": 5,
+      "severity_rationale": "Self-contained utility; failure is contained to the feature.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/findinpage/**"],
+      "page_objects": ["findInPage"],
+      "test_patterns": ["FindInPage"]
+    },
+    {
+      "id": "translations",
+      "name": "Translations",
+      "severity": 5,
+      "severity_rationale": "Newer opt-in feature; incorrect translation is visible but non-destructive.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/translations/**"],
+      "page_objects": [],
+      "test_patterns": ["Translation"]
+    },
+    {
+      "id": "messaging-nimbus",
+      "name": "Nimbus Experiments & Messaging",
+      "severity": 6,
+      "severity_rationale": "Controls rollout of everything else; a break can mis-target experiments.",
+      "iso25010": ["functional_suitability", "maintainability"],
+      "source_globs": ["**/org/mozilla/fenix/messaging/**", "**/org/mozilla/fenix/nimbus/**", "**/org/mozilla/fenix/experiments/**", "mobile/android/fenix/app/nimbus.fml.yaml", "mobile/android/fenix/app/.experimenter.yaml", "**/res/raw/initial_experiments.json"],
+      "page_objects": ["settingsExperiments"],
+      "test_patterns": ["Nimbus", "Messaging"]
+    },
+    {
+      "id": "telemetry",
+      "name": "Telemetry & Data Collection",
+      "severity": 5,
+      "severity_rationale": "Data quality issue rather than user-facing, but blinds decision making.",
+      "iso25010": ["maintainability", "security"],
+      "source_globs": ["**/org/mozilla/fenix/telemetry/**", "**/org/mozilla/fenix/components/metrics/**", "mobile/android/fenix/app/metrics.yaml", "mobile/android/fenix/app/pings.yaml"],
+      "page_objects": ["settingsDataCollection"],
+      "test_patterns": ["Telemetry", "DataCollection", "Glean"]
+    },
+    {
+      "id": "accessibility",
+      "name": "Accessibility",
+      "severity": 7,
+      "severity_rationale": "Regressions here exclude users entirely and carry compliance risk.",
+      "iso25010": ["usability", "compatibility"],
+      "source_globs": ["**/org/mozilla/fenix/settings/accessibility/**"],
+      "page_objects": ["settingsAccessibility"],
+      "test_patterns": ["Accessibility"]
+    },
+    {
+      "id": "media",
+      "name": "Media Playback & Notifications",
+      "severity": 6,
+      "severity_rationale": "Background playback and notification controls; visible when broken.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/media/**"],
+      "page_objects": [],
+      "test_patterns": ["MediaNotification"]
+    },
+    {
+      "id": "notifications",
+      "name": "Push & Notifications",
+      "severity": 5,
+      "severity_rationale": "Delivery surface for re-engagement; failures are silent.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/push/**"],
+      "page_objects": ["notification"],
+      "test_patterns": ["Notification"]
+    },
+    {
+      "id": "theme-customization",
+      "name": "Theming, Wallpapers & App Icon",
+      "severity": 4,
+      "severity_rationale": "Largely cosmetic; contained blast radius.",
+      "iso25010": ["usability"],
+      "source_globs": ["**/org/mozilla/fenix/theme/**", "**/org/mozilla/fenix/wallpapers/**", "**/org/mozilla/fenix/iconpicker/**"],
+      "page_objects": ["settingsCustomize", "settingsAppIcon"],
+      "test_patterns": ["Customize", "Wallpaper", "AppIcon"]
+    },
+    {
+      "id": "webcompat",
+      "name": "Web Compat Reporter",
+      "severity": 4,
+      "severity_rationale": "Reporting utility; failure does not affect browsing.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/webcompat/**"],
+      "page_objects": ["webCompatReporter"],
+      "test_patterns": ["WebCompat"]
+    },
+    {
+      "id": "microsurvey",
+      "name": "Microsurveys & Review Prompt",
+      "severity": 3,
+      "severity_rationale": "Peripheral prompt surface; worst case is an annoying dialog.",
+      "iso25010": ["usability"],
+      "source_globs": ["**/org/mozilla/fenix/microsurvey/**", "**/org/mozilla/fenix/reviewprompt/**"],
+      "page_objects": ["microsurveys"],
+      "test_patterns": ["Microsurvey", "ReviewPrompt"]
+    },
+    {
+      "id": "summarization",
+      "name": "Page Summarization",
+      "severity": 4,
+      "severity_rationale": "New opt-in AI surface with limited rollout.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/summarization/**"],
+      "page_objects": [],
+      "test_patterns": ["Summar"]
+    },
+    {
+      "id": "terms-distribution",
+      "name": "Terms of Use & Distributions",
+      "severity": 5,
+      "severity_rationale": "Legal acceptance gate and partner build config; blocks first run when broken.",
+      "iso25010": ["compliance", "functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/termsofuse/**", "**/org/mozilla/fenix/distributions/**"],
+      "page_objects": [],
+      "test_patterns": ["TermsOfUse", "Distribution"]
+    },
+    {
+      "id": "settings-general",
+      "name": "Settings (General & Shell)",
+      "severity": 7,
+      "severity_rationale": "Container for most controls; a broken settings shell blocks many features.",
+      "iso25010": ["functional_suitability"],
+      "source_globs": ["**/org/mozilla/fenix/settings/**"],
+      "page_objects": ["settings", "settingsAbout", "settingsHomepage", "settingsLanguage", "settingsOpenLinksInApps"],
+      "test_patterns": ["SettingsTest", "SettingsGeneral", "SettingsAdvanced", "SettingsAbout", "SettingsCustomize", "SettingsHomepage", "SettingsLanguage", "SettingsOpenLinksInApps", "SettingsPageSummaries", "SettingsPrivacy"]
+    },
+    {
+      "id": "app-infrastructure",
+      "name": "App Infrastructure & Components",
+      "severity": 8,
+      "severity_rationale": "Shared plumbing. Changes here can destabilise every feature at once.",
+      "iso25010": ["reliability", "maintainability"],
+      "source_globs": ["**/org/mozilla/fenix/components/**", "**/org/mozilla/fenix/ext/**", "**/org/mozilla/fenix/utils/**", "**/org/mozilla/fenix/bindings/**", "**/org/mozilla/fenix/compose/**", "**/org/mozilla/fenix/datastore/**", "**/org/mozilla/fenix/navigation/**", "**/org/mozilla/fenix/HomeActivity.kt", "**/org/mozilla/fenix/FenixApplication.kt", "**/org/mozilla/fenix/AppRequestInterceptor.kt", "**/org/mozilla/fenix/gecko/**"],
+      "page_objects": [],
+      "test_patterns": [],
+      "indirect": true
+    },
+    {
+      "id": "build-config",
+      "name": "Build, Gradle & Manifest",
+      "severity": 8,
+      "severity_rationale": "Build config errors ship broken binaries or wrong permissions to everyone.",
+      "iso25010": ["reliability", "portability"],
+      "source_globs": ["mobile/android/fenix/**/*.gradle", "mobile/android/fenix/**/AndroidManifest.xml", "mobile/android/fenix/**/*.properties", "mobile/android/fenix/**/proguard*", "mobile/android/fenix/config/**"],
+      "page_objects": [],
+      "test_patterns": [],
+      "indirect": true
+    },
+    {
+      "id": "localization",
+      "name": "Strings & Localization",
+      "severity": 3,
+      "severity_rationale": "String-only changes; risk is truncation or an untranslated surface.",
+      "iso25010": ["usability"],
+      "source_globs": ["mobile/android/fenix/**/res/values*/**"],
+      "page_objects": [],
+      "test_patterns": [],
+      "indirect": true
+    },
+    {
+      "id": "resources-ui",
+      "name": "Layouts, Drawables & UI Resources",
+      "severity": 5,
+      "severity_rationale": "Visual and layout regressions; can break interaction if a view id changes.",
+      "iso25010": ["usability"],
+      "source_globs": ["mobile/android/fenix/**/res/layout*/**", "mobile/android/fenix/**/res/drawable*/**", "mobile/android/fenix/**/res/xml/**", "mobile/android/fenix/**/res/navigation/**", "mobile/android/fenix/**/res/color/**"],
+      "page_objects": [],
+      "test_patterns": [],
+      "indirect": true
+    }
+  ]
+}

--- a/release-test-planner/docs/architecture.md
+++ b/release-test-planner/docs/architecture.md
@@ -27,11 +27,11 @@ Three constraints shaped the whole thing:
       |
   [1] changes     git log --numstat -> per-file churn          deterministic
   [2] featuremap  path globs -> features                       + agent for misses
-  [3] corpus      parse androidTest Kotlin -> test inventory   deterministic
+  [3] corpus      parse Kotlin / Swift tests -> test inventory  deterministic
   [4] coverage    bind tests to features, score depth          + agent for weak bindings
   [5] risk        FMEA: RPN = S x O x D                        + agent for S and O
   [6] plan        greedy budgeted selection -> gaps            + agent for manual cases
-  [7] factories   generated-case candidate space               deterministic
+  [7] factories   generated-case candidate space               deterministic (Android only)
   [8] matrix      risk-tiered covering arrays                  deterministic
       report      static HTML
 ```
@@ -43,7 +43,9 @@ can be run, inspected or replaced in isolation.
 |---|---|---|
 | `changes.py` | git range -> per-file churn, bug ids, backout detection | the record separator must **prefix** each record; `--numstat` output follows the format string, so a trailing separator pairs each commit with the *previous* commit's files |
 | `featuremap.py` | path globs -> features, longest-glob-wins | a file gets exactly one primary feature so churn is never double counted |
-| `corpus.py` | Kotlin parsing: `@Test`, annotations, TestRail ids, surfaces | handles both the legacy robot DSL and the efficiency `on.<page>` form |
+| `corpus.py` | Kotlin **and Swift** parsing: tests, TestRail ids, surfaces, what actually runs | one reader per language behind one interface; on iOS a test's `.xctestplan` membership decides whether it runs at all |
+| `platforms.py` | where tests live, which language, whether a candidate space exists | `has_factories` gates whether a coverage percentage may be printed |
+| `testrail.py` | the assumed denominator: joins a case export to the corpus on case id | never merged with the derived denominator — see denominators.md |
 | `coverage.py` | test-to-feature binding, Detection curve | binding strength is the whole ballgame — see risk-model.md |
 | `risk.py` | FMEA scoring, bands, CRAP | no Fenix knowledge; reusable as-is |
 | `plan.py` | greedy budgeted selection, gap detection | gain is re-derived per candidate, not assumed |
@@ -52,8 +54,11 @@ can be run, inspected or replaced in isolation.
 | `agentio.py` | the deterministic/AI boundary | typed questions out, audited overrides in |
 | `report.py` | the self-contained HTML dashboard | data embedded *and* fetched — see below |
 
-`risk.py` and `matrix.py` carry no platform knowledge at all. When this grows
-beyond Android, those two should move unchanged.
+`risk.py` and `matrix.py` carry no platform knowledge at all. That claim was
+tested by the iOS port: both moved unchanged, as did `changes.py` and `plan.py`.
+What the port actually needed was a Swift reader in `corpus.py`, a second
+catalog, and `platforms.py` to hold the paths that used to be constants in
+`cli.py`.
 
 ## Configuration is data
 
@@ -133,8 +138,10 @@ source globs, page objects, test patterns, and a severity rationale. No code.
 **A new matrix factor** — add it to `infrastructure_factors` and reference it in
 the allocation policy. Declare its `source` honestly.
 
-**A new platform** — `risk.py` and `matrix.py` move unchanged. `featuremap.py`
-and `corpus.py` need a per-platform catalog and parser. `factories.py` is
+**A new platform** — add a `Platform` to `platforms.py`, a catalog under
+`config/`, and a reader to `corpus.readers` if the language is new. `risk.py`,
+`matrix.py`, `changes.py` and `plan.py` need no changes; iOS proved that.
+`factories.py` is
 Android-specific by nature. The pipeline shape holds.
 
 **A new test layer (unit/component/service)** — this is the highest-value

--- a/release-test-planner/docs/architecture.md
+++ b/release-test-planner/docs/architecture.md
@@ -1,0 +1,148 @@
+# Architecture
+
+How the pipeline is put together, what each stage owns, and where to reach in
+if you want to change or extend it.
+
+---
+
+## Design rules
+
+Three constraints shaped the whole thing:
+
+1. **Deterministic by default.** The pipeline never calls a model. Same inputs,
+   same output, every time — because a risk number that changes between runs is
+   not a risk number, it's a mood. AI judgement enters through an explicit,
+   auditable seam.
+2. **Stdlib only.** Python 3.9+, no install step, no venv, no API key, no
+   network. A tool you have to set up is a tool people don't run. This also
+   keeps it a comfortable neighbour in `testops-tools`.
+3. **Every number traceable.** Every score exposes its inputs. The report shows
+   the churn basis under each feature name, the tuple count each array verified,
+   and the rationale behind every agent override.
+
+## Stages
+
+```
+  git range
+      |
+  [1] changes     git log --numstat -> per-file churn          deterministic
+  [2] featuremap  path globs -> features                       + agent for misses
+  [3] corpus      parse androidTest Kotlin -> test inventory   deterministic
+  [4] coverage    bind tests to features, score depth          + agent for weak bindings
+  [5] risk        FMEA: RPN = S x O x D                        + agent for S and O
+  [6] plan        greedy budgeted selection -> gaps            + agent for manual cases
+  [7] factories   generated-case candidate space               deterministic
+  [8] matrix      risk-tiered covering arrays                  deterministic
+      report      static HTML
+```
+
+One module per stage in `testplanner/`. Each returns plain dicts, so any stage
+can be run, inspected or replaced in isolation.
+
+| module | owns | watch out for |
+|---|---|---|
+| `changes.py` | git range -> per-file churn, bug ids, backout detection | the record separator must **prefix** each record; `--numstat` output follows the format string, so a trailing separator pairs each commit with the *previous* commit's files |
+| `featuremap.py` | path globs -> features, longest-glob-wins | a file gets exactly one primary feature so churn is never double counted |
+| `corpus.py` | Kotlin parsing: `@Test`, annotations, TestRail ids, surfaces | handles both the legacy robot DSL and the efficiency `on.<page>` form |
+| `coverage.py` | test-to-feature binding, Detection curve | binding strength is the whole ballgame — see risk-model.md |
+| `risk.py` | FMEA scoring, bands, CRAP | no Fenix knowledge; reusable as-is |
+| `plan.py` | greedy budgeted selection, gap detection | gain is re-derived per candidate, not assumed |
+| `factories.py` | parses `generation/` to size the candidate space | the only module that knows about the efficiency harness internals |
+| `matrix.py` | IPOG covering arrays, Rao-Hamming OAs, verification | no Fenix knowledge; reusable as-is |
+| `agentio.py` | the deterministic/AI boundary | typed questions out, audited overrides in |
+| `report.py` | the self-contained HTML dashboard | data embedded *and* fetched — see below |
+
+`risk.py` and `matrix.py` carry no platform knowledge at all. When this grows
+beyond Android, those two should move unchanged.
+
+## Configuration is data
+
+Two JSON files hold everything a non-Python-reader might want to argue with:
+
+**`config/features.json`** — the feature catalog. Per feature: severity plus a
+written rationale, ISO 25010 quality attributes, production source globs,
+efficiency page objects, and test class name patterns. Features marked
+`"indirect": true` are cross-cutting code no UI test is named for; a zero there
+means "not *directly* covered", not "never executed", and the report says so.
+
+**`config/environment.json`** — matrix factors, each declaring whether it is
+`real`, `partly-real` or `stubbed` with its origin, plus the risk-band ->
+strength allocation policy and cost multipliers.
+
+Both are validated by unit tests: duplicate feature ids fail, a severity outside
+1-10 fails, a missing severity rationale fails, an environment factor that
+doesn't declare its provenance fails. Config is data, so it gets tested like
+data.
+
+## The agent seam
+
+The pipeline emits typed questions rather than calling a model. Each carries the
+evidence already gathered, a statement of *why* the call needs judgement, and a
+schema for the answer. An agent (or a person) answers into JSON; `--answers`
+folds them back as overrides; `meta.agent_overrides_applied` records what
+changed and why.
+
+Adding a question type means adding an entry to `TASK_TYPES` in `agentio.py`,
+emitting it in `emit()`, and handling it in `apply_overrides()`.
+
+The property worth preserving: **you can always run the whole thing with no AI
+at all and get a complete, defensible answer.** Judgement improves it; nothing
+depends on it.
+
+## The report
+
+One HTML file, no external requests — no CDN, no webfonts, no images. It resolves
+its data in this order:
+
+1. `report.json` sitting next to it, so `serve` gives you a plain browser refresh
+2. a copy embedded in the file itself, so it works from `file://` and can be
+   dropped on a static host alone
+
+The header states which one it used. It paints the embedded copy immediately and
+swaps in live data when it arrives — under `serve --live` the fetch triggers a
+full pipeline re-run, and a page that sits blank for several seconds reads as
+broken.
+
+Caveat: CSS and JS are inline, so a host enforcing a strict CSP without
+`'unsafe-inline'` renders an empty shell. Fix if needed is external `report.css`
+/ `report.js`, or CSP hashes.
+
+## Tests
+
+69 unit tests, ~0.6s, **no Firefox checkout required** — Kotlin parsing runs
+against fixtures in `tests/fixtures`, git parsing against a throwaway repo built
+in `setUpClass`.
+
+```bash
+python -m unittest discover -s tests -p '*tests.py'
+```
+
+Two exist specifically because the prototype got it wrong first, and are named
+so the next person doesn't undo the fix:
+
+- `test_every_added_test_still_gains_something` — the tiered Detection lookup
+  that stalled the greedy planner at 3 tests out of 769
+- `GitChangeTests` — the record-separator bug that reported one commit and zero
+  files, which looked exactly like an empty range
+
+## Extending it
+
+**A new feature in the catalog** — add an entry to `config/features.json` with
+source globs, page objects, test patterns, and a severity rationale. No code.
+
+**A new matrix factor** — add it to `infrastructure_factors` and reference it in
+the allocation policy. Declare its `source` honestly.
+
+**A new platform** — `risk.py` and `matrix.py` move unchanged. `featuremap.py`
+and `corpus.py` need a per-platform catalog and parser. `factories.py` is
+Android-specific by nature. The pipeline shape holds.
+
+**A new test layer (unit/component/service)** — this is the highest-value
+extension. `corpus.py` grows a parser per layer, and `coverage.py` weights the
+layers into Detection. Today's confidence is *understated* for well-unit-tested
+code, and closing that is worth more than any refinement of the existing scoring.
+
+---
+
+*See also: [why-factories.md](why-factories.md), [risk-model.md](risk-model.md),
+[matrix.md](matrix.md).*

--- a/release-test-planner/docs/denominators.md
+++ b/release-test-planner/docs/denominators.md
@@ -1,0 +1,98 @@
+# Two kinds of denominator
+
+*What a coverage percentage is allowed to mean, on a platform with test factories
+and on one without.*
+
+---
+
+[why-factories.md](why-factories.md) makes the case that a hand-written suite has
+no denominator, so percentages against it are theater. The factories fix that on
+Android by *enumerating* a space. This document is about what to do on a platform
+that has no factories — which is to say, on iOS today — and about a second
+denominator that turns out to work on both.
+
+## Derived vs assumed
+
+|  | derived | assumed |
+|---|---|---|
+| source | generation factories enumerate the reachable space | someone wrote down the cases a release needs |
+| available on | Android | Android and iOS |
+| total is | computed | asserted |
+| answers | "of what could be tested, how much is" | "of the plan we wrote, how much is automated" |
+| fails when | the page-object model is incomplete | nobody wrote a case for something |
+
+Both are legitimate. They are not interchangeable, and the tool never merges
+them into a single number.
+
+## Why iOS gets no derived denominator
+
+The obvious temptation, having ported everything else, is to estimate one: count
+the XCUITest screens, multiply by something, call it a candidate space. That
+would be inventing the exact quantity the model's coverage claims rest on.
+
+`factories.empty()` therefore returns zeros and `has_candidate_space: False`, and
+the report says "not available on Firefox iOS" rather than printing 0. A zero
+that looks like a measurement is worse than an absence, because the reader cannot
+tell them apart.
+
+Firefox iOS could grow a factory space — a MappaMundi screen graph is a
+navigation model, and `FxScreenGraphTests` already walks it. Enumerating
+reachability over that graph is the same construction the Fenix reachability
+factory uses. That is a real piece of work, not a config change, and until it
+exists iOS coverage is counts and gaps.
+
+## Why the TestRail case set is a defensible assumed denominator
+
+Three properties, in order of how much they matter.
+
+**The join is exact.** Both codebases already carry the case id above each test,
+in the same URL form, and `corpus.py` extracts it with one regex on both
+platforms. So binding automation to cases is an id match. This matters more than
+it sounds: a name-similarity heuristic would stack a second assumption on top of
+an already-assumed denominator, and the error bars would swallow the result.
+
+**It is a deliberate artefact.** Someone decided each case was worth writing for
+a release. That is a statement of intent about what a release needs — and unlike
+the automated suite, it was not shaped by what happened to be cheap to automate.
+
+**It answers the question a release manager actually asks.** Not "how much of the
+app is covered" but "how much of the plan will a machine run, and what is left
+for people?" The remainder *is* the manual-testing plan.
+
+### Where it is weak, stated plainly
+
+TestRail is also a pile that accumulated. Cases cluster where bugs were once
+found and thin out where nobody got round to writing them. So:
+
+- The output is named `automated_ratio`, never `coverage`.
+- `denominator: "assumed"` travels in the JSON so no downstream consumer can
+  mistake it for the derived kind.
+- A feature with 100% `automated_ratio` means every case someone wrote is
+  automated. It does not mean the feature is well tested.
+
+### Two rules that keep the ratio honest
+
+**Automation that never runs is not automated coverage.** A case whose only
+automated test is `@Ignore`d, skipped by every `.xctestplan`, or guarded behind
+`#available … else { return }` counts as manual. On firefox-ios `release/v153.3`
+this is not a rounding error: of 440 case ids referenced by XCUITests, **125** are
+claimed by a test that no test plan runs. Counting those as automated would
+overstate automation by 28% and, worse, would hide 125 cases that need a human.
+
+**A referenced id absent from the export is reported, not counted.** Tests
+sometimes point at cases in another project or suite, or at deleted ones. Those
+inflate the numerator against an export that does not contain them, so they are
+surfaced as `unmatched_ids` instead.
+
+## Using both together on Android
+
+Android can compute both, and the pair is more informative than either:
+
+- derived coverage low, assumed high → the written plan is thin relative to what
+  the app can do. The factories know about surfaces nobody wrote cases for.
+- derived low, assumed low → ordinary under-automation.
+- derived high, assumed low → automation exists for things the release plan does
+  not ask about. Worth asking whether the plan is stale.
+
+That comparison is the argument for wiring TestRail on Android too, not just as
+the iOS consolation prize.

--- a/release-test-planner/docs/denominators.md
+++ b/release-test-planner/docs/denominators.md
@@ -70,6 +70,45 @@ found and thin out where nobody got round to writing them. So:
 - A feature with 100% `automated_ratio` means every case someone wrote is
   automated. It does not mean the feature is well tested.
 
+### A run export is not a denominator
+
+This one only became obvious with real files in hand.
+
+A TestRail **run** ("Full Functional 153.3 RC 1") is a manual execution plan. Its
+737 cases are the ones humans were asked to click through. The automated tests
+reference 440 case ids, and only **35** of them are in that run — the two sets are
+almost disjoint, because the automation tracks a different population of cases.
+
+Computed naively that gives "3.4% automated", which is not an automation rate and
+not a coverage figure. It is an artefact of dividing by the wrong set. So
+`populations_disjoint` is set when overlap falls below half, and the report leads
+with that instead of the ratio.
+
+The **suite** export is the denominator: 1,779 cases, 417 of the 440 referenced
+ids present, 95% overlap. Merge both and you get the suite's completeness plus the
+run's section tree and execution statuses.
+
+### Trusting neither source, and comparing them
+
+The suite export carries TestRail's own triage — `Automation`,
+`Automation Coverage`, `Automated Test Name(s)`. That is a human decision, and the
+source tree is a fact. Neither is authoritative:
+
+| | in the tree | not in the tree |
+|---|---|---|
+| triaged automated | 376 — agreement | **22 — stale status or lost link** |
+| triaged `Unsuitable` | 0 | 335 — consistent |
+| triaged `Suitable` | 1 | 23 — the actionable backlog |
+| never triaged | 1 | 915 — nobody has decided |
+
+The two disagreement cells are the output worth acting on, and neither source
+could produce them alone.
+
+`Unsuitable` deserves special handling: those cases are deliberately manual
+forever. Leaving them in the denominator means the "gap" can never close, so the
+tool reports both the raw ratio and the addressable one (308/1,775 = 17.3% raw;
+308/1,440 = 21.4% addressable).
+
 ### Two rules that keep the ratio honest
 
 **Automation that never runs is not automated coverage.** A case whose only

--- a/release-test-planner/docs/matrix.md
+++ b/release-test-planner/docs/matrix.md
@@ -1,0 +1,149 @@
+# The configuration matrix
+
+A test is not one thing. It is a test **run in a configuration**. This is where
+the candidate space stops being a list and becomes a schedule.
+
+---
+
+## The problem
+
+Every feature multiplies out against the environment it runs in: device class,
+API level, browser mode, account state, build variant, network, theme. The full
+cross product of even a modest factor set is unaffordable, and most of it is
+redundant — the same defect surfacing in the fortieth configuration teaches you
+nothing the first one didn't.
+
+Two standard reductions exist. They are not interchangeable, and the difference
+between them is worth real device hours.
+
+## Orthogonal arrays — a design for *analysis*
+
+Every pair of factor levels appears **exactly** the same number of times.
+
+That balance is the point. It's what lets you attribute an observed effect to a
+particular factor, which is why orthogonal arrays come out of Taguchi's design
+of experiments — a tradition concerned with *understanding which variable
+caused the change*.
+
+Built here with the **Rao-Hamming construction**: runs are the vectors of
+GF(q)^m, columns are the points of the projective space PG(m−1, q), and the cell
+value is their dot product mod q. Four 3-level factors produces the textbook
+**L9** — 9 runs, every pair exactly once. There is a unit test asserting exactly
+that, because a construction that silently produces a not-quite-orthogonal array
+is worse than none.
+
+Balance has a price. Strength-2 orthogonal arrays only exist for particular run
+counts and level structures. Mixed level counts fall back to the standard
+dummy-level technique, which preserves pairwise coverage but **breaks the
+balance that was the reason to choose an OA in the first place** — so the output
+flags it rather than presenting a compromised array as a clean one.
+
+## Covering arrays — a design for *detection*
+
+Every pair appears **at least** once.
+
+Dropping the balance requirement makes the array markedly smaller and lets it
+accept any mix of level counts. Built with **IPOG** (In-Parameter-Order-General),
+the algorithm behind NIST's ACTS: build the exhaustive array over the first t
+factors, then grow one factor at a time — horizontally, choosing for each
+existing row the level covering the most still-uncovered tuples, then vertically,
+adding rows for whatever is left over.
+
+On the review-band factor set:
+
+| design | configs |
+|---|---|
+| full factorial | 96 |
+| orthogonal array | 23 |
+| **covering array (2-way)** | **13** |
+
+Same pairwise coverage. **43% fewer runs.**
+
+For release testing you want to know a combination *breaks*, not to attribute
+variance to a factor. You want detection. You want the covering array. The
+orthogonal array is implemented anyway because it is what people ask for by
+name, and because putting 23 next to 13 is the fastest way to explain why it
+usually isn't what you want.
+
+## Everything is verified
+
+`matrix.verify()` re-derives every t-tuple in the factor set and confirms the
+generated array actually contains it. Arrays are verified on generation, and the
+report shows the tuple count that was checked.
+
+This matters more than it sounds. A subtly wrong covering array does not crash —
+it silently under-tests, and reports a coverage number that is simply false.
+That is the single worst failure mode available to a tool whose entire job is
+telling you how covered you are. So the verifier has its own test
+(`test_detects_a_missing_pair`) proving it can fail; a safety net nobody has
+watched fail is not a safety net.
+
+## Allocation by risk band
+
+Generating an array is the easy part. Deciding **who gets how much** is where
+this connects back to the risk model.
+
+| band | strength | configs | rationale |
+|---|---|---|---|
+| action-required | 3-way | 40 of 576 | catches interaction faults pairwise provably cannot |
+| review | 2-way | 13 of 96 | most reported combinatorial faults are 2-way |
+| acceptable | baseline | 1 | enough to notice a total break |
+
+Uniform 3-way everywhere is how a test matrix becomes unaffordable and gets
+abandoned. A single config on an action-required feature is how a release ships
+broken. The allocation is the compromise, and it is expressed as policy in
+`config/environment.json` rather than buried in code, so it can be argued about
+by people who don't read Python.
+
+Net effect on the sample range: **73 selected tests become 458 executions and
+21.7 device-hours — 8.8x the single-configuration run.** That multiplier is the
+number a release manager is actually approving, and most planning conversations
+never surface it at all.
+
+## The output that surprised me
+
+Three features on the sample range are action-required with **zero** automation:
+App Infrastructure, IP Protection, and the newly-split-out Google Lens
+integration.
+
+Each gets a 40-configuration 3-way design. Each has nothing to execute in it.
+
+That is not a bug — it is the most useful thing on the page. Those 40
+configurations are not a test run, they are **the manual test scope**, sized and
+justified. The report labels those rows *"no automation — this matrix is the
+manual scope"* rather than quietly showing zero and letting the eye slide past.
+
+The tool cannot tell you a feature is safe. It can tell you exactly how much
+risk you are choosing to accept, and precisely where a human has to go look.
+
+## Where the factors come from
+
+Six are **parsed from the tree** — `BrowserMode`, `Account`, `DeviceClass`,
+`Pocket`, `RecentlyVisited`, `UnifiedTrustPanel` — read directly out of
+`BehaviorContextMatrix.kt`, including its existing 2^6 exhaustive profile. The
+efficiency harness already models product state as a factor space; the planner
+just reads it.
+
+The rest are **stubbed** and labelled as such in the UI and the config:
+`ApiLevel` values (real minSdk/targetSdk are computed in mach's Python build
+config; the shipping matrix should come from Play Console distribution data),
+`BuildVariant`, `Network`, `Theme`, the `Foldable` device class, and the
+per-config cost multipliers.
+
+## Known limits
+
+- Every selected test is assumed runnable in every configuration. Real
+  constraints — tablet-only, online-only, signed-in-only — need
+  **forbidden-tuple** support in the generator. This is the most valuable next
+  change and is contained to `covering_array()`.
+- Cost is a flat per-suite estimate times a per-config multiplier, not measured
+  runtime. Real numbers would come from Firebase Test Lab billing or Treeherder
+  task durations.
+- Allocation is per risk band, not per feature. A feature could plausibly earn a
+  bespoke factor subset — a settings-only change has no business varying network
+  state.
+
+---
+
+*See also: [why-factories.md](why-factories.md) for where the candidate pool
+comes from, and [risk-model.md](risk-model.md) for how bands are assigned.*

--- a/release-test-planner/docs/risk-model.md
+++ b/release-test-planner/docs/risk-model.md
@@ -1,0 +1,206 @@
+# The risk model
+
+Why FMEA, how each factor is derived, and the two modelling decisions that are
+load-bearing enough to have regression tests guarding them.
+
+---
+
+## Why FMEA specifically
+
+The requirement was a risk number that is *defensible in a release review* —
+something you can point at a standard for when someone asks "where did 51.1%
+come from?" Inventing a scoring heuristic is easy; defending one in a go/no-go
+meeting is not.
+
+**FMEA** — Failure Mode and Effects Analysis, IEC 60812, and the scheme ISTQB's
+risk-based testing material is built on — fits this problem almost suspiciously
+well:
+
+```
+RPN = Severity x Occurrence x Detection        range 1 .. 1000
+```
+
+The reason it fits is the third factor. In FMEA, **Detection** means *how likely
+is this failure to escape before it reaches the customer*. That is not an
+analogy for the coverage question. It is the coverage question, already
+formalised, with fifty years of industrial use behind it.
+
+Which gives the model a property you want:
+
+- **Severity** — you cannot change it. It's what the feature is worth.
+- **Occurrence** — you cannot change it either. The code already changed.
+- **Detection** — **this is the only factor a test plan moves.**
+
+So "what should we run?" becomes a question about exactly one variable, and
+"what did testing buy us?" becomes the measurable difference it made.
+
+## The three factors
+
+### Severity (1-10) — blast radius
+
+Hand-assigned per feature in `config/features.json`. Every value carries a
+written rationale, and a unit test fails the build if one is missing — the
+number is a judgement call, so the reasoning ships next to it.
+
+The scale is anchored on consequences, not on feelings:
+
+| | |
+|---|---|
+| 10 | Silent data loss, privacy/security leak, or app unusable. Ships = chemspill. |
+| 9 | Core journey broken or trust boundary weakened. Ships = dot release. |
+| 8 | Major feature broken for all users of it. Highly visible. |
+| 5-7 | Secondary feature broken or degraded. |
+| 1-4 | Cosmetic, peripheral, or internal-only. |
+
+Tracking Protection and Private Browsing sit at 10 not because they are complex
+but because silent failure means telling users they are protected when they are
+not. Theming sits at 4. That gap is the model doing its job.
+
+### Occurrence (1-10) — did this change probably break it
+
+Derived, not guessed, from **relative code churn**: churned LOC over total LOC
+of the feature.
+
+The choice of *relative* is deliberate and comes from Nagappan & Ball, *Use of
+Relative Code Churn Measures to Predict System Defect Density* (ICSE 2005),
+which found that churn normalised against file size predicts defect density
+substantially better than absolute churn does. 400 changed lines in a 4,000-line
+subsystem is routine. 400 changed lines in a 500-line one is a rewrite. Absolute
+churn cannot tell those apart; relative churn can.
+
+Modifiers on top of the churn band:
+
+| signal | delta | why |
+|---|---|---|
+| 10+ files touched | +1 | broad change surface |
+| 15+ commits | +1 | sustained churn, not one clean landing |
+| 4+ authors | +1 | coordination risk |
+| **touched by a backout** | **+2** | proven instability, not predicted |
+| agent semantic review | -3..+3 | see below |
+
+The backout signal is the strongest one available because it is not a
+prediction. Something already went wrong there this cycle.
+
+### Detection (1-10) — will a defect escape
+
+Inverted coverage depth. 10 means nothing would catch it; the floor of 2 means a
+defect would have to survive the whole suite.
+
+Weighted by what a test is actually worth as evidence:
+
+| binding | meaning | weight |
+|---|---|---|
+| `strong` | class name **and** page object match | 1.0 |
+| `name-only` | class name matches | 0.8 |
+| `incidental` | only passes through the surface | **0.0** |
+
+Smoke tests count 1.5x. Disabled tests count zero — automation that is switched
+off is not detection, and the report names it separately so it does not hide.
+
+## Two decisions with tests guarding them
+
+These both came out of the prototype being *wrong* first, which is why they have
+named regression tests.
+
+### Detection is a curve, not a lookup table
+
+The first implementation mapped coverage tiers to Detection values. It was
+wrong, and the failure mode was instructive: with a step function, the second
+test added to a feature produces **exactly zero** marginal gain. The greedy
+planner, which selects by risk-removed-per-minute, hit that plateau immediately
+and stopped — it picked **3 tests out of 769** and reported itself finished.
+
+Detection now decays continuously toward its floor as weighted test count rises.
+Every added test earns a positive but diminishing gain, which unblocks the
+planner and is also the more honest shape: the fifth test on a feature really
+does buy less than the first.
+
+Guarded by `test_every_added_test_still_gains_something`.
+
+### Incidental coverage counts for nothing
+
+The first coverage pass credited Home Screen with **502** covering tests. Only
+**16** verify it. The rest import `homeScreen` to navigate somewhere else.
+
+Overstated coverage is worse than no coverage, because it suppresses the RPN
+that should have triggered manual testing. A feature reported as "deeply
+covered" gets no scrutiny. So an incidental binding is worth zero until a human
+or agent confirms it, and the planner refuses to schedule one as coverage.
+
+Guarded by `test_incidental_bindings_are_worth_nothing` and
+`test_incidental_tests_are_never_scheduled`.
+
+## Derived numbers
+
+| number | formula | what it tells you |
+|---|---|---|
+| **Criticality** (FMECA) | S x O | inherent risk of the change. You cannot test this away, only code it away. |
+| **Inherent RPN** | S x O x 10 | risk if you shipped with no testing at all. |
+| **Residual RPN** | S x O x D(selected) | what survives the planned run. |
+| **Release confidence** | 1 − residual / inherent | share of inherent risk the plan removes. |
+| **CRAP score** | C² x (1−cov)³ + C | secondary complex-and-untested signal, adapted from per-method to feature scope. |
+
+Bands follow conventional AIAG FMEA practice: **200+ action required**, **100+
+review**, below that acceptable.
+
+Release confidence is deliberately weighted so high-severity, high-churn
+features dominate. Scoring 90% by covering a pile of trivia while a
+severity-10 feature sits untested is exactly the failure this number exists to
+prevent.
+
+## Selection
+
+Choosing the run is a **budgeted maximum-coverage problem** — NP-hard, so the
+planner uses the standard greedy approximation, which has a (1 − 1/e)
+worst-case bound for submodular gain.
+
+The gain of a test is measured, not assumed: after tentatively adding it, the
+feature's coverage is **re-derived from the selected set only**, and the gain is
+the resulting drop in RPN. A fifth redundant smoke test on an already
+well-covered feature scores approximately zero and never gets picked. On the
+sample range this classifies **244** bound tests as adding no measurable risk
+reduction — that is 244 tests' worth of device time the tool can justify not
+spending.
+
+The diminishing returns are real and visible:
+
+| budget | tests | confidence |
+|---|---|---|
+| 15 min | 9 | 29.1% |
+| 45 min | 24 | 43.3% |
+| 240 min | 73 | 51.1% |
+
+**45 minutes buys 85% of what 147 minutes buys.** That curve is the actual
+deliverable for a release manager deciding how much device time to fund.
+
+## Where judgement enters, and how it stays auditable
+
+The pipeline never calls a model. It runs deterministically and emits typed
+questions for the things that genuinely need judgement, each with the gathered
+evidence and a schema for the answer:
+
+| task | the judgement call |
+|---|---|
+| `classify-unmapped-path` | changed code that matched no feature |
+| `assess-change-semantics` | churn cannot tell a rename from a behaviour change |
+| `review-severity` | catalog severity is a static average |
+| `review-weak-binding` | does this test really exercise the feature |
+| `author-manual-tests` | turn residual risk into manual cases |
+
+Answers are fed back with `--answers` and recorded in
+`meta.agent_overrides_applied`. Every AI-influenced number traces to a question,
+an answer, and a rationale — which is the difference between a risk score you
+can defend and one you have to trust.
+
+This is not decoration. On the sample range, answering
+`assess-change-semantics` by reading the actual diffs found that 342 of 690
+lines filed under "App Infrastructure" were a **new Google Lens integration**
+(bug 2028573) living under `components/lens/`. It is now its own feature, and it
+lands as action-required with zero UI coverage — which it genuinely has. The
+deterministic layer found the churn; judgement found the misclassification.
+
+---
+
+*See also: [why-factories.md](why-factories.md) for why a candidate pool worth
+selecting from exists at all, and [matrix.md](matrix.md) for configuration
+coverage.*

--- a/release-test-planner/docs/why-factories.md
+++ b/release-test-planner/docs/why-factories.md
@@ -1,0 +1,218 @@
+# Why the test factories are the whole ballgame
+
+*The case for why this planner can exist at all, and why it could not have been
+built on top of the legacy suite.*
+
+---
+
+## The uncomfortable question every risk tool has to answer
+
+Risk-based test selection sounds obviously good. Score the risk, run the tests
+that address it, skip the rest. Every QA org has wanted this forever.
+
+So why doesn't everyone have it?
+
+Because selection is only worth doing when **supply exceeds budget**. If your
+release window fits 200 tests and your suite has 200 tests, the optimal plan is
+"run everything," and no amount of scoring machinery improves on that. You have
+built an expensive way to arrive at the obvious answer.
+
+Worse — and this is the part that quietly kills most coverage initiatives — a
+hand-written suite has **no denominator**. You cannot say "this run gives us 60%
+coverage of the tabs feature," because nobody ever enumerated what 100% would
+be. The suite is not a sample of a defined space. It is a pile of artifacts that
+accumulated because somebody had time to write them. Percentages computed
+against a pile are theater.
+
+That is the honest reason most test-selection tooling stalls out at "here are
+some tests that mention the word you changed."
+
+## What the factories change
+
+A factory does not write tests. It **enumerates a space** and emits a case per
+point in it.
+
+That distinction is the entire argument, so it's worth being concrete. The
+efficiency harness models the app as a navigation graph of page objects, each
+with a catalog of selectors. From that model, without anyone authoring a test:
+
+| factory | enumerates | candidates today |
+|---|---|---|
+| **Reachability** | every registered page | **50** |
+| Interaction | every interactive selector, per page | 466 |
+| Pairs | every ordered page-to-page transition | 2,450 |
+| Behavior | capability x template x context variant | 192 |
+
+**3,158 candidate cases**, derived from a model that a person maintains at the
+cost of ~50 page objects and 58 selector catalogs.
+
+Two things follow, and they are both load-bearing.
+
+### 1. Supply now exceeds budget, so selection means something
+
+3,158 candidates against a release window that fits maybe 70 tests is a genuine
+oversupply problem. *Now* the question "which of these actually reduce release
+risk?" is a real question with a non-obvious answer worth computing. The planner
+in this directory is the answer to a question the factories created.
+
+Run the counterfactual. On the legacy suite — 629 hand-written tests across 71
+files — the honest recommendation for most release cycles is "run the smoke
+subset, it's what you've got." That's not risk-based testing. That's a
+convention with a spreadsheet attached.
+
+### 2. Coverage finally has a denominator
+
+This is the one that matters more, and it's the one that's hard to appreciate
+until you've tried to compute a coverage number and found you couldn't.
+
+Because the candidate space is *derived from the model*, it is enumerable. So
+these statements become arithmetic rather than aspiration:
+
+- "This run exercises 38 of 50 reachable pages — 76% page reachability."
+- "We touched 112 of 466 interactive selectors on the surfaces we changed."
+- "Every pairwise combination of device class, API level and browser mode is
+  covered by 13 configurations, verified."
+
+Each of those has a real denominator, because something enumerated the space.
+Ask a hand-written suite for the same numbers and the only truthful answer is a
+shrug. You can count what you wrote. You cannot count what you *should* have
+written, because nobody ever built the list.
+
+**A generated suite is defined by its enumeration. That is what makes theoretical
+coverage claims defensible instead of embarrassing.**
+
+## The compounding property
+
+Here is the part that decides whether this pays off over five years.
+
+Under hand-authoring, coverage scales with headcount. Test number 630 costs
+about the same as test number 12. Linear in, linear out, forever. The suite grows
+exactly as fast as people type, and shrinks whenever they stop.
+
+Under the factory model, the marginal artifact is a **page object**, and the
+candidate space grows superlinearly against it. Register page object number 51
+and, for one authored file, the space gains:
+
+- **+1** reachability case, automatically
+- **+100** pair candidates (2 x 50 existing pages, both directions)
+- **+k** interaction candidates, one per selector in its catalog
+
+One artifact authored. A hundred-odd candidates generated. And nobody has to
+remember to do it — `PageCatalog` discovers page objects by reflection, so a new
+page object enters the candidate space by existing. There is no registry to
+update and therefore no registry to forget.
+
+That is the difference between a suite that grows when you hire and a suite that
+grows when you model.
+
+## Three design decisions that make it work
+
+Pitching the outcome without the mechanism is how you get a skeptic. So:
+
+**Arrival is the assertion.** `navigateToPage()` routes over the graph via BFS
+and verifies the target page's `requiredForPage` anchor on arrival. This is why
+the reachability factory needs no authored assertions — reaching the page *is*
+the check. A generated case with a hand-written assertion isn't generated; it's
+a template you still have to fill in. Making arrival self-verifying is what
+turns "generate a case per page" from a nice idea into 50 real tests.
+
+**One resolve() seam, and it handles the Compose trap.** Element resolution
+tries **both** the merged and unmerged Compose semantic trees and picks the
+*displayed* match. Anyone who has fought Compose merged-vs-unmerged flakiness
+knows that is a recurring, expensive, deeply annoying bug class. Fixing it once
+underneath everything means generated cases inherit the fix — you cannot
+generate thousands of cases on top of a resolution layer that's a coin flip.
+
+**Deterministic sharding.** `ShardUtils` splits generated cases across shards by
+index modulo shard count. Volume you cannot distribute is volume you cannot run,
+so this is the difference between an interesting candidate count and an
+executable suite.
+
+## The part I am not going to oversell
+
+The in-tree architecture doc is blunt about factory status, and it's right to be:
+
+- **Reachability** is production-ready. It auto-covers every registered page.
+- **Interaction** is implemented for bookmarks only.
+- **Behavior**'s context matrix is largely unimplemented.
+- **Pairs** has no clear failure class it uniquely catches, and whether to keep,
+  cut or redesign it is an open decision.
+
+So today: page-open checks come from the Reachability factory; everything else
+is hand-composed on `BasePage`, which is the mature path.
+
+**That does not weaken the argument. It sharpens it.** The claim is not "we have
+3,158 tests." The claim is:
+
+> The generation machinery is built, and one factory has already proven the whole
+> thesis end to end in production — 50 pages covered, zero per-page authoring,
+> self-updating by reflection.
+
+Reachability is the existence proof. The remaining three are the same machine
+pointed at richer spaces, and their candidate counts are what the space *is*,
+not a promise about what will be runnable. Anyone can go read `PageCatalog`,
+`NavigationRegistry`, and `ReachabilityCaseFactory` and check that the mechanism
+is real.
+
+The right way to read the 3,158 is: *this is the size of the space the model
+already describes.* Turning more of it into runnable cases is engineering
+against a proven pattern — not a research bet.
+
+## The evidence that showed up unplanned
+
+While building this planner, something happened that argues for the efficiency
+refactor better than anything designed to.
+
+The first coverage pass credited the Home Screen feature with **502 covering
+tests**. That's obviously wrong — it's most of the entire suite. The cause: in
+the legacy robot DSL, almost every test imports `homeScreen` and
+`navigationToolbar` in order to *navigate somewhere else*. A `BookmarksTest`
+looks, to any static analysis, exactly like a home screen test.
+
+Only **16** tests actually verify the home screen.
+
+Two conclusions, and the second is the important one:
+
+1. Overstated coverage is more dangerous than no coverage. It suppresses the risk
+   score that should have triggered manual testing. A tool confidently reporting
+   "deeply covered" on a feature with 16 real tests will get a release shipped
+   broken.
+
+2. **The legacy suite is not analyzable, and the efficiency suite is.** In the
+   legacy DSL, navigation and verification are the same gesture, so what a test
+   *covers* is not recoverable from its source. In the efficiency framework,
+   `on.<page>` makes the surface a test touches machine-readable, page objects
+   make the model explicit, and the navigation graph makes routing separable
+   from assertion.
+
+That second point was not a design goal of the refactor as far as I know. It
+fell out of it. And it's the precondition for *any* coverage tooling — including
+every future version of this planner, and including the Mozilla-wide,
+cross-platform version this is heading toward.
+
+You cannot compute risk-weighted coverage over a suite you cannot parse. The
+refactor is what made the suite parseable.
+
+## What this unlocks next
+
+The planner currently reasons about hand-written UI tests. Wiring the factory
+candidates into selection is the next step, and it changes the question the tool
+answers:
+
+Today: *"Which of our existing tests should we run for this release?"*
+
+Next: *"What is the minimum set of cases — existing or generatable on demand —
+that drives residual risk below threshold for this release?"*
+
+That second question is only askable if cases can be *materialized to order*
+from a model. It is not askable of a fixed pile of files. The factories are what
+make it askable.
+
+And the reason to care about the difference: the first question is bounded by
+what someone already wrote. The second is bounded by what the app actually is.
+
+---
+
+*See also: [risk-model.md](risk-model.md) for how risk is scored, and
+[matrix.md](matrix.md) for how the candidate space is reduced to a runnable
+configuration set.*

--- a/release-test-planner/examples/answers.example.json
+++ b/release-test-planner/examples/answers.example.json
@@ -1,0 +1,38 @@
+{
+  "_note": "Agent answers for range HEAD~300..HEAD. Each one was produced by reading the actual diff, not by inspecting the summary numbers. Re-run with --answers answers.json to apply.",
+  "answers": {
+    "semantics-home": {
+      "kind": "behaviour-change",
+      "occurrence_delta": 1,
+      "rationale": "Bug 2056670 adds HomeSwipeIntegration (237 lines, new file) and reworks HomeFragment gesture handling to allow swiping from home when HNT is enabled. New interaction surface, not a rename."
+    },
+    "semantics-localization": {
+      "kind": "config",
+      "occurrence_delta": -2,
+      "rationale": "The 705 churned lines are two bulk 'Import translations from android-l10n' commits. Machine-generated string updates carry truncation risk at worst, not logic risk."
+    },
+    "semantics-browser-core": {
+      "kind": "behaviour-change",
+      "occurrence_delta": 0,
+      "rationale": "Mixed: BrowserFragment gesture wiring plus ACCESS_LOCAL_NETWORK permission handling on load errors. Real behaviour change, but the churn-derived Occurrence of 8 already reflects it."
+    },
+    "semantics-settings-general": {
+      "kind": "behaviour-change",
+      "occurrence_delta": 0,
+      "rationale": "IPProtectionFragment and assorted settings surfaces. Churn-derived Occurrence is proportionate."
+    },
+    "semantics-app-infrastructure": {
+      "kind": "new-feature",
+      "occurrence_delta": -1,
+      "rationale": "342 of the 690 churned lines were the new Google Lens integration under components/lens/, which has since been split out into its own 'lens' catalog entry. What remains in this bucket is StartupMiddleware and preference plumbing, so the original Occurrence of 7 overstated it."
+    },
+    "severity-ip-protection": {
+      "severity": 9,
+      "rationale": "Confirmed. A silent IP Protection failure tells the user they are protected when they are not, which is a trust violation rather than a broken feature."
+    },
+    "severity-app-infrastructure": {
+      "severity": 8,
+      "rationale": "Confirmed at 8. StartupMiddleware sits on the cold-start path and a fault there affects every session."
+    }
+  }
+}

--- a/release-test-planner/plan.py
+++ b/release-test-planner/plan.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Release test planner for Fenix - entry point.
+
+Maps a git range to the Fenix features it touches, checks what UI automation
+exists for those features, scores the risk with FMEA, and produces both a
+recommended test run and the manual-testing gap.
+
+    ./plan.py analyze --repo /path/to/firefox --range v1..v2 --budget 240 --open
+    ./plan.py serve --repo /path/to/firefox --live --open
+
+Stdlib only - no install step, no API key. See README.md.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from testplanner.cli import main  # noqa: E402
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/release-test-planner/requirements.txt
+++ b/release-test-planner/requirements.txt
@@ -1,0 +1,6 @@
+# No third-party dependencies.
+#
+# The planner is deliberately stdlib-only so it runs on any Python 3.9+ with
+# no install step: no API key, no venv, no network. Tests use unittest.
+#
+# If that changes, anything added here should be justified in the README.

--- a/release-test-planner/testplanner/__init__.py
+++ b/release-test-planner/testplanner/__init__.py
@@ -1,0 +1,5 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Risk-based release test planner for Fenix (proof of concept)."""

--- a/release-test-planner/testplanner/agentio.py
+++ b/release-test-planner/testplanner/agentio.py
@@ -1,0 +1,240 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""The deterministic/AI boundary.
+
+The pipeline never calls a model. Instead it emits typed questions for the
+things that genuinely need judgement, each with the evidence already gathered
+and a schema for the answer. An agent answers them into a JSON file, which is
+fed back on the next run as overrides.
+
+Keeping the boundary explicit means every AI-supplied number in the final report
+is traceable to a question, an answer, and a rationale - which is what makes the
+output defensible in a release readiness review.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict, List
+
+TASK_TYPES = {
+    "classify-unmapped-path": {
+        "why": "Unrecognised code is unquantified risk. Every changed path must "
+               "land in a feature or be explicitly ruled out.",
+        "answer_schema": {
+            "feature_id": "existing feature id, or 'new' to propose one",
+            "proposed_feature": "{id, name, severity, source_globs} if feature_id=='new'",
+            "ignore": "true if this path carries no release risk",
+            "rationale": "one sentence",
+        },
+    },
+    "assess-change-semantics": {
+        "why": "Relative churn cannot tell a mechanical rename from a behaviour "
+               "change. The Occurrence factor is materially different for each.",
+        "answer_schema": {
+            "kind": "refactor | behaviour-change | new-feature | bugfix | config",
+            "occurrence_delta": "integer -3..+3 adjustment to the derived Occurrence",
+            "rationale": "one sentence citing the diff",
+        },
+    },
+    "review-severity": {
+        "why": "Catalog severity is a static default. A specific change may hit a "
+               "more or less critical part of the feature than the average.",
+        "answer_schema": {
+            "severity": "integer 1-10",
+            "rationale": "one sentence",
+        },
+    },
+    "review-weak-binding": {
+        "why": "A test bound by one weak signal may not actually exercise the "
+               "feature. False coverage is more dangerous than no coverage.",
+        "answer_schema": {
+            "binding_valid": "true|false",
+            "rationale": "one sentence",
+        },
+    },
+    "author-manual-tests": {
+        "why": "Residual risk after automation is the manual testing scope. This "
+               "is the handoff to the human test plan.",
+        "answer_schema": {
+            "cases": "[{title, steps, expected, priority: P0|P1|P2, est_minutes}]",
+            "rationale": "why these cases close the specific residual risk",
+        },
+    },
+}
+
+
+def _task(task_id: str, kind: str, question: str, context: Dict) -> Dict:
+    spec = TASK_TYPES[kind]
+    return {
+        "id": task_id,
+        "type": kind,
+        "question": question,
+        "why_this_needs_judgement": spec["why"],
+        "context": context,
+        "answer_schema": spec["answer_schema"],
+    }
+
+
+def emit(
+    attribution: Dict,
+    coverage: Dict,
+    risk_result: Dict,
+    plan_result: Dict,
+    max_per_type: int = 25,
+) -> Dict:
+    tasks: List[Dict] = []
+
+    for i, fc in enumerate(attribution["unmapped_files"][:max_per_type]):
+        tasks.append(
+            _task(
+                "unmapped-{}".format(i),
+                "classify-unmapped-path",
+                "Which Fenix feature does '{}' belong to?".format(fc["path"]),
+                {
+                    "path": fc["path"],
+                    "added": fc["added"],
+                    "deleted": fc["deleted"],
+                    "commits": fc["commits"],
+                },
+            )
+        )
+
+    high_churn = [
+        r for r in risk_result["rows"] if r["churned_lines"] >= 100
+    ][:max_per_type]
+    for row in high_churn:
+        tasks.append(
+            _task(
+                "semantics-{}".format(row["feature_id"]),
+                "assess-change-semantics",
+                "Is the change to '{}' a refactor or a behaviour change? "
+                "Read the diff before answering.".format(row["name"]),
+                {
+                    "feature_id": row["feature_id"],
+                    "churned_lines": row["churned_lines"],
+                    "file_count": row["file_count"],
+                    "commits": row["commits"],
+                    "derived_occurrence": row["occurrence"],
+                    "occurrence_basis": row["occurrence_basis"],
+                },
+            )
+        )
+
+    for row in risk_result["rows"]:
+        if row["band"] == "action-required":
+            tasks.append(
+                _task(
+                    "severity-{}".format(row["feature_id"]),
+                    "review-severity",
+                    "Confirm severity {} for '{}' given what actually changed."
+                    .format(row["severity"], row["name"]),
+                    {
+                        "feature_id": row["feature_id"],
+                        "catalog_severity": row["severity"],
+                        "catalog_rationale": row["severity_rationale"],
+                        "rpn": row["rpn"],
+                    },
+                )
+            )
+
+    weak = []
+    for fid, entry in coverage["per_feature"].items():
+        for test in entry["tests"]:
+            if test["binding"] == "incidental" and not test["is_disabled"]:
+                weak.append((fid, test))
+    for i, (fid, test) in enumerate(weak[:max_per_type]):
+        tasks.append(
+            _task(
+                "binding-{}".format(i),
+                "review-weak-binding",
+                "Does {}.{} really exercise feature '{}'? It was bound only by "
+                "a shared page object.".format(test["class_name"], test["name"], fid),
+                {
+                    "feature_id": fid,
+                    "test": "{}#{}".format(test["file"], test["name"]),
+                    "surfaces": test["surfaces"],
+                },
+            )
+        )
+
+    for gap in plan_result["gaps"][:max_per_type]:
+        tasks.append(
+            _task(
+                "manual-{}".format(gap["feature_id"]),
+                "author-manual-tests",
+                "Write manual test cases covering the residual risk in '{}'."
+                .format(gap["name"]),
+                {
+                    "feature_id": gap["feature_id"],
+                    "residual_rpn": gap["residual_rpn"],
+                    "reason": gap["reason"],
+                    "severity_rationale": gap["severity_rationale"],
+                    "quality_attributes_at_risk": gap["iso25010"],
+                    "planned_automated_tests": gap["planned_tests"],
+                },
+            )
+        )
+
+    by_type: Dict[str, int] = {}
+    for t in tasks:
+        by_type[t["type"]] = by_type.get(t["type"], 0) + 1
+
+    return {"task_count": len(tasks), "by_type": by_type, "tasks": tasks}
+
+
+def load_answers(path: str) -> Dict[str, Dict]:
+    """Load agent answers keyed by task id. Missing file means no overrides."""
+    if not path or not os.path.exists(path):
+        return {}
+    with open(path) as fh:
+        data = json.load(fh)
+    answers = data.get("answers", data)
+    if isinstance(answers, list):
+        return {a["id"]: a for a in answers if "id" in a}
+    return answers
+
+
+def apply_overrides(catalog, attribution: Dict, answers: Dict[str, Dict]) -> List[str]:
+    """Apply agent answers to the attribution before risk is scored.
+
+    Returns a human-readable audit trail of what the agent changed.
+    """
+    applied: List[str] = []
+    if not answers:
+        return applied
+
+    by_feature = {b["feature_id"]: b for b in attribution["features_touched"]}
+
+    for task_id, answer in answers.items():
+        if task_id.startswith("severity-"):
+            fid = task_id[len("severity-"):]
+            bucket = by_feature.get(fid)
+            if bucket and "severity" in answer:
+                old = bucket["severity"]
+                bucket["severity"] = int(answer["severity"])
+                applied.append(
+                    "severity[{}] {} -> {} ({})".format(
+                        fid, old, answer["severity"], answer.get("rationale", "")
+                    )
+                )
+
+        elif task_id.startswith("semantics-"):
+            fid = task_id[len("semantics-"):]
+            bucket = by_feature.get(fid)
+            if bucket and "occurrence_delta" in answer:
+                bucket["agent_occurrence_delta"] = int(answer["occurrence_delta"])
+                bucket["agent_change_kind"] = answer.get("kind", "")
+                applied.append(
+                    "occurrence[{}] {:+d} ({}: {})".format(
+                        fid,
+                        int(answer["occurrence_delta"]),
+                        answer.get("kind", "?"),
+                        answer.get("rationale", ""),
+                    )
+                )
+
+    return applied

--- a/release-test-planner/testplanner/changes.py
+++ b/release-test-planner/testplanner/changes.py
@@ -1,0 +1,199 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 1: extract what changed in a git range.
+
+Deterministic. Produces per-file churn measures that later feed the FMEA
+Occurrence factor. The churn measures follow Nagappan & Ball, "Use of Relative
+Code Churn Measures to Predict System Defect Density" (ICSE 2005), which found
+that churn normalised against file size predicts defect density far better than
+absolute churn does.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+BUG_RE = re.compile(r"\bBug\s+(\d{6,})", re.IGNORECASE)
+BACKOUT_RE = re.compile(r"\b(back(ed)?\s?out|revert(ed)?)\b", re.IGNORECASE)
+RECORD_SEP = "\x1e"
+FIELD_SEP = "\x1f"
+
+
+@dataclass
+class Commit:
+    sha: str
+    author: str
+    date: str
+    subject: str
+    bugs: List[str] = field(default_factory=list)
+    is_backout: bool = False
+    files: List[str] = field(default_factory=list)
+
+
+@dataclass
+class FileChange:
+    path: str
+    added: int = 0
+    deleted: int = 0
+    commits: int = 0
+    authors: int = 0
+    total_lines: int = 0
+    is_binary: bool = False
+    touched_by_backout: bool = False
+
+    @property
+    def churned_lines(self) -> int:
+        return self.added + self.deleted
+
+    def relative_churn(self) -> Dict[str, float]:
+        """Nagappan & Ball relative churn measures, as far as a git range allows.
+
+        M1 churned LOC / total LOC   - how much of the file is new
+        M2 deleted LOC / total LOC   - how much was torn out
+        M4 churn count / file        - how many separate commits touched it
+        M7 churned LOC / deleted LOC - add-vs-rewrite character of the change
+        """
+        total = max(self.total_lines, 1)
+        return {
+            "m1_churn_ratio": round(self.churned_lines / total, 4),
+            "m2_delete_ratio": round(self.deleted / total, 4),
+            "m4_commits_per_file": self.commits,
+            "m7_churn_over_delete": round(
+                self.churned_lines / self.deleted, 4
+            ) if self.deleted else float(self.churned_lines),
+        }
+
+
+def _run(repo: str, args: List[str]) -> str:
+    proc = subprocess.run(
+        ["git"] + args,
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            "git {} failed: {}".format(" ".join(args[:2]), proc.stderr.strip())
+        )
+    return proc.stdout
+
+
+def _file_line_count(repo: str, path: str) -> int:
+    """Line count of the file at the tip of the range."""
+    try:
+        out = _run(repo, ["show", "HEAD:{}".format(path)])
+    except RuntimeError:
+        return 0
+    return out.count("\n")
+
+
+def collect(
+    repo: str,
+    rev_range: str,
+    pathspec: Optional[List[str]] = None,
+    max_commits: int = 2000,
+) -> Dict:
+    """Walk a git range and return commits plus per-file churn."""
+    pathspec = pathspec or []
+    # The record separator must PREFIX each record: git emits the --numstat
+    # block after the format string, so a trailing separator would split each
+    # commit away from its own file list.
+    fmt = RECORD_SEP + FIELD_SEP.join(["%H", "%an", "%aI", "%s"])
+
+    args = [
+        "log",
+        "--no-merges",
+        "--max-count={}".format(max_commits),
+        "--format={}".format(fmt),
+        "--numstat",
+        rev_range,
+    ]
+    if pathspec:
+        args += ["--"] + pathspec
+
+    raw = _run(repo, args)
+
+    commits: List[Commit] = []
+    files: Dict[str, FileChange] = {}
+    file_authors: Dict[str, set] = defaultdict(set)
+
+    for record in raw.split(RECORD_SEP):
+        record = record.strip("\n")
+        if not record.strip():
+            continue
+
+        head, _, body = record.partition("\n")
+        parts = head.split(FIELD_SEP)
+        if len(parts) < 4:
+            continue
+        sha, author, date, subject = parts[0], parts[1], parts[2], parts[3]
+
+        commit = Commit(
+            sha=sha[:12],
+            author=author,
+            date=date,
+            subject=subject,
+            bugs=sorted(set(BUG_RE.findall(subject))),
+            is_backout=bool(BACKOUT_RE.search(subject)),
+        )
+
+        for line in body.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            cols = line.split("\t")
+            if len(cols) != 3:
+                continue
+            added_s, deleted_s, path = cols
+
+            # Git renames appear as "old => new"; attribute to the new path.
+            if " => " in path:
+                path = _resolve_rename(path)
+
+            fc = files.setdefault(path, FileChange(path=path))
+            if added_s == "-" or deleted_s == "-":
+                fc.is_binary = True
+            else:
+                fc.added += int(added_s)
+                fc.deleted += int(deleted_s)
+            fc.commits += 1
+            fc.touched_by_backout = fc.touched_by_backout or commit.is_backout
+            file_authors[path].add(author)
+            commit.files.append(path)
+
+        commits.append(commit)
+
+    for path, fc in files.items():
+        fc.authors = len(file_authors[path])
+        if not fc.is_binary:
+            fc.total_lines = _file_line_count(repo, path)
+
+    return {
+        "range": rev_range,
+        "pathspec": pathspec,
+        "commit_count": len(commits),
+        "file_count": len(files),
+        "total_churn": sum(f.churned_lines for f in files.values()),
+        "commits": [asdict(c) for c in commits],
+        "files": [
+            dict(asdict(fc), churned_lines=fc.churned_lines, **fc.relative_churn())
+            for fc in sorted(
+                files.values(), key=lambda f: f.churned_lines, reverse=True
+            )
+        ],
+    }
+
+
+def _resolve_rename(path: str) -> str:
+    """Turn git's 'a/{b => c}/d' or 'old => new' notation into the new path."""
+    brace = re.search(r"\{(.*?) => (.*?)\}", path)
+    if brace:
+        return path[: brace.start()] + brace.group(2) + path[brace.end():]
+    return path.split(" => ")[-1]

--- a/release-test-planner/testplanner/changes.py
+++ b/release-test-planner/testplanner/changes.py
@@ -191,6 +191,31 @@ def collect(
     }
 
 
+def tip_in_working_tree(repo: str, commits: List[Dict]) -> Optional[str]:
+    """Is the newest commit of the analysed range present in the checked-out tree?
+
+    If it is not, the corpus and the churn describe different revisions: we
+    would be scoring one branch's changes against another branch's tests, and
+    reporting a confidence number that is quietly wrong. Analysing
+    `origin/release..origin/beta` from a `main` checkout is the easy way to do
+    this by accident.
+
+    Returns the offending tip SHA, or None when the tree is consistent.
+    """
+    if not commits:
+        return None
+
+    tip = commits[0]["sha"]
+    proc = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tip, "HEAD"],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return None if proc.returncode == 0 else tip
+
+
 def _resolve_rename(path: str) -> str:
     """Turn git's 'a/{b => c}/d' or 'old => new' notation into the new path."""
     brace = re.search(r"\{(.*?) => (.*?)\}", path)

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -154,7 +154,7 @@ def run_analysis(args, quiet: bool = False):
                 "addressable".format(rt["deliberately_manual"],
                                      rt["automated_ratio_addressable"],
                                      rt["addressable_cases"]))
-        if rt["status_counts"] and rt["status_counts"] != {"unknown": rt["cases"]}:
+        if rt["has_execution_data"]:
             log("      execution: {} ({} not run, {} not applicable)".format(
                 ", ".join("{} {}".format(v, k)
                           for k, v in sorted(rt["status_counts"].items(),

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -243,6 +243,7 @@ def run_analysis(args, quiet: bool = False):
             "platform_label": platform.label,
             "has_factories": platform.has_factories,
             "platform_notes": platform.notes,
+            "report_title": platform.report_title,
             "agent_overrides_applied": audit,
             "tree_mismatch_tip": stray_tip,
         },

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-"""Command line entry point for the Fenix release test planner PoC."""
+"""Command line entry point for the release test planner PoC."""
 
 from __future__ import annotations
 
@@ -14,17 +14,26 @@ import webbrowser
 
 from . import (
     agentio, changes, corpus, coverage, factories, featuremap, matrix, plan,
-    report, risk,
+    platforms, report, risk, testrail,
 )
 
 DEFAULT_REPO = os.environ.get("FENIX_REPO", "")
-FENIX_APP = "mobile/android/fenix/app"
-FENIX_SRC = FENIX_APP + "/src/main"
-FENIX_UI_TESTS = FENIX_APP + "/src/androidTest/java/org/mozilla/fenix/ui"
-FENIX_EFFICIENCY = FENIX_UI_TESTS + "/efficiency"
 HERE = os.path.dirname(os.path.abspath(__file__))
-DEFAULT_CATALOG = os.path.join(HERE, "..", "config", "features.json")
 DEFAULT_ENV = os.path.join(HERE, "..", "config", "environment.json")
+
+# Only the paths git is asked to look at. Fenix lives in mozilla-central beside
+# everything else, so the Android default scopes the range to it; firefox-ios is
+# its own repo and needs no scoping.
+DEFAULT_PATHSPEC = {
+    "android": ["mobile/android/fenix/"],
+    "ios": [],
+}
+
+
+def _catalog_for(args, platform) -> str:
+    if args.catalog:
+        return os.path.abspath(args.catalog)
+    return os.path.abspath(os.path.join(HERE, "..", platform.default_catalog))
 
 
 def run_analysis(args, quiet: bool = False):
@@ -36,14 +45,15 @@ def run_analysis(args, quiet: bool = False):
     log = (lambda *a: None) if quiet else (lambda *a: print(*a))
 
     repo = os.path.abspath(os.path.expanduser(args.repo))
+    platform = platforms.get(args.platform)
 
-    catalog = featuremap.FeatureCatalog.load(os.path.abspath(args.catalog))
+    catalog = featuremap.FeatureCatalog.load(_catalog_for(args, platform))
 
-    log("[1/8] reading git range {}".format(args.range))
+    log("[1/8] reading git range {} ({})".format(args.range, platform.label))
     change_data = changes.collect(
         repo,
         args.range,
-        pathspec=args.pathspec or ["mobile/android/fenix/"],
+        pathspec=args.pathspec or DEFAULT_PATHSPEC.get(platform.id, []),
         max_commits=args.max_commits,
     )
     log("      {} commits, {} files, {} lines churned".format(
@@ -88,17 +98,44 @@ def run_analysis(args, quiet: bool = False):
         log("      applied {} agent override(s)".format(len(audit)))
 
     log("[3/8] indexing test corpus")
-    inventory = corpus.build(repo, FENIX_UI_TESTS)
+    inventory = corpus.build(repo, platform, tests_root=args.tests_root)
     log("      {} tests ({}), {} smoke, {} disabled".format(
         inventory["total_tests"],
         ", ".join("{} {}".format(v, k) for k, v in inventory["by_suite"].items()),
         inventory["smoke_tests"],
         inventory["disabled_tests"],
     ))
+    if inventory["test_plans"]:
+        log("      test plans: {}".format(", ".join(
+            "{} ({})".format(k, v) for k, v in inventory["test_plans"].items())))
+    # An empty corpus is the failure that looks most like a result: every feature
+    # reads 0% covered, risk maxes out, and the plan says everything is critical
+    # and untested. Say so loudly instead.
+    if not inventory["total_tests"]:
+        log("\n  !! WARNING - no tests found. Coverage will read 0% for every\n"
+            "     feature and the risk scores will all max out, which is a\n"
+            "     wrong path rather than a finding.")
+        for missing in inventory["missing_roots"]:
+            log("     missing: {}".format(missing))
+        log("     Check --platform (currently {}) and --tests-root.".format(
+            platform.id))
 
     log("[4/8] binding tests to features")
     cov = coverage.bind(catalog, inventory)
     log("      {} tests bound to no feature".format(cov["unbound_count"]))
+
+    # Optional denominator from TestRail. Independent of the factory space and
+    # measuring a different thing - see testplanner/testrail.py.
+    rail = None
+    if args.testrail_export:
+        log("      joining TestRail export")
+        rail = testrail.build(args.testrail_export, catalog, inventory, cov)
+        log("      {} cases, {} automated ({:.1%}), {} manual-only".format(
+            rail["totals"]["cases"], rail["totals"]["automated"],
+            rail["totals"]["automated_ratio"], rail["totals"]["manual_only"]))
+        if rail["totals"]["unmatched_ids"]:
+            log("      {} case ids referenced by tests but absent from the "
+                "export".format(rail["totals"]["unmatched_ids"]))
 
     log("[5/8] scoring FMEA risk")
     risk_result = risk.score(attribution, cov)
@@ -117,14 +154,24 @@ def run_analysis(args, quiet: bool = False):
         pt["features_with_gaps"],
     ))
 
-    log("[7/8] scanning generated-test factories")
-    factory_scan = factories.scan(repo, FENIX_EFFICIENCY)
-    factory_by_feature = factories.attribute_to_features(
-        factory_scan, catalog, risk_result["rows"]
-    )
-    log("      {} candidate cases across {} factories".format(
-        factory_scan["total_candidates"], len(factory_scan["factories"])
-    ))
+    if platform.has_factories:
+        log("[7/8] scanning generated-test factories")
+        factory_scan = factories.scan(repo, platform.factory_root)
+        factory_by_feature = factories.attribute_to_features(
+            factory_scan, catalog, risk_result["rows"]
+        )
+        log("      {} candidate cases across {} factories".format(
+            factory_scan["total_candidates"], len(factory_scan["factories"])
+        ))
+    else:
+        # Not a gap to be filled with an estimate. The factory space is what
+        # gives coverage a derived denominator; asserting one here would be
+        # inventing the number the whole model rests on.
+        log("[7/8] no generated-test factories on this platform")
+        log("      coverage is reported without a derived denominator" +
+            (" (TestRail supplies an assumed one)" if rail else ""))
+        factory_scan = factories.empty(platform.id)
+        factory_by_feature = {}
 
     log("[8/8] building the combinatorial matrix")
     with open(os.path.abspath(args.environment)) as fh:
@@ -145,10 +192,15 @@ def run_analysis(args, quiet: bool = False):
             "repo": repo,
             "range": args.range,
             "budget_minutes": args.budget,
-            "catalog": os.path.abspath(args.catalog),
+            "catalog": _catalog_for(args, platform),
+            "platform": platform.id,
+            "platform_label": platform.label,
+            "has_factories": platform.has_factories,
+            "platform_notes": platform.notes,
             "agent_overrides_applied": audit,
             "tree_mismatch_tip": stray_tip,
         },
+        "testrail": rail,
         "changes": change_data,
         "attribution": attribution,
         "inventory": {k: v for k, v in inventory.items() if k != "tests"},
@@ -268,7 +320,8 @@ def _serve(args) -> int:
 def main(argv=None) -> int:
     parser = argparse.ArgumentParser(
         prog="testplanner",
-        description="Risk-based release test planner for Fenix (proof of concept).",
+        description="Risk-based release test planner for Fenix and Firefox iOS "
+                    "(proof of concept).",
     )
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -276,9 +329,20 @@ def main(argv=None) -> int:
         p.add_argument("--range", default="HEAD~200..HEAD",
                        help="git revision range (default: HEAD~200..HEAD)")
         p.add_argument("--repo", default=DEFAULT_REPO,
-                       help="path to a mozilla-central / firefox checkout "
-                            "(or set FENIX_REPO)")
-        p.add_argument("--catalog", default=DEFAULT_CATALOG)
+                       help="path to a firefox (Android) or firefox-ios "
+                            "checkout (or set FENIX_REPO)")
+        p.add_argument("--platform", default=platforms.DEFAULT,
+                       choices=sorted(platforms.PLATFORMS),
+                       help="which app is being analysed (default: %s)"
+                            % platforms.DEFAULT)
+        p.add_argument("--tests-root", default="",
+                       help="override the platform's UI test directory, for a "
+                            "checkout whose layout differs from the current one")
+        p.add_argument("--testrail-export", default=None,
+                       help="TestRail case export (JSON or CSV) to use as an "
+                            "assumed coverage denominator")
+        p.add_argument("--catalog", default=None,
+                       help="feature catalog (default: the platform's)")
         p.add_argument("--environment", default=DEFAULT_ENV,
                        help="JSON file of environment factors and allocation policy")
         p.add_argument("--budget", type=float, default=None,
@@ -306,13 +370,18 @@ def main(argv=None) -> int:
 
     if not args.repo:
         parser.error(
-            "no Firefox checkout given. Pass --repo /path/to/firefox, or set "
-            "FENIX_REPO in your environment."
+            "no checkout given. Pass --repo /path/to/firefox (or "
+            "/path/to/firefox-ios with --platform ios), or set FENIX_REPO."
         )
-    if not os.path.isdir(os.path.join(os.path.expanduser(args.repo), FENIX_APP)):
+    # Sanity-check against the platform's own source root, so pointing an iOS
+    # run at an Android checkout fails here rather than producing an empty
+    # report that looks like a finding.
+    expected = platforms.get(args.platform).source_root
+    if not os.path.isdir(os.path.join(os.path.expanduser(args.repo), expected)):
         parser.error(
-            "{} does not look like a Firefox checkout - expected to find {} "
-            "under it.".format(args.repo, FENIX_APP)
+            "{} does not look like a {} checkout - expected to find {} under "
+            "it. Wrong --platform?".format(
+                args.repo, platforms.get(args.platform).label, expected)
         )
 
     return args.func(args)

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -1,0 +1,303 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Command line entry point for the Fenix release test planner PoC."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import webbrowser
+
+from . import (
+    agentio, changes, corpus, coverage, factories, featuremap, matrix, plan,
+    report, risk,
+)
+
+DEFAULT_REPO = os.environ.get("FENIX_REPO", "")
+FENIX_APP = "mobile/android/fenix/app"
+FENIX_SRC = FENIX_APP + "/src/main"
+FENIX_UI_TESTS = FENIX_APP + "/src/androidTest/java/org/mozilla/fenix/ui"
+FENIX_EFFICIENCY = FENIX_UI_TESTS + "/efficiency"
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_CATALOG = os.path.join(HERE, "..", "config", "features.json")
+DEFAULT_ENV = os.path.join(HERE, "..", "config", "environment.json")
+
+
+def run_analysis(args, quiet: bool = False):
+    """Run the whole pipeline and return the report payload.
+
+    Shared by `analyze` (writes files) and `serve --live` (regenerates on each
+    request), so the served JSON can never drift from the written one.
+    """
+    log = (lambda *a: None) if quiet else (lambda *a: print(*a))
+
+    repo = os.path.abspath(os.path.expanduser(args.repo))
+
+    catalog = featuremap.FeatureCatalog.load(os.path.abspath(args.catalog))
+
+    log("[1/8] reading git range {}".format(args.range))
+    change_data = changes.collect(
+        repo,
+        args.range,
+        pathspec=args.pathspec or ["mobile/android/fenix/"],
+        max_commits=args.max_commits,
+    )
+    log("      {} commits, {} files, {} lines churned".format(
+        change_data["commit_count"],
+        change_data["file_count"],
+        change_data["total_churn"],
+    ))
+
+    if not change_data["files"]:
+        log("\nNo changed files in that range. Try a wider --range.")
+        return None
+
+    log("[2/8] mapping paths to features")
+    attribution = featuremap.attribute(catalog, change_data["files"])
+    log("      {} features touched, {} paths unmapped, {} ignored".format(
+        len(attribution["features_touched"]),
+        len(attribution["unmapped_files"]),
+        attribution["ignored_count"],
+    ))
+
+    answers = agentio.load_answers(args.answers)
+    audit = agentio.apply_overrides(catalog, attribution, answers)
+    if audit:
+        log("      applied {} agent override(s)".format(len(audit)))
+
+    log("[3/8] indexing test corpus")
+    inventory = corpus.build(repo, FENIX_UI_TESTS)
+    log("      {} tests ({}), {} smoke, {} disabled".format(
+        inventory["total_tests"],
+        ", ".join("{} {}".format(v, k) for k, v in inventory["by_suite"].items()),
+        inventory["smoke_tests"],
+        inventory["disabled_tests"],
+    ))
+
+    log("[4/8] binding tests to features")
+    cov = coverage.bind(catalog, inventory)
+    log("      {} tests bound to no feature".format(cov["unbound_count"]))
+
+    log("[5/8] scoring FMEA risk")
+    risk_result = risk.score(attribution, cov)
+    t = risk_result["totals"]
+    log("      total RPN {} / inherent {} | {} action-required".format(
+        t["total_rpn"], t["total_inherent_rpn"], t["action_required"]
+    ))
+
+    log("[6/8] planning test selection")
+    plan_result = plan.build(risk_result, cov, budget_minutes=args.budget)
+    pt = plan_result["totals"]
+    log("      {} tests selected, {} min, confidence {:.1%}, {} gaps".format(
+        plan_result["selected_count"],
+        plan_result["estimated_minutes"],
+        pt["release_confidence"],
+        pt["features_with_gaps"],
+    ))
+
+    log("[7/8] scanning generated-test factories")
+    factory_scan = factories.scan(repo, FENIX_EFFICIENCY)
+    factory_by_feature = factories.attribute_to_features(
+        factory_scan, catalog, risk_result["rows"]
+    )
+    log("      {} candidate cases across {} factories".format(
+        factory_scan["total_candidates"], len(factory_scan["factories"])
+    ))
+
+    log("[8/8] building the combinatorial matrix")
+    with open(os.path.abspath(args.environment)) as fh:
+        env_config = json.load(fh)
+    matrix_result = matrix.allocate(
+        risk_result["rows"], plan_result, env_config,
+        factory_scan["context_factors"],
+    )
+    mt = matrix_result["totals"]
+    log("      {} executions, {} h device time ({}x the single-config run)".format(
+        mt["executions"], mt["est_hours"], mt["matrix_multiplier"]
+    ))
+
+    tasks = agentio.emit(attribution, cov, risk_result, plan_result)
+
+    payload = {
+        "meta": {
+            "repo": repo,
+            "range": args.range,
+            "budget_minutes": args.budget,
+            "catalog": os.path.abspath(args.catalog),
+            "agent_overrides_applied": audit,
+        },
+        "changes": change_data,
+        "attribution": attribution,
+        "inventory": {k: v for k, v in inventory.items() if k != "tests"},
+        "coverage_summary": {
+            "unbound_count": cov["unbound_count"],
+        },
+        "risk": risk_result,
+        "plan": plan_result,
+        "factories": {
+            **{k: v for k, v in factory_scan.items() if k != "selectors_per_page"},
+            "per_feature": factory_by_feature,
+        },
+        "matrix": matrix_result,
+        "agent_tasks": tasks,
+    }
+
+    return payload
+
+
+def _write(payload, outdir: str, quiet: bool = False) -> str:
+    """Write report.json, agent-tasks.json and the standalone report.html."""
+    log = (lambda *a: None) if quiet else (lambda *a: print(*a))
+    os.makedirs(outdir, exist_ok=True)
+
+    json_path = os.path.join(outdir, "report.json")
+    with open(json_path, "w") as fh:
+        json.dump(payload, fh, indent=2)
+
+    tasks = payload["agent_tasks"]
+    tasks_path = os.path.join(outdir, "agent-tasks.json")
+    with open(tasks_path, "w") as fh:
+        json.dump(tasks, fh, indent=2)
+
+    html_path = os.path.join(outdir, "report.html")
+    report.render(payload, html_path)
+
+    log("\nwrote:")
+    log("  {}".format(json_path))
+    log("  {}  ({} questions for an agent)".format(tasks_path, tasks["task_count"]))
+    log("  {}  (standalone - embeds its own data)".format(html_path))
+    return html_path
+
+
+def _analyze(args) -> int:
+    payload = run_analysis(args)
+    if payload is None:
+        return 1
+    html_path = _write(payload, os.path.abspath(os.path.expanduser(args.out)))
+    if args.open:
+        webbrowser.open("file://" + html_path)
+    return 0
+
+
+def _serve(args) -> int:
+    """Serve out/ so a browser refresh picks up fresh data.
+
+    With --live the pipeline re-runs on every request for report.json, so
+    refreshing the page is enough to see a config or catalog edit take effect.
+    Without it, the last written report.json is served as static files.
+    """
+    import http.server
+    import socketserver
+
+    outdir = os.path.abspath(os.path.expanduser(args.out))
+
+    if not os.path.exists(os.path.join(outdir, "report.html")):
+        print("No report in {} yet - running the pipeline once.".format(outdir), flush=True)
+        payload = run_analysis(args)
+        if payload is None:
+            return 1
+        _write(payload, outdir)
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *a, **kw):
+            super().__init__(*a, directory=outdir, **kw)
+
+        def do_GET(self):
+            if args.live and self.path.split("?")[0].rstrip("/") in ("/report.json",):
+                print("regenerating report.json ...", flush=True)
+                try:
+                    payload = run_analysis(args, quiet=True)
+                except Exception as exc:  # keep the server alive on a bad edit
+                    self.send_error(500, "analysis failed: {}".format(exc))
+                    return
+                if payload is None:
+                    self.send_error(500, "no changes in range")
+                    return
+                _write(payload, outdir, quiet=True)
+                print("  done - {} features, confidence {:.1%}".format(
+                    payload["risk"]["totals"]["features_touched"],
+                    payload["plan"]["totals"]["release_confidence"],
+                ))
+            return super().do_GET()
+
+        def end_headers(self):
+            self.send_header("Cache-Control", "no-store")
+            super().end_headers()
+
+        def log_message(self, fmt, *a):
+            pass
+
+    socketserver.TCPServer.allow_reuse_address = True
+    with socketserver.TCPServer(("127.0.0.1", args.port), Handler) as httpd:
+        url = "http://127.0.0.1:{}/report.html".format(args.port)
+        print("serving {} at {}".format(outdir, url), flush=True)
+        print("live regeneration: {}".format("on" if args.live else "off"), flush=True)
+        print("refresh the page to pick up changes. ctrl-c to stop.", flush=True)
+        if args.open:
+            webbrowser.open(url)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nstopped.", flush=True)
+    return 0
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="testplanner",
+        description="Risk-based release test planner for Fenix (proof of concept).",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def common(p):
+        p.add_argument("--range", default="HEAD~200..HEAD",
+                       help="git revision range (default: HEAD~200..HEAD)")
+        p.add_argument("--repo", default=DEFAULT_REPO,
+                       help="path to a mozilla-central / firefox checkout "
+                            "(or set FENIX_REPO)")
+        p.add_argument("--catalog", default=DEFAULT_CATALOG)
+        p.add_argument("--environment", default=DEFAULT_ENV,
+                       help="JSON file of environment factors and allocation policy")
+        p.add_argument("--budget", type=float, default=None,
+                       help="device-minutes available for the test run")
+        p.add_argument("--answers", default=None,
+                       help="JSON file of agent answers to apply as overrides")
+        p.add_argument("--pathspec", nargs="*", default=None)
+        p.add_argument("--max-commits", type=int, default=2000)
+        p.add_argument("--out", default="out")
+        p.add_argument("--open", action="store_true",
+                       help="open the report in a browser")
+        return p
+
+    a = common(sub.add_parser("analyze", help="run the pipeline over a git range"))
+    a.set_defaults(func=_analyze)
+
+    s = common(sub.add_parser(
+        "serve", help="serve the report so a browser refresh picks up changes"))
+    s.add_argument("--port", type=int, default=8765)
+    s.add_argument("--live", action="store_true",
+                   help="re-run the pipeline on every request for report.json")
+    s.set_defaults(func=_serve)
+
+    args = parser.parse_args(argv)
+
+    if not args.repo:
+        parser.error(
+            "no Firefox checkout given. Pass --repo /path/to/firefox, or set "
+            "FENIX_REPO in your environment."
+        )
+    if not os.path.isdir(os.path.join(os.path.expanduser(args.repo), FENIX_APP)):
+        parser.error(
+            "{} does not look like a Firefox checkout - expected to find {} "
+            "under it.".format(args.repo, FENIX_APP)
+        )
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -56,6 +56,24 @@ def run_analysis(args, quiet: bool = False):
         log("\nNo changed files in that range. Try a wider --range.")
         return None
 
+    # The churn comes from the range; the test corpus comes from the checked-out
+    # tree. If they are different revisions the confidence number is wrong, and
+    # nothing else in the pipeline would notice.
+    stray_tip = changes.tip_in_working_tree(repo, change_data["commits"])
+    if stray_tip:
+        log(
+            "\n  !! WARNING - the checkout does not contain the code being analysed.\n"
+            "     Range tip {} is not an ancestor of HEAD in {}.\n"
+            "     Churn is being scored against a DIFFERENT revision's tests, so\n"
+            "     coverage and confidence will be wrong (usually overstated).\n"
+            "\n     Fix - analyse a branch from a worktree of that branch:\n"
+            "       git worktree add --no-checkout ../firefox-beta origin/beta\n"
+            "       cd ../firefox-beta && git sparse-checkout set mobile/android/fenix\n"
+            "       git checkout\n"
+            "       ./plan.py analyze --repo ../firefox-beta --range \"{}\"\n"
+            .format(stray_tip, repo, args.range)
+        )
+
     log("[2/8] mapping paths to features")
     attribution = featuremap.attribute(catalog, change_data["files"])
     log("      {} features touched, {} paths unmapped, {} ignored".format(
@@ -129,6 +147,7 @@ def run_analysis(args, quiet: bool = False):
             "budget_minutes": args.budget,
             "catalog": os.path.abspath(args.catalog),
             "agent_overrides_applied": audit,
+            "tree_mismatch_tip": stray_tip,
         },
         "changes": change_data,
         "attribution": attribution,

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -86,17 +86,25 @@ def run_analysis(args, quiet: bool = False):
     # nothing else in the pipeline would notice.
     stray_tip = changes.tip_in_working_tree(repo, change_data["commits"])
     if stray_tip:
+        # The remediation has to name this platform's branches and directories.
+        # It used to hardcode origin/beta and mobile/android/fenix, which on an
+        # iOS run is confidently wrong advice - worse than no advice.
+        tip_ref = args.range.split("..")[-1].strip() or "the branch"
+        worktree = "../%s-rc" % platform.id
+        sparse = (" && git sparse-checkout set %s" % " ".join(platform.sparse_paths)
+                  if platform.sparse_paths else "")
         log(
             "\n  !! WARNING - the checkout does not contain the code being analysed.\n"
             "     Range tip {} is not an ancestor of HEAD in {}.\n"
             "     Churn is being scored against a DIFFERENT revision's tests, so\n"
             "     coverage and confidence will be wrong (usually overstated).\n"
             "\n     Fix - analyse a branch from a worktree of that branch:\n"
-            "       git worktree add --no-checkout ../firefox-beta origin/beta\n"
-            "       cd ../firefox-beta && git sparse-checkout set mobile/android/fenix\n"
+            "       git worktree add --no-checkout {wt} {ref}\n"
+            "       cd {wt}{sparse}\n"
             "       git checkout\n"
-            "       ./plan.py analyze --repo ../firefox-beta --range \"{}\"\n"
-            .format(stray_tip, repo, args.range)
+            "       ./plan.py analyze --platform {plat} --repo {wt} --range \"{rng}\"\n"
+            .format(stray_tip, repo, wt=worktree, ref=tip_ref,
+                    sparse=sparse, plat=platform.id, rng=args.range)
         )
 
     log("[2/8] mapping paths to features")

--- a/release-test-planner/testplanner/cli.py
+++ b/release-test-planner/testplanner/cli.py
@@ -30,6 +30,21 @@ DEFAULT_PATHSPEC = {
 }
 
 
+
+def _wrap(text: str, width: int):
+    """Minimal word wrap for terminal warnings. textwrap would do, but this keeps
+    the module's imports to what the pipeline needs."""
+    words, line, out = text.split(), "", []
+    for word in words:
+        if line and len(line) + 1 + len(word) > width:
+            out.append(line)
+            line = word
+        else:
+            line = word if not line else line + " " + word
+    if line:
+        out.append(line)
+    return out
+
 def _catalog_for(args, platform) -> str:
     if args.catalog:
         return os.path.abspath(args.catalog)
@@ -130,12 +145,43 @@ def run_analysis(args, quiet: bool = False):
     if args.testrail_export:
         log("      joining TestRail export")
         rail = testrail.build(args.testrail_export, catalog, inventory, cov)
+        rt = rail["totals"]
         log("      {} cases, {} automated ({:.1%}), {} manual-only".format(
-            rail["totals"]["cases"], rail["totals"]["automated"],
-            rail["totals"]["automated_ratio"], rail["totals"]["manual_only"]))
-        if rail["totals"]["unmatched_ids"]:
+            rt["cases"], rt["automated"], rt["automated_ratio"],
+            rt["manual_only"]))
+        if rt["deliberately_manual"]:
+            log("      excluding {} triaged manual-forever: {:.1%} of the {} "
+                "addressable".format(rt["deliberately_manual"],
+                                     rt["automated_ratio_addressable"],
+                                     rt["addressable_cases"]))
+        if rt["status_counts"] and rt["status_counts"] != {"unknown": rt["cases"]}:
+            log("      execution: {} ({} not run, {} not applicable)".format(
+                ", ".join("{} {}".format(v, k)
+                          for k, v in sorted(rt["status_counts"].items(),
+                                             key=lambda kv: -kv[1])),
+                rt["not_run"], rt["excluded"]))
+        if rt["claims"]:
+            log("      TestRail triage: {}".format(", ".join(
+                "{} {}".format(v, k) for k, v in sorted(
+                    rt["claims"].items(), key=lambda kv: -kv[1]))))
+            if rt["claimed_not_in_code"] or rt["in_code_not_claimed"]:
+                log("      disagreement: {} claimed automated with no test "
+                    "linking to them, {} linked by a test but not triaged as "
+                    "automated".format(rt["claimed_not_in_code"],
+                                       rt["in_code_not_claimed"]))
+        if rt["malformed_rows"]:
+            log("      {} row(s) had shifted columns (rich text in a case "
+                "field); their automation status was not trusted".format(
+                    rt["malformed_rows"]))
+        if rail["populations_disjoint"]:
+            log("\n  !! WARNING - this export and the automation reference "
+                "different case sets.")
+            for line in _wrap(rail["disjoint_note"], 72):
+                log("     " + line)
+            log("")
+        elif rt["unmatched_ids"]:
             log("      {} case ids referenced by tests but absent from the "
-                "export".format(rail["totals"]["unmatched_ids"]))
+                "export".format(rt["unmatched_ids"]))
 
     log("[5/8] scoring FMEA risk")
     risk_result = risk.score(attribution, cov)
@@ -338,9 +384,13 @@ def main(argv=None) -> int:
         p.add_argument("--tests-root", default="",
                        help="override the platform's UI test directory, for a "
                             "checkout whose layout differs from the current one")
-        p.add_argument("--testrail-export", default=None,
-                       help="TestRail case export (JSON or CSV) to use as an "
-                            "assumed coverage denominator")
+        p.add_argument("--testrail-export", nargs="*", default=None,
+                       metavar="FILE",
+                       help="TestRail export(s) (JSON or CSV) to use as an "
+                            "assumed coverage denominator. Several are merged "
+                            "by case id: a run export carries the section tree, "
+                            "a case export carries automation triage and the "
+                            "whole suite.")
         p.add_argument("--catalog", default=None,
                        help="feature catalog (default: the platform's)")
         p.add_argument("--environment", default=DEFAULT_ENV,

--- a/release-test-planner/testplanner/corpus.py
+++ b/release-test-planner/testplanner/corpus.py
@@ -4,23 +4,35 @@
 
 """Stage 3: build an inventory of the existing UI test automation.
 
-Deterministic. Parses the Kotlin androidTest sources for both suites:
+Deterministic. Kotlin (Fenix) and Swift (firefox-ios) are parsed by separate
+readers behind one interface, because the two languages declare a test
+differently but the *evidence* we want out of them is identical: what the test
+is called, whether it actually runs, which TestRail case it claims, and which
+app surfaces it drives.
 
-  ui/                  legacy robot-DSL tests
-  ui/efficiency/tests/ modernised page-object tests
+  Android  ui/                  legacy robot-DSL tests
+           ui/efficiency/tests/ modernised page-object tests
+  iOS      XCUITests/           XCUITest classes
 
-For each @Test we record its annotations, TestRail id, and the app surfaces it
-drives. Surfaces come from `on.<pageObject>` in the efficiency suite and from
-`org.mozilla.fenix.ui.robots.*` imports in the legacy suite; they are the
-evidence used to bind a test to a feature when the class name is ambiguous.
+Surfaces are the evidence used to bind a test to a feature when the class name
+is ambiguous. They come from `on.<pageObject>` and `robots.*` imports on
+Android, and from `navigator.goto/nowAt/performAction` - the MappaMundi screen
+graph - on iOS. Same idea, same role in coverage.bind().
+
+**"A test exists" is not "a test runs", on either platform.** Android says so
+with `@Ignore`; iOS says it in `.xctestplan` files, which list skipped tests per
+plan - and they skip a lot of them. A test present in the repo but skipped by
+every plan is not coverage, and counting it as coverage is how a release plan
+ends up confidently wrong.
 """
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from dataclasses import dataclass, field, asdict
-from typing import Dict, List, Set
+from typing import Dict, List, Optional, Set
 
 CLASS_RE = re.compile(r"^\s*(?:open\s+|abstract\s+)?class\s+(\w+)", re.MULTILINE)
 TEST_FN_RE = re.compile(r"\bfun\s+(\w+)\s*\(")
@@ -31,6 +43,23 @@ ROBOT_IMPORT_RE = re.compile(r"import\s+org\.mozilla\.fenix\.ui\.robots\.(\w+)")
 
 # Annotations that mean the test does not run in a normal CI pass.
 DISABLING = {"Ignore", "Suppress", "Manual"}
+
+# ---- Swift / XCUITest -----------------------------------------------------
+
+SWIFT_CLASS_RE = re.compile(r"^\s*(?:final\s+|open\s+|public\s+)?class\s+(\w+)",
+                            re.MULTILINE)
+# XCTest identifies a test by convention, not annotation: an instance method
+# whose name begins with `test`.
+SWIFT_TEST_FN_RE = re.compile(r"^\s*(?:@\w+\s+)*(?:private\s+|public\s+|final\s+)*"
+                              r"func\s+(test\w*)\s*\(")
+# MappaMundi screen graph: the iOS equivalent of `on.<pageObject>`.
+SWIFT_NAV_RE = re.compile(r"navigator\.(?:goto|nowAt)\(\s*([A-Za-z_][\w.]*)")
+SWIFT_ACTION_RE = re.compile(r"navigator\.performAction\(\s*Action\.([A-Za-z_]\w*)")
+# Skips decided in code rather than in a test plan. `guard #available ... else
+# { return }` is the quietest of them: the test reports success having asserted
+# nothing, which is the same failure mode as an all-@Ignore'd Android class.
+SWIFT_SKIP_RE = re.compile(r"\bXCTSkip(?:If|Unless)?\b|\bskipPlatform\b")
+SWIFT_AVAILABILITY_GUARD_RE = re.compile(r"guard\s+#available[^\n]*else\s*\{\s*return")
 
 
 @dataclass
@@ -43,14 +72,27 @@ class TestCase:
     testrail_id: str = ""
     surfaces: List[str] = field(default_factory=list)
     line: int = 0
+    # Which .xctestplan files run this test. `None` means the platform does not
+    # express selection that way (Android); `[]` means every plan skips it,
+    # which is dead automation rather than coverage. Conflating those two would
+    # mark every Android test disabled.
+    plans: Optional[List[str]] = None
+    skipped_in_code: bool = False
 
     @property
     def is_smoke(self) -> bool:
-        return "SmokeTest" in self.annotations
+        if "SmokeTest" in self.annotations:
+            return True
+        return bool(self.plans) and any(p.startswith("Smoketest")
+                                        for p in self.plans)
 
     @property
     def is_disabled(self) -> bool:
-        return any(a in DISABLING for a in self.annotations)
+        if any(a in DISABLING for a in self.annotations):
+            return True
+        if self.skipped_in_code:
+            return True
+        return self.plans is not None and not self.plans
 
 
 def _strip_comments(src: str) -> str:
@@ -121,6 +163,136 @@ def parse_file(path: str, suite: str, repo_root: str) -> List[TestCase]:
     return cases
 
 
+def parse_swift_file(path: str, suite: str, repo_root: str) -> List[TestCase]:
+    """Parse one XCUITest source file.
+
+    XCTest has no @Test annotation: a test is an instance method whose name
+    starts with `test`. The TestRail link is a `//` comment above the method, in
+    the same URL form Fenix uses, so the same regex serves both platforms.
+    """
+    with open(path, errors="replace") as fh:
+        src = fh.read()
+
+    rel = os.path.relpath(path, repo_root)
+    class_match = SWIFT_CLASS_RE.search(src)
+    class_name = (class_match.group(1) if class_match
+                  else os.path.basename(path)[: -len(".swift")])
+
+    # Screens reached in setUp or in helpers apply to every test in the file, the
+    # same way a robot import does on Android.
+    file_surfaces: Set[str] = set()
+    lines = src.splitlines()
+    cases: List[TestCase] = []
+    pending_testrail = ""
+
+    for idx, line in enumerate(lines):
+        rail = TESTRAIL_RE.search(line)
+        if rail:
+            pending_testrail = rail.group(1)
+            continue
+
+        fn = SWIFT_TEST_FN_RE.match(line)
+        if not fn:
+            continue
+
+        body = _test_body(lines, idx)
+        clean = _strip_comments(body)
+        surfaces = set(SWIFT_NAV_RE.findall(clean))
+        surfaces |= {"Action." + a for a in SWIFT_ACTION_RE.findall(clean)}
+        surfaces |= file_surfaces
+
+        cases.append(
+            TestCase(
+                name=fn.group(1),
+                class_name=class_name,
+                suite=suite,
+                file=rel,
+                annotations=[],
+                testrail_id=pending_testrail,
+                surfaces=sorted(surfaces),
+                line=idx + 1,
+                plans=[],
+                skipped_in_code=bool(SWIFT_SKIP_RE.search(clean)
+                                     or SWIFT_AVAILABILITY_GUARD_RE.search(clean)),
+            )
+        )
+        pending_testrail = ""
+
+    return cases
+
+
+def load_test_plans(repo_root: str, plan_root: str,
+                    test_target: str = "") -> Dict[str, Dict[str, Set[str]]]:
+    """Read .xctestplan files into {plan name: skip/selection sets}.
+
+    Only the target named `test_target` is read. Most plans in firefox-ios do not
+    include XCUITests at all - UnitTest.xctestplan lists two dozen unit-test
+    targets - and collapsing every target together made those plans look as
+    though they ran all 536 UI tests.
+
+    Skip entries take two shapes: `ClassName` skips the whole class, and
+    `ClassName/testMethod()` skips one method. Both matter - resolving only the
+    method form would silently treat a wholly skipped class as running.
+    """
+    plans: Dict[str, Dict[str, Set[str]]] = {}
+    root = os.path.join(repo_root, plan_root)
+    if not os.path.isdir(root):
+        return plans
+
+    for entry in sorted(os.listdir(root)):
+        if not entry.endswith(".xctestplan"):
+            continue
+        try:
+            with open(os.path.join(root, entry), errors="replace") as fh:
+                data = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            continue
+
+        targets = [t for t in data.get("testTargets", [])
+                   if not test_target
+                   or t.get("target", {}).get("name") == test_target]
+        if not targets:
+            continue        # this plan does not run the UI tests at all
+
+        classes: Set[str] = set()
+        tests: Set[str] = set()
+        selected: Set[str] = set()
+        for target in targets:
+            for skipped in target.get("skippedTests", []) or []:
+                if "/" in skipped:
+                    tests.add(skipped.split("/", 1)[1].rstrip("()"))
+                else:
+                    classes.add(skipped)
+            for chosen in target.get("selectedTests", []) or []:
+                selected.add(chosen.split("/", 1)[-1].rstrip("()")
+                             if "/" in chosen else chosen)
+        plans[entry[: -len(".xctestplan")]] = {
+            "skipped_classes": classes,
+            "skipped_tests": tests,
+            "selected": selected,
+        }
+    return plans
+
+
+def _runs_in(plan: Dict[str, Set[str]], case: TestCase) -> bool:
+    # A plan with an explicit selection runs only that; otherwise it runs
+    # everything except its skip lists.
+    if plan["selected"]:
+        return case.name in plan["selected"] or case.class_name in plan["selected"]
+    if case.class_name in plan["skipped_classes"]:
+        return False
+    return case.name not in plan["skipped_tests"]
+
+
+def apply_test_plans(cases: List[TestCase],
+                     plans: Dict[str, Dict[str, Set[str]]]) -> None:
+    for case in cases:
+        if case.plans is None:
+            continue
+        case.plans = sorted(name for name, plan in plans.items()
+                            if _runs_in(plan, case))
+
+
 def _test_body(lines: List[str], start: int, max_lines: int = 120) -> str:
     """Grab the body of the test function starting at `start` by brace depth."""
     depth = 0
@@ -136,34 +308,56 @@ def _test_body(lines: List[str], start: int, max_lines: int = 120) -> str:
     return "\n".join(out)
 
 
-def build(repo_root: str, fenix_test_root: str) -> Dict:
-    """Scan both UI suites and return the full test inventory."""
-    legacy_dir = os.path.join(repo_root, fenix_test_root)
-    efficiency_dir = os.path.join(legacy_dir, "efficiency", "tests")
+def build(repo_root: str, platform, tests_root: str = "") -> Dict:
+    """Scan the platform's UI suites and return the full test inventory.
+
+    `tests_root` overrides the platform's first test root, for a checkout whose
+    layout differs from the current one - firefox-ios moved everything under
+    `firefox-ios/` at v106, and old release branches are still flat.
+    """
+    readers = {".kt": parse_file, ".swift": parse_swift_file}
+    reader = readers[platform.extension]
+
+    roots = platform.roots(repo_root)
+    if tests_root:
+        roots = [(os.path.join(repo_root, tests_root), roots[0][1])] + list(roots[1:])
 
     cases: List[TestCase] = []
+    missing: List[str] = []
+    for directory, suite in roots:
+        if not os.path.isdir(directory):
+            missing.append(os.path.relpath(directory, repo_root))
+            continue
+        for entry in sorted(os.listdir(directory)):
+            if entry.endswith(platform.extension):
+                cases += reader(os.path.join(directory, entry), suite, repo_root)
 
-    for entry in sorted(os.listdir(legacy_dir)):
-        if entry.endswith(".kt"):
-            cases += parse_file(os.path.join(legacy_dir, entry), "ui", repo_root)
-
-    if os.path.isdir(efficiency_dir):
-        for entry in sorted(os.listdir(efficiency_dir)):
-            if entry.endswith(".kt"):
-                cases += parse_file(
-                    os.path.join(efficiency_dir, entry), "ui.efficiency", repo_root
-                )
+    plans: Dict[str, Dict[str, Set[str]]] = {}
+    if platform.test_plan_root:
+        plans = load_test_plans(repo_root, platform.test_plan_root,
+                                platform.test_target)
+        apply_test_plans(cases, plans)
 
     by_suite: Dict[str, int] = {}
     for c in cases:
         by_suite[c.suite] = by_suite.get(c.suite, 0) + 1
 
+    per_plan = {
+        name: sum(1 for c in cases if c.plans and name in c.plans)
+        for name in sorted(plans)
+    }
+
     return {
+        "platform": platform.id,
         "total_tests": len(cases),
         "by_suite": by_suite,
         "smoke_tests": sum(1 for c in cases if c.is_smoke),
         "disabled_tests": sum(1 for c in cases if c.is_disabled),
         "with_testrail_id": sum(1 for c in cases if c.testrail_id),
+        # Empty is the signal that matters: it means the roots below were not
+        # found, so "no tests" is a wrong path rather than a bare repo.
+        "missing_roots": missing,
+        "test_plans": per_plan,
         "tests": [
             dict(
                 asdict(c),

--- a/release-test-planner/testplanner/corpus.py
+++ b/release-test-planner/testplanner/corpus.py
@@ -1,0 +1,175 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 3: build an inventory of the existing UI test automation.
+
+Deterministic. Parses the Kotlin androidTest sources for both suites:
+
+  ui/                  legacy robot-DSL tests
+  ui/efficiency/tests/ modernised page-object tests
+
+For each @Test we record its annotations, TestRail id, and the app surfaces it
+drives. Surfaces come from `on.<pageObject>` in the efficiency suite and from
+`org.mozilla.fenix.ui.robots.*` imports in the legacy suite; they are the
+evidence used to bind a test to a feature when the class name is ambiguous.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Set
+
+CLASS_RE = re.compile(r"^\s*(?:open\s+|abstract\s+)?class\s+(\w+)", re.MULTILINE)
+TEST_FN_RE = re.compile(r"\bfun\s+(\w+)\s*\(")
+ANNOTATION_RE = re.compile(r"^\s*@(\w+)")
+TESTRAIL_RE = re.compile(r"cases/view/(\d+)")
+PAGE_OBJECT_RE = re.compile(r"\bon\.(\w+)")
+ROBOT_IMPORT_RE = re.compile(r"import\s+org\.mozilla\.fenix\.ui\.robots\.(\w+)")
+
+# Annotations that mean the test does not run in a normal CI pass.
+DISABLING = {"Ignore", "Suppress", "Manual"}
+
+
+@dataclass
+class TestCase:
+    name: str
+    class_name: str
+    suite: str
+    file: str
+    annotations: List[str] = field(default_factory=list)
+    testrail_id: str = ""
+    surfaces: List[str] = field(default_factory=list)
+    line: int = 0
+
+    @property
+    def is_smoke(self) -> bool:
+        return "SmokeTest" in self.annotations
+
+    @property
+    def is_disabled(self) -> bool:
+        return any(a in DISABLING for a in self.annotations)
+
+
+def _strip_comments(src: str) -> str:
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    return re.sub(r"//[^\n]*", "", src)
+
+
+def parse_file(path: str, suite: str, repo_root: str) -> List[TestCase]:
+    with open(path, errors="replace") as fh:
+        src = fh.read()
+
+    rel = os.path.relpath(path, repo_root)
+    class_match = CLASS_RE.search(src)
+    class_name = class_match.group(1) if class_match else os.path.basename(path)[:-3]
+
+    file_surfaces: Set[str] = set(ROBOT_IMPORT_RE.findall(src))
+
+    lines = src.splitlines()
+    cases: List[TestCase] = []
+
+    pending_annotations: List[str] = []
+    pending_testrail = ""
+
+    for idx, line in enumerate(lines):
+        stripped = line.strip()
+
+        rail = TESTRAIL_RE.search(stripped)
+        if rail:
+            pending_testrail = rail.group(1)
+            continue
+
+        ann = ANNOTATION_RE.match(line)
+        if ann:
+            pending_annotations.append(ann.group(1))
+            continue
+
+        if "Test" not in pending_annotations:
+            # Reset the TestRail hint if we drift past a non-annotated block.
+            if stripped and not stripped.startswith("@") and not stripped.startswith("*"):
+                if not stripped.startswith("fun "):
+                    pending_annotations = []
+                    pending_testrail = ""
+            continue
+
+        fn = TEST_FN_RE.search(line)
+        if not fn:
+            continue
+
+        body = _test_body(lines, idx)
+        surfaces = set(PAGE_OBJECT_RE.findall(_strip_comments(body)))
+        surfaces |= file_surfaces
+
+        cases.append(
+            TestCase(
+                name=fn.group(1),
+                class_name=class_name,
+                suite=suite,
+                file=rel,
+                annotations=sorted(set(pending_annotations)),
+                testrail_id=pending_testrail,
+                surfaces=sorted(surfaces),
+                line=idx + 1,
+            )
+        )
+        pending_annotations = []
+        pending_testrail = ""
+
+    return cases
+
+
+def _test_body(lines: List[str], start: int, max_lines: int = 120) -> str:
+    """Grab the body of the test function starting at `start` by brace depth."""
+    depth = 0
+    seen_open = False
+    out = []
+    for line in lines[start : start + max_lines]:
+        out.append(line)
+        depth += line.count("{") - line.count("}")
+        if "{" in line:
+            seen_open = True
+        if seen_open and depth <= 0:
+            break
+    return "\n".join(out)
+
+
+def build(repo_root: str, fenix_test_root: str) -> Dict:
+    """Scan both UI suites and return the full test inventory."""
+    legacy_dir = os.path.join(repo_root, fenix_test_root)
+    efficiency_dir = os.path.join(legacy_dir, "efficiency", "tests")
+
+    cases: List[TestCase] = []
+
+    for entry in sorted(os.listdir(legacy_dir)):
+        if entry.endswith(".kt"):
+            cases += parse_file(os.path.join(legacy_dir, entry), "ui", repo_root)
+
+    if os.path.isdir(efficiency_dir):
+        for entry in sorted(os.listdir(efficiency_dir)):
+            if entry.endswith(".kt"):
+                cases += parse_file(
+                    os.path.join(efficiency_dir, entry), "ui.efficiency", repo_root
+                )
+
+    by_suite: Dict[str, int] = {}
+    for c in cases:
+        by_suite[c.suite] = by_suite.get(c.suite, 0) + 1
+
+    return {
+        "total_tests": len(cases),
+        "by_suite": by_suite,
+        "smoke_tests": sum(1 for c in cases if c.is_smoke),
+        "disabled_tests": sum(1 for c in cases if c.is_disabled),
+        "with_testrail_id": sum(1 for c in cases if c.testrail_id),
+        "tests": [
+            dict(
+                asdict(c),
+                is_smoke=c.is_smoke,
+                is_disabled=c.is_disabled,
+            )
+            for c in cases
+        ],
+    }

--- a/release-test-planner/testplanner/coverage.py
+++ b/release-test-planner/testplanner/coverage.py
@@ -1,0 +1,194 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 4: bind existing tests to features and score coverage depth.
+
+Deterministic. Two independent signals bind a test to a feature:
+
+  name   the test class name matches one of the feature's test_patterns
+  surface the test drives one of the feature's page objects / robots
+
+Two signals agreeing is treated as strong evidence; one alone is weaker and is
+recorded as such so an agent can review the thin bindings rather than trusting
+them silently.
+"""
+
+from __future__ import annotations
+
+import math
+import re
+from typing import Dict, List
+
+# FMEA Detection runs 1-10, higher = LESS likely to catch a defect before
+# release. Inverting coverage this way is what makes RPN fall as automation
+# improves, per IEC 60812.
+#
+# Detection is CONTINUOUS rather than tiered. A step function would give the
+# second test added to a feature exactly zero marginal gain, and the greedy
+# planner would stall on that plateau instead of continuing to select tests.
+# The curve below decays from 10 (nothing would catch it) asymptotically toward
+# 2 (a defect would have to survive the whole suite), so every added test earns
+# a positive but diminishing gain - which is also the honest shape, since
+# redundant tests really do buy less than the first one.
+DETECTION_FLOOR = 2.0
+DETECTION_CEILING = 10.0
+DECAY = 0.35
+
+# Weights on what a test is worth as evidence.
+#
+# The binding weights matter more than they look. Almost every legacy test
+# imports homeScreen/navigationToolbar in order to NAVIGATE somewhere else, not
+# because it verifies the home screen. Counting those as coverage credited the
+# Home Screen feature with 500+ tests and made it look deeply covered when
+# nothing was actually asserting on it. Overstated coverage is worse than no
+# coverage - it suppresses the RPN that should have triggered a manual test -
+# so an incidental binding is worth almost nothing until an agent confirms it.
+# An incidental binding is worth zero until an agent confirms it: the planner
+# already refuses to schedule those tests, so letting them lower Detection here
+# would promise risk reduction the plan cannot deliver. They stay recorded on
+# the feature so they can be reviewed and promoted.
+SMOKE_WEIGHT = 1.5
+BINDING_WEIGHT = {
+    "strong": 1.0,
+    "name-only": 0.8,
+    "incidental": 0.0,
+}
+
+TIER_BY_DETECTION = [
+    (9.5, "none"),
+    (8.0, "minimal"),
+    (6.5, "thin"),
+    (5.0, "moderate"),
+    (3.5, "good"),
+    (0.0, "deep"),
+]
+
+
+def effective_tests(tests: List[Dict]) -> float:
+    """Weighted count of tests that actually count as evidence."""
+    total = 0.0
+    for t in tests:
+        if t.get("is_disabled"):
+            continue
+        w = BINDING_WEIGHT.get(t.get("binding", "strong"), 1.0)
+        if t.get("is_smoke"):
+            w *= SMOKE_WEIGHT
+        total += w
+    return total
+
+
+def detection_for(tests: List[Dict]) -> float:
+    n = effective_tests(tests)
+    if n <= 0:
+        return DETECTION_CEILING
+    span = DETECTION_CEILING - DETECTION_FLOOR
+    return round(DETECTION_CEILING - span * (1 - math.exp(-DECAY * n)), 3)
+
+
+def tier_for(detection: float) -> str:
+    for threshold, label in TIER_BY_DETECTION:
+        if detection >= threshold:
+            return label
+    return "deep"
+
+
+def _normalise(surface: str) -> str:
+    """Reduce a page object or robot name to a comparable stem.
+
+    downloadRobot -> download ; settingsAutofill -> settingsautofill
+    """
+    s = re.sub(r"(Robot|Screen|Page|Component|Overlay)$", "", surface)
+    return s.lower().rstrip("s")
+
+
+def bind(catalog, inventory: Dict) -> Dict:
+    """Attach tests to every feature they plausibly cover."""
+    tests = inventory["tests"]
+
+    feature_surface_stems = {
+        f.id: {_normalise(p) for p in f.page_objects} for f in catalog
+    }
+    feature_patterns = {f.id: f.test_patterns for f in catalog}
+
+    per_feature: Dict[str, Dict] = {
+        f.id: {
+            "feature_id": f.id,
+            "name": f.name,
+            "tests": [],
+        }
+        for f in catalog
+    }
+
+    unbound: List[Dict] = []
+
+    for test in tests:
+        stems = {_normalise(s) for s in test["surfaces"]}
+        matched_any = False
+
+        for feature in catalog:
+            name_hit = any(
+                p.lower() in test["class_name"].lower()
+                for p in feature_patterns[feature.id]
+                if p
+            )
+            surface_hit = bool(stems & feature_surface_stems[feature.id])
+
+            if not (name_hit or surface_hit):
+                continue
+
+            if name_hit and surface_hit:
+                strength = "strong"
+            elif name_hit:
+                strength = "name-only"
+            else:
+                # Drives the surface but is not named for it - most often a
+                # test navigating through this feature to reach another one.
+                strength = "incidental"
+
+            per_feature[feature.id]["tests"].append(
+                dict(test, binding=strength)
+            )
+            matched_any = True
+
+        if not matched_any:
+            unbound.append(test)
+
+    for entry in per_feature.values():
+        entry.update(_score(entry["tests"]))
+
+    return {
+        "per_feature": per_feature,
+        "unbound_tests": unbound,
+        "unbound_count": len(unbound),
+    }
+
+
+def _score(tests: List[Dict]) -> Dict:
+    """Turn a set of bound tests into a coverage tier and Detection factor."""
+    total = len(tests)
+    active = [t for t in tests if not t["is_disabled"]]
+    smoke = [t for t in active if t["is_smoke"]]
+    strong = [t for t in active if t["binding"] == "strong"]
+    incidental = [t for t in active if t["binding"] == "incidental"]
+    modern = [t for t in active if t["suite"] == "ui.efficiency"]
+
+    detection = detection_for(tests)
+    # Automation that exists but is switched off is worth calling out by name;
+    # numerically it is still no detection at all.
+    tier = "disabled-only" if total and not active else tier_for(detection)
+
+    return {
+        "test_count": total,
+        "active_count": len(active),
+        "smoke_count": len(smoke),
+        "strong_binding_count": len(strong),
+        "incidental_count": len(incidental),
+        "direct_count": len(active) - len(incidental),
+        "modernised_count": len(modern),
+        "disabled_count": total - len(active),
+        "effective_tests": round(effective_tests(tests), 2),
+        "coverage_tier": tier,
+        "detection": detection,
+        "modernisation_ratio": round(len(modern) / len(active), 2) if active else 0.0,
+    }

--- a/release-test-planner/testplanner/factories.py
+++ b/release-test-planner/testplanner/factories.py
@@ -295,3 +295,28 @@ def attribute_to_features(scan_result: Dict, catalog, risk_rows: List[Dict]) -> 
         )
 
     return sorted(per_feature.values(), key=lambda e: e["rpn"], reverse=True)
+
+
+def empty(platform_id: str) -> Dict:
+    """A scan result for a platform that has no generated-test factories.
+
+    Every count is zero and `has_candidate_space` is False, so downstream code
+    reports "no derived denominator" rather than dividing by a number that was
+    never computed. Estimating a candidate space here would fabricate exactly
+    the quantity the model's coverage claims rest on.
+    """
+    return {
+        "platform": platform_id,
+        "has_candidate_space": False,
+        "total_candidates": 0,
+        "page_count": 0,
+        "capabilities": [],
+        "capability_features": [],
+        "templates": [],
+        "factories": [],
+        "selectors_per_page": {},
+        "context_factors": [],
+        "context_profiles": {},
+        "reason": "no factory framework on this platform; coverage has no "
+                  "derived denominator",
+    }

--- a/release-test-planner/testplanner/factories.py
+++ b/release-test-planner/testplanner/factories.py
@@ -1,0 +1,297 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Model the generated-test candidate space.
+
+The efficiency framework does not only contain hand-written tests. Under
+`generation/` there are factories that synthesise cases from the page-object
+model, and they scale very differently from hand-written ones:
+
+  interaction   one case per interactive selector per page
+  behavior      capability x template x context variant
+  pairs         one case per ordered page-to-page transition
+  reachability  one case per reachable page
+
+That is the explosion the planner exists to filter. A pairs factory over 51
+page objects is 2,550 candidates before anyone has decided whether a single one
+of them is worth running this cycle. Risk is what turns that catalogue into a
+run list.
+
+Real counts are parsed from the tree. Where the framework is still early - the
+behavior capability catalog currently covers only bookmarks - the parsed number
+is small and is reported as-is rather than inflated, with a projection showing
+what the same machinery yields once the catalog is filled in.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Dict, List
+
+from .coverage import _normalise
+
+SELECTOR_RE = re.compile(r"\bSelector\s*\(")
+CAPABILITY_RE = re.compile(
+    r"BehaviorCapability\s*\(\s*id\s*=\s*\"([^\"]+)\"\s*,\s*"
+    r"feature\s*=\s*\"([^\"]+)\"\s*,\s*"
+    r"entity\s*=\s*\"([^\"]+)\"\s*,\s*"
+    r"operation\s*=\s*BehaviorOperation\.(\w+)",
+    re.DOTALL,
+)
+TEMPLATE_RE = re.compile(r"BehaviorTemplate\s*\(\s*id\s*=\s*\"([^\"]+)\"")
+LIST_OF_RE = re.compile(r"val\s+(\w+)\s*=\s*listOf\(([^)]*)\)")
+STRING_RE = re.compile(r"\"([^\"]*)\"")
+PAGE_FIELD_RE = re.compile(r"val\s+(\w+)\s*=\s*\w+(?:Page|Component)\s*\(")
+
+
+def _read(path: str) -> str:
+    if not os.path.exists(path):
+        return ""
+    with open(path, errors="replace") as fh:
+        return fh.read()
+
+
+def scan(repo_root: str, efficiency_root: str) -> Dict:
+    """Parse the generation framework and quantify the candidate space."""
+    eff = os.path.join(repo_root, efficiency_root)
+    gen = os.path.join(eff, "generation")
+
+    # ---- interaction factory: selectors per page -------------------------
+    selectors_dir = os.path.join(eff, "selectors")
+    per_page: Dict[str, int] = {}
+    if os.path.isdir(selectors_dir):
+        for entry in sorted(os.listdir(selectors_dir)):
+            if not entry.endswith(".kt"):
+                continue
+            stem = entry[:-3].replace("Selectors", "")
+            per_page[stem] = len(SELECTOR_RE.findall(_read(os.path.join(selectors_dir, entry))))
+    total_selectors = sum(per_page.values())
+
+    # ---- page objects ----------------------------------------------------
+    page_src = _read(os.path.join(eff, "helpers", "PageContext.kt"))
+    pages = [m for m in PAGE_FIELD_RE.findall(page_src)]
+    page_count = len(pages)
+
+    # ---- behavior factory ------------------------------------------------
+    cap_src = _read(os.path.join(gen, "behavior", "BehaviorCapability.kt"))
+    capabilities = [
+        {"id": cid, "feature": feat, "entity": ent, "operation": op}
+        for cid, feat, ent, op in CAPABILITY_RE.findall(cap_src)
+    ]
+    templates = TEMPLATE_RE.findall(
+        _read(os.path.join(gen, "behavior", "BehaviorTemplate.kt"))
+    )
+
+    # ---- context matrix: the real product-state factors ------------------
+    ctx_src = _read(os.path.join(gen, "behavior", "BehaviorContextMatrix.kt"))
+    context_factors = []
+    for var_name, body in LIST_OF_RE.findall(ctx_src):
+        values = STRING_RE.findall(body)
+        if len(values) < 2:
+            continue
+        context_factors.append(
+            {
+                "name": _factor_name(var_name),
+                "levels": values,
+                "source": "real",
+                "origin": "BehaviorContextMatrix.kt::exhaustivePreview",
+            }
+        )
+
+    profiles = _profile_sizes(ctx_src, context_factors)
+
+    # ---- candidate counts ------------------------------------------------
+    exhaustive_contexts = profiles.get("EXHAUSTIVE_PREVIEW", 1)
+    behavior_matched = _match_capabilities_to_templates(capabilities, templates)
+
+    factories = [
+        {
+            "id": "interaction",
+            "name": "Interaction factory",
+            "unit": "one case per interactive selector, per page",
+            "candidates": total_selectors,
+            "basis": "{} selectors across {} selector objects".format(
+                total_selectors, len(per_page)
+            ),
+            "source": "parsed",
+        },
+        {
+            "id": "reachability",
+            "name": "Reachability factory",
+            "unit": "one case per page reachable from the launch state",
+            "candidates": page_count,
+            "basis": "{} page objects on PageContext".format(page_count),
+            "source": "parsed",
+        },
+        {
+            "id": "pairs",
+            "name": "Pairs factory",
+            "unit": "one case per ordered page-to-page transition",
+            "candidates": page_count * (page_count - 1),
+            "basis": "{} pages, ordered pairs".format(page_count),
+            "source": "parsed",
+        },
+        {
+            "id": "behavior",
+            "name": "Behavior factory",
+            "unit": "capability x template x context variant",
+            "candidates": behavior_matched * exhaustive_contexts,
+            "basis": "{} capability/template matches x {} exhaustive contexts".format(
+                behavior_matched, exhaustive_contexts
+            ),
+            "source": "parsed",
+            "note": (
+                "The capability catalog currently covers bookmarks only, so this "
+                "is small today. Projected at one capability set per feature it "
+                "is the largest factory of the four."
+            ),
+            "projection": _behavior_projection(templates, exhaustive_contexts),
+        },
+    ]
+
+    return {
+        "factories": factories,
+        "total_candidates": sum(f["candidates"] for f in factories),
+        "selectors_per_page": per_page,
+        "page_count": page_count,
+        "capabilities": capabilities,
+        "capability_features": sorted({c["feature"] for c in capabilities}),
+        "templates": templates,
+        "context_factors": context_factors,
+        "context_profiles": profiles,
+    }
+
+
+def _factor_name(var_name: str) -> str:
+    """browserModes -> BrowserMode, deviceClasses -> DeviceClass, pocketValues -> Pocket."""
+    if var_name.endswith("Values"):
+        name = var_name[: -len("Values")]
+    elif var_name.endswith("Classes"):
+        name = var_name[: -len("es")]
+    elif var_name.endswith("s"):
+        name = var_name[:-1]
+    else:
+        name = var_name
+    return name[:1].upper() + name[1:]
+
+
+def _profile_sizes(src: str, factors: List[Dict]) -> Dict[str, int]:
+    """Variant count per BehaviorMatrixProfile."""
+    sizes = {}
+    for profile, fn in [
+        ("SMOKE", "smoke"),
+        ("BASE_FLAGS", "baseFlags"),
+        ("PAIRWISE_PREVIEW", "pairwisePreview"),
+    ]:
+        block = re.search(
+            r"private fun {}\(\).*?(?=\n    private fun |\n\}})".format(fn),
+            src,
+            re.DOTALL,
+        )
+        sizes[profile] = len(re.findall(r"defaultContext\(", block.group(0))) if block else 0
+
+    exhaustive = 1
+    for f in factors:
+        exhaustive *= len(f["levels"])
+    sizes["EXHAUSTIVE_PREVIEW"] = exhaustive
+    return sizes
+
+
+def _match_capabilities_to_templates(capabilities: List[Dict], templates: List[str]) -> int:
+    """How many (capability-set, template) pairs are actually satisfiable.
+
+    A template needs every operation it requires to exist for the same
+    feature/entity pair, so the real number is well below capabilities x
+    templates.
+    """
+    by_entity: Dict[tuple, set] = {}
+    for cap in capabilities:
+        by_entity.setdefault((cap["feature"], cap["entity"]), set()).add(cap["operation"])
+
+    matched = 0
+    for ops in by_entity.values():
+        for template in templates:
+            required = _template_ops(template)
+            if required and required <= ops:
+                matched += 1
+    return matched
+
+
+def _template_ops(template_id: str) -> set:
+    """Infer required operations from the template id."""
+    ops = set()
+    if "create" in template_id:
+        ops.add("CREATE")
+    if "delete.cancel" in template_id:
+        ops.add("CANCEL_DELETE")
+    elif "delete" in template_id:
+        ops.add("DELETE")
+    return ops
+
+
+def _behavior_projection(templates: List[str], contexts: int) -> Dict:
+    """What the behavior factory yields once the catalog covers more features."""
+    projected_entities = 30  # stub: roughly one CRUD entity per catalogued feature
+    return {
+        "assumed_entities": projected_entities,
+        "templates": len(templates),
+        "contexts": contexts,
+        "candidates": projected_entities * len(templates) * contexts,
+        "source": "stubbed projection",
+    }
+
+
+def attribute_to_features(scan_result: Dict, catalog, risk_rows: List[Dict]) -> List[Dict]:
+    """Split factory candidates across the features touched this cycle.
+
+    Interaction, reachability and pairs candidates belong to whichever feature
+    owns the page object. Behavior candidates carry their own `feature` field.
+    """
+    touched = {r["feature_id"]: r for r in risk_rows}
+
+    stem_to_feature = {}
+    for feature in catalog:
+        for po in feature.page_objects:
+            stem_to_feature[_normalise(po)] = feature.id
+
+    per_feature: Dict[str, Dict] = {
+        fid: {
+            "feature_id": fid,
+            "name": row["name"],
+            "band": row["band"],
+            "rpn": row["rpn"],
+            "interaction": 0,
+            "reachability": 0,
+            "pairs": 0,
+            "behavior": 0,
+        }
+        for fid, row in touched.items()
+    }
+
+    for stem, count in scan_result["selectors_per_page"].items():
+        fid = stem_to_feature.get(_normalise(stem))
+        if fid in per_feature:
+            per_feature[fid]["interaction"] += count
+            per_feature[fid]["reachability"] += 1
+
+    page_count = scan_result["page_count"]
+    for fid, entry in per_feature.items():
+        # A feature's share of the pairs space is its pages against all others.
+        entry["pairs"] = entry["reachability"] * (page_count - 1)
+
+    contexts = scan_result["context_profiles"].get("EXHAUSTIVE_PREVIEW", 1)
+    templates = len(scan_result["templates"])
+    for cap in scan_result["capabilities"]:
+        fid = cap["feature"]
+        if fid in per_feature:
+            per_feature[fid]["behavior"] += templates * contexts
+
+    for entry in per_feature.values():
+        entry["total"] = (
+            entry["interaction"] + entry["reachability"]
+            + entry["pairs"] + entry["behavior"]
+        )
+
+    return sorted(per_feature.values(), key=lambda e: e["rpn"], reverse=True)

--- a/release-test-planner/testplanner/featuremap.py
+++ b/release-test-planner/testplanner/featuremap.py
@@ -1,0 +1,164 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 2: map changed source paths onto user-facing features.
+
+Deterministic where the catalog has a rule. Paths that match nothing are not
+silently dropped - they are collected as open questions for an AI agent to
+classify, because "we did not recognise this code" is itself a risk signal.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import json
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+# Paths that legitimately carry no release risk for the app under test.
+IGNORED_GLOBS = [
+    "**/test/**",
+    "**/androidTest/**",
+    "**/*Test.kt",
+    "**/*Spec.kt",
+    "**/docs/**",
+    "**/*.md",
+]
+
+
+@dataclass
+class Feature:
+    id: str
+    name: str
+    severity: int
+    severity_rationale: str = ""
+    iso25010: List[str] = field(default_factory=list)
+    source_globs: List[str] = field(default_factory=list)
+    page_objects: List[str] = field(default_factory=list)
+    test_patterns: List[str] = field(default_factory=list)
+    # Cross-cutting code that no UI test is named for. It is exercised by the
+    # whole suite rather than by a dedicated test, so a zero here means "not
+    # directly covered", not "never executed".
+    indirect: bool = False
+
+
+class FeatureCatalog:
+    def __init__(self, features: List[Feature]):
+        self.features = features
+        self._by_id = {f.id: f for f in features}
+
+    @classmethod
+    def load(cls, path: str) -> "FeatureCatalog":
+        with open(path) as fh:
+            data = json.load(fh)
+        return cls([Feature(**f) for f in data["features"]])
+
+    def get(self, feature_id: str) -> Optional[Feature]:
+        return self._by_id.get(feature_id)
+
+    def __iter__(self):
+        return iter(self.features)
+
+    def match(self, path: str) -> List[tuple]:
+        """Return [(feature, glob_specificity)] for every feature matching path."""
+        hits = []
+        for feature in self.features:
+            best = 0
+            for glob in feature.source_globs:
+                if _glob_match(path, glob):
+                    best = max(best, _specificity(glob))
+            if best:
+                hits.append((feature, best))
+        return sorted(hits, key=lambda h: h[1], reverse=True)
+
+
+def _glob_match(path: str, glob: str) -> bool:
+    if fnmatch.fnmatch(path, glob):
+        return True
+    # fnmatch does not treat ** as spanning separators, so also try a
+    # separator-insensitive form for the common "**/pkg/**" shape.
+    if "**/" in glob:
+        tail = glob.replace("**/", "", 1)
+        return fnmatch.fnmatch(path, "*" + tail) or fnmatch.fnmatch(path, tail)
+    return False
+
+
+def _specificity(glob: str) -> int:
+    """Longer, less-wildcarded globs win when several features match."""
+    return len(glob.replace("*", ""))
+
+
+def is_ignored(path: str) -> bool:
+    return any(_glob_match(path, g) for g in IGNORED_GLOBS)
+
+
+def attribute(catalog: FeatureCatalog, files: List[Dict]) -> Dict:
+    """Attribute changed files to features.
+
+    Each file gets one primary feature (longest matching glob) plus any
+    secondary features it also touches. Risk is aggregated on the primary so
+    that a single change is not counted several times over.
+    """
+    per_feature: Dict[str, Dict] = {}
+    unmapped: List[Dict] = []
+    ignored: List[str] = []
+
+    for fc in files:
+        path = fc["path"]
+
+        if is_ignored(path):
+            ignored.append(path)
+            continue
+
+        hits = catalog.match(path)
+        if not hits:
+            unmapped.append(fc)
+            continue
+
+        primary = hits[0][0]
+        secondary = [f.id for f, _ in hits[1:]]
+
+        bucket = per_feature.setdefault(
+            primary.id,
+            {
+                "feature_id": primary.id,
+                "name": primary.name,
+                "severity": primary.severity,
+                "severity_rationale": primary.severity_rationale,
+                "iso25010": primary.iso25010,
+                "indirect": primary.indirect,
+                "files": [],
+                "added": 0,
+                "deleted": 0,
+                "churned_lines": 0,
+                "total_lines": 0,
+                "commits": set(),
+                "authors": 0,
+                "backout_touched": False,
+            },
+        )
+        bucket["files"].append(dict(fc, secondary_features=secondary))
+        bucket["added"] += fc["added"]
+        bucket["deleted"] += fc["deleted"]
+        bucket["churned_lines"] += fc["churned_lines"]
+        bucket["total_lines"] += fc["total_lines"]
+        bucket["authors"] = max(bucket["authors"], fc["authors"])
+        bucket["backout_touched"] = (
+            bucket["backout_touched"] or fc["touched_by_backout"]
+        )
+
+    for bucket in per_feature.values():
+        bucket["file_count"] = len(bucket["files"])
+        bucket["commits"] = sum(f["commits"] for f in bucket["files"])
+        total = max(bucket["total_lines"], 1)
+        bucket["m1_churn_ratio"] = round(bucket["churned_lines"] / total, 4)
+        bucket["m2_delete_ratio"] = round(bucket["deleted"] / total, 4)
+
+    return {
+        "features_touched": sorted(
+            per_feature.values(), key=lambda b: b["churned_lines"], reverse=True
+        ),
+        "unmapped_files": unmapped,
+        "ignored_count": len(ignored),
+    }

--- a/release-test-planner/testplanner/featuremap.py
+++ b/release-test-planner/testplanner/featuremap.py
@@ -42,6 +42,10 @@ class Feature:
     source_globs: List[str] = field(default_factory=list)
     page_objects: List[str] = field(default_factory=list)
     test_patterns: List[str] = field(default_factory=list)
+    # Vocabulary used in TestRail section and case titles, which is prose written
+    # by hand over years and does not line up with the catalog's names by luck.
+    # Only used to attribute TestRail cases - never for source attribution.
+    testrail_keywords: List[str] = field(default_factory=list)
     # Cross-cutting code that no UI test is named for. It is exercised by the
     # whole suite rather than by a dedicated test, so a zero here means "not
     # directly covered", not "never executed".

--- a/release-test-planner/testplanner/featuremap.py
+++ b/release-test-planner/testplanner/featuremap.py
@@ -16,7 +16,12 @@ import json
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-# Paths that legitimately carry no release risk for the app under test.
+# Paths that legitimately carry no release risk for the app under test. A
+# catalog can replace this with `_ignored_globs`, because what counts as
+# "not app code" is platform-specific: on iOS the test targets, asset catalogs
+# and Xcode plumbing would otherwise show up as unmapped feature churn, which
+# reads as "we did not recognise this code" - a risk signal - when it is really
+# just a test file.
 IGNORED_GLOBS = [
     "**/test/**",
     "**/androidTest/**",
@@ -44,15 +49,24 @@ class Feature:
 
 
 class FeatureCatalog:
-    def __init__(self, features: List[Feature]):
+    def __init__(self, features: List[Feature],
+                 ignored_globs: Optional[List[str]] = None,
+                 platform: str = ""):
         self.features = features
+        self.platform = platform
+        self.ignored_globs = (list(ignored_globs) if ignored_globs
+                              else list(IGNORED_GLOBS))
         self._by_id = {f.id: f for f in features}
 
     @classmethod
     def load(cls, path: str) -> "FeatureCatalog":
         with open(path) as fh:
             data = json.load(fh)
-        return cls([Feature(**f) for f in data["features"]])
+        return cls(
+            [Feature(**f) for f in data["features"]],
+            ignored_globs=data.get("_ignored_globs"),
+            platform=data.get("_platform", ""),
+        )
 
     def get(self, feature_id: str) -> Optional[Feature]:
         return self._by_id.get(feature_id)
@@ -89,8 +103,8 @@ def _specificity(glob: str) -> int:
     return len(glob.replace("*", ""))
 
 
-def is_ignored(path: str) -> bool:
-    return any(_glob_match(path, g) for g in IGNORED_GLOBS)
+def is_ignored(path: str, globs: Optional[List[str]] = None) -> bool:
+    return any(_glob_match(path, g) for g in (globs or IGNORED_GLOBS))
 
 
 def attribute(catalog: FeatureCatalog, files: List[Dict]) -> Dict:
@@ -107,7 +121,7 @@ def attribute(catalog: FeatureCatalog, files: List[Dict]) -> Dict:
     for fc in files:
         path = fc["path"]
 
-        if is_ignored(path):
+        if is_ignored(path, catalog.ignored_globs):
             ignored.append(path)
             continue
 

--- a/release-test-planner/testplanner/matrix.py
+++ b/release-test-planner/testplanner/matrix.py
@@ -1,0 +1,400 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Combinatorial test matrices: orthogonal arrays and covering arrays.
+
+Two different reductions of the same explosion, and the difference matters when
+you are arguing about how many device-hours a release needs.
+
+ORTHOGONAL ARRAY (OA)
+    Every pair of factor levels appears exactly the same number of times. That
+    balance is what lets you attribute an effect to a factor - it is a design
+    for ANALYSIS, inherited from Taguchi's design of experiments. The cost of
+    balance is size, and the constraint is rigid: a strength-2 OA only exists
+    for particular run counts and level structures.
+
+COVERING ARRAY (CA)
+    Every pair of factor levels appears AT LEAST once. Dropping the balance
+    requirement makes the array substantially smaller and lets it accept any
+    mix of level counts. It is a design for DETECTION - you want to know a
+    combination breaks, not to attribute variance to a factor. This is the form
+    used for large-scale combinatorial test selection, generated here with
+    IPOG (In-Parameter-Order-General), the algorithm behind NIST's ACTS.
+
+For release testing you almost always want the covering array. The OA is kept
+because it is what people ask for by name, and because the size difference
+between the two is the clearest way to show why.
+
+Both outputs are verified: `verify()` re-derives every t-tuple and confirms the
+array actually covers it, so a bug in generation shows up as a failed check
+rather than a quietly under-covered test run.
+"""
+
+from __future__ import annotations
+
+from itertools import combinations, product
+from typing import Dict, List, Optional, Sequence, Tuple
+
+Factor = Tuple[str, List[str]]
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+def full_factorial_size(factors: Sequence[Factor]) -> int:
+    n = 1
+    for _, levels in factors:
+        n *= len(levels)
+    return n
+
+
+def verify(rows: List[Dict[str, str]], factors: Sequence[Factor],
+           strength: int = 2) -> Dict:
+    """Confirm every t-way combination of levels appears at least once."""
+    names = [n for n, _ in factors]
+    by_name = dict(factors)
+
+    required = 0
+    missing = []
+    for combo in combinations(names, strength):
+        for values in product(*[by_name[n] for n in combo]):
+            required += 1
+            target = dict(zip(combo, values))
+            if not any(all(r.get(k) == v for k, v in target.items()) for r in rows):
+                missing.append(target)
+
+    return {
+        "strength": strength,
+        "tuples_required": required,
+        "tuples_covered": required - len(missing),
+        "complete": not missing,
+        "missing_examples": missing[:5],
+    }
+
+
+# --------------------------------------------------------------------------
+# covering array - IPOG
+# --------------------------------------------------------------------------
+
+def covering_array(factors: Sequence[Factor], strength: int = 2) -> List[Dict[str, str]]:
+    """IPOG (In-Parameter-Order-General) t-way covering array.
+
+    Builds the exhaustive array over the first t factors, then grows one factor
+    at a time: horizontally, by picking for each existing row the level that
+    covers the most still-uncovered tuples; then vertically, by adding rows for
+    whatever tuples horizontal growth could not place.
+    """
+    factors = list(factors)
+    if not factors:
+        return []
+    if strength <= 0:
+        # Baseline: one representative configuration, no combinatorics.
+        return [{n: lv[0] for n, lv in factors}]
+    if len(factors) <= strength:
+        names = [n for n, _ in factors]
+        return [
+            dict(zip(names, values))
+            for values in product(*[lv for _, lv in factors])
+        ]
+
+    # Largest domains first - fewer rows result.
+    factors = sorted(factors, key=lambda f: len(f[1]), reverse=True)
+    names = [n for n, _ in factors]
+    levels = {n: lv for n, lv in factors}
+
+    rows: List[Dict[str, Optional[str]]] = [
+        dict(zip(names[:strength], values))
+        for values in product(*[levels[n] for n in names[:strength]])
+    ]
+
+    for i in range(strength, len(names)):
+        current = names[: i + 1]
+        new_factor = names[i]
+
+        uncovered = set()
+        for combo in combinations(current[:-1], strength - 1):
+            for values in product(*[levels[n] for n in combo]):
+                for nv in levels[new_factor]:
+                    uncovered.add(
+                        tuple(sorted(list(zip(combo, values)) + [(new_factor, nv)]))
+                    )
+
+        # Horizontal growth.
+        for row in rows:
+            best_level, best_gain, best_covered = None, -1, set()
+            for candidate in levels[new_factor]:
+                trial = dict(row)
+                trial[new_factor] = candidate
+                covered = _tuples_in_row(trial, current, strength) & uncovered
+                if len(covered) > best_gain:
+                    best_level, best_gain, best_covered = candidate, len(covered), covered
+            row[new_factor] = best_level
+            uncovered -= best_covered
+
+        # Vertical growth.
+        for tup in sorted(uncovered, key=lambda t: [str(x) for x in t]):
+            assignment = dict(tup)
+            placed = False
+            for row in rows:
+                if all(
+                    row.get(k) is None or row.get(k) == v
+                    for k, v in assignment.items()
+                ):
+                    row.update(assignment)
+                    placed = True
+                    break
+            if not placed:
+                new_row: Dict[str, Optional[str]] = {n: None for n in current}
+                new_row.update(assignment)
+                rows.append(new_row)
+
+    # Fill any remaining don't-cares with the first level.
+    return [{n: (r.get(n) or levels[n][0]) for n in names} for r in rows]
+
+
+def _tuples_in_row(row: Dict, current: Sequence[str], strength: int) -> set:
+    present = [n for n in current if row.get(n) is not None]
+    out = set()
+    for combo in combinations(present, strength):
+        out.add(tuple(sorted((n, row[n]) for n in combo)))
+    return out
+
+
+# --------------------------------------------------------------------------
+# orthogonal array - Rao-Hamming construction
+# --------------------------------------------------------------------------
+
+PRIMES = [2, 3, 5, 7, 11, 13]
+
+
+def _rao_hamming(q: int, m: int) -> List[List[int]]:
+    """OA(q^m, (q^m-1)/(q-1), q, strength 2) for prime q.
+
+    Runs are all vectors in GF(q)^m. Columns are the points of the projective
+    space PG(m-1, q) - nonzero vectors normalised so the leading nonzero entry
+    is 1 - and the cell value is the dot product mod q.
+    """
+    columns = []
+    for vec in product(range(q), repeat=m):
+        if all(v == 0 for v in vec):
+            continue
+        lead = next(v for v in vec if v != 0)
+        if lead != 1:
+            continue
+        columns.append(vec)
+
+    rows = []
+    for x in product(range(q), repeat=m):
+        rows.append([sum(a * b for a, b in zip(x, col)) % q for col in columns])
+    return rows
+
+
+def orthogonal_array(factors: Sequence[Factor]) -> Dict:
+    """Strength-2 orthogonal array covering `factors`.
+
+    A true OA needs every factor to share one level count. Mixed-level inputs
+    are handled with the standard dummy-level technique: build the OA at the
+    largest level count and fold surplus levels back onto real ones. That keeps
+    pairwise coverage complete but breaks perfect balance, so the return value
+    says so explicitly rather than presenting a compromised array as a clean one.
+    """
+    factors = list(factors)
+    if not factors:
+        return {"rows": [], "runs": 0, "balanced": True, "notes": []}
+
+    max_levels = max(len(lv) for _, lv in factors)
+    q = next((p for p in PRIMES if p >= max_levels), None)
+    notes = []
+
+    if q is None:
+        return {
+            "rows": [], "runs": 0, "balanced": False,
+            "notes": ["No supported orthogonal array for {} levels.".format(max_levels)],
+        }
+
+    mixed = len({len(lv) for _, lv in factors}) > 1
+    if mixed or q != max_levels:
+        notes.append(
+            "Mixed level counts, so the dummy-level technique was applied: "
+            "pairwise coverage is complete but the array is no longer perfectly "
+            "balanced, and factor effects cannot be cleanly attributed."
+        )
+
+    m = 2
+    while (q ** m - 1) // (q - 1) < len(factors):
+        m += 1
+        if m > 6:
+            return {
+                "rows": [], "runs": 0, "balanced": False,
+                "notes": ["Too many factors for a tractable orthogonal array."],
+            }
+
+    grid = _rao_hamming(q, m)
+    names = [n for n, _ in factors]
+    levels = {n: lv for n, lv in factors}
+
+    rows = []
+    for line in grid:
+        row = {}
+        for idx, name in enumerate(names):
+            lv = levels[name]
+            row[name] = lv[line[idx] % len(lv)]
+        rows.append(row)
+
+    # Identical rows can appear once surplus levels fold back.
+    deduped, seen = [], set()
+    for r in rows:
+        key = tuple(sorted(r.items()))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(r)
+
+    if len(deduped) != len(rows):
+        notes.append(
+            "{} duplicate runs collapsed after level folding.".format(
+                len(rows) - len(deduped)
+            )
+        )
+
+    return {
+        "rows": deduped,
+        "runs": len(deduped),
+        "designation": "OA({}, {}, {}, 2) via Rao-Hamming".format(
+            q ** m, (q ** m - 1) // (q - 1), q
+        ),
+        "balanced": not mixed and q == max_levels,
+        "notes": notes,
+    }
+
+
+def allocate(risk_rows: List[Dict], plan_result: Dict, env: Dict,
+             context_factors: List[Dict]) -> Dict:
+    """Give each feature as much matrix as its FMEA band earns.
+
+    This is the join between the two halves of the tool. Risk decides the
+    strength; the covering array decides the configurations; the selected test
+    list decides what runs in each one. The product is the real device cost of
+    the release, which is the number a release manager actually has to approve.
+    """
+    pool: Dict[str, Dict] = {}
+    for f in context_factors:
+        pool[f["name"]] = f
+    for f in env["infrastructure_factors"]:
+        # A factor declared in both places keeps the richer level list.
+        existing = pool.get(f["name"])
+        if not existing or len(f["levels"]) >= len(existing["levels"]):
+            pool[f["name"]] = f
+
+    policy = env["allocation_policy"]
+    multipliers = env.get("config_cost_multiplier", {})
+
+    planned_minutes = {e["feature_id"]: e["planned_cost_minutes"]
+                       for e in plan_result["per_feature"]}
+    planned_tests = {e["feature_id"]: e["planned_tests"]
+                     for e in plan_result["per_feature"]}
+
+    designs: Dict[str, Dict] = {}
+    for band, spec in policy.items():
+        selected = [(n, pool[n]["levels"]) for n in spec["factors"] if n in pool]
+        rows = covering_array(selected, strength=spec["strength"])
+        check = verify(rows, selected, spec["strength"]) if spec["strength"] >= 2 else None
+        oa = orthogonal_array(selected) if spec["strength"] == 2 else None
+        designs[band] = {
+            "band": band,
+            "strength": spec["strength"],
+            "rationale": spec["rationale"],
+            "factors": [{"name": n, "levels": lv} for n, lv in selected],
+            "configs": rows,
+            "config_count": len(rows),
+            "full_factorial": full_factorial_size(selected),
+            "reduction": round(1 - len(rows) / full_factorial_size(selected), 4)
+            if full_factorial_size(selected) else 0.0,
+            "verification": check,
+            "orthogonal_alternative": {
+                "runs": oa["runs"],
+                "balanced": oa["balanced"],
+                "designation": oa.get("designation", ""),
+                "notes": oa["notes"],
+            } if oa else None,
+        }
+
+    per_feature = []
+    for row in risk_rows:
+        fid = row["feature_id"]
+        design = designs.get(row["band"], designs["acceptable"])
+        tests = planned_tests.get(fid, 0)
+        base_minutes = planned_minutes.get(fid, 0.0)
+
+        cost = 0.0
+        for cfg in design["configs"]:
+            mult = 1.0
+            for factor, level in cfg.items():
+                mult *= multipliers.get(factor, {}).get(level, 1.0)
+            cost += base_minutes * mult
+
+        per_feature.append({
+            "feature_id": fid,
+            "name": row["name"],
+            "band": row["band"],
+            "rpn": row["rpn"],
+            "strength": design["strength"],
+            "config_count": design["config_count"],
+            "planned_tests": tests,
+            "executions": tests * design["config_count"],
+            "est_minutes": round(cost, 1),
+        })
+
+    per_feature.sort(key=lambda e: e["executions"], reverse=True)
+    total_exec = sum(e["executions"] for e in per_feature)
+    total_min = sum(e["est_minutes"] for e in per_feature)
+
+    return {
+        "factor_pool": [
+            {"name": n, **{k: v for k, v in f.items() if k != "name"}}
+            for n, f in sorted(pool.items())
+        ],
+        "designs": designs,
+        "per_feature": per_feature,
+        "totals": {
+            "executions": total_exec,
+            "est_minutes": round(total_min, 1),
+            "est_hours": round(total_min / 60.0, 1),
+            "single_config_minutes": plan_result["estimated_minutes"],
+            "matrix_multiplier": round(total_min / plan_result["estimated_minutes"], 2)
+            if plan_result["estimated_minutes"] else 0.0,
+        },
+    }
+
+
+def compare(factors: Sequence[Factor], strength: int = 2) -> Dict:
+    """Full factorial vs orthogonal array vs covering array, all verified."""
+    full = full_factorial_size(factors)
+
+    ca = covering_array(factors, strength=strength)
+    ca_check = verify(ca, factors, strength=strength)
+
+    oa = orthogonal_array(factors)
+    oa_check = verify(oa["rows"], factors, strength=2) if oa["rows"] else None
+
+    return {
+        "factors": [{"name": n, "levels": lv, "count": len(lv)} for n, lv in factors],
+        "full_factorial": full,
+        "covering_array": {
+            "strength": strength,
+            "runs": len(ca),
+            "rows": ca,
+            "reduction": round(1 - len(ca) / full, 4) if full else 0.0,
+            "verification": ca_check,
+        },
+        "orthogonal_array": {
+            "runs": oa["runs"],
+            "rows": oa["rows"],
+            "designation": oa.get("designation", ""),
+            "balanced": oa["balanced"],
+            "notes": oa["notes"],
+            "reduction": round(1 - oa["runs"] / full, 4) if full and oa["runs"] else 0.0,
+            "verification": oa_check,
+        },
+    }

--- a/release-test-planner/testplanner/plan.py
+++ b/release-test-planner/testplanner/plan.py
@@ -1,0 +1,218 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 6: choose which tests to actually run, and find the gaps.
+
+The selection problem is a budgeted maximum-coverage problem: pick the subset
+of tests that removes the most risk per minute of device time. That is NP-hard,
+so we use the standard greedy approximation, which for submodular gain has a
+(1 - 1/e) worst-case bound.
+
+The gain of a test is honest rather than assumed: after adding it we RE-DERIVE
+the feature's coverage tier from the selected set only, and the gain is the drop
+in RPN that re-derivation produces. A fifth redundant smoke test on an already
+well-covered feature therefore scores a gain of zero and never gets picked.
+
+Whatever risk survives running every automated test we own is, by definition,
+the manual testing gap.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from .coverage import _score
+
+# Rough device-minutes per test. The efficiency suite is cheaper by design.
+DEFAULT_COST_MINUTES = {
+    "ui": 2.5,
+    "ui.efficiency": 1.5,
+}
+
+# A test must remove at least this many RPN points to be worth its slot. With a
+# continuous detection curve the gain of the twentieth redundant test is
+# positive but negligible; this is where "diminishing" becomes "not worth it".
+MIN_GAIN = 1.0
+
+
+def _cost(test: Dict, costs: Dict[str, float]) -> float:
+    return costs.get(test["suite"], 2.0)
+
+
+def _rpn_for(row: Dict, selected_tests: List[Dict]) -> float:
+    """RPN of a feature given only the tests currently selected for it.
+
+    Kept as a float so the greedy loop sees the smooth diminishing gains of the
+    detection curve rather than integer-rounded plateaus.
+    """
+    detection = _score(selected_tests)["detection"]
+    return row["severity"] * row["occurrence"] * detection
+
+
+def build(
+    risk_result: Dict,
+    coverage: Dict,
+    budget_minutes: Optional[float] = None,
+    costs: Optional[Dict[str, float]] = None,
+) -> Dict:
+    costs = costs or DEFAULT_COST_MINUTES
+    rows = {r["feature_id"]: r for r in risk_result["rows"]}
+
+    # Candidate tests, and which at-risk features each one serves.
+    candidates: Dict[str, Dict] = {}
+    for fid, row in rows.items():
+        for test in coverage["per_feature"].get(fid, {}).get("tests", []):
+            if test["is_disabled"]:
+                continue
+            # Never schedule a test as coverage for a feature it merely passes
+            # through. If an agent confirms the binding it becomes selectable.
+            if test["binding"] == "incidental":
+                continue
+            key = "{}#{}".format(test["file"], test["name"])
+            entry = candidates.setdefault(
+                key, {"test": test, "features": [], "key": key}
+            )
+            entry["features"].append(fid)
+
+    selected_by_feature: Dict[str, List[Dict]] = {fid: [] for fid in rows}
+    current_rpn = {fid: _rpn_for(rows[fid], []) for fid in rows}
+    baseline_rpn = dict(current_rpn)
+
+    selected: List[Dict] = []
+    spent = 0.0
+    remaining = dict(candidates)
+
+    while remaining:
+        best_key = None
+        best_gain = 0.0
+        best_abs = 0
+        best_cost = 0.0
+
+        for key, entry in remaining.items():
+            cost = _cost(entry["test"], costs)
+            gain = 0
+            for fid in entry["features"]:
+                trial = selected_by_feature[fid] + [entry["test"]]
+                gain += current_rpn[fid] - _rpn_for(rows[fid], trial)
+            if gain < MIN_GAIN:
+                continue
+            density = gain / cost
+            if density > best_gain:
+                best_gain, best_key, best_abs, best_cost = density, key, gain, cost
+
+        if best_key is None:
+            break
+        if budget_minutes is not None and spent + best_cost > budget_minutes:
+            del remaining[best_key]
+            continue
+
+        entry = remaining.pop(best_key)
+        for fid in entry["features"]:
+            selected_by_feature[fid].append(entry["test"])
+            current_rpn[fid] = _rpn_for(rows[fid], selected_by_feature[fid])
+
+        spent += best_cost
+        selected.append(
+            {
+                **entry["test"],
+                "covers_features": entry["features"],
+                "rpn_removed": round(best_abs, 1),
+                "cost_minutes": best_cost,
+            }
+        )
+
+    # Anything still on the table adds no measurable risk reduction.
+    redundant = [
+        {**e["test"], "covers_features": e["features"]} for e in remaining.values()
+    ]
+
+    per_feature = []
+    gaps = []
+    for fid, row in rows.items():
+        chosen = selected_by_feature[fid]
+        residual = current_rpn[fid]
+        tier = _score(chosen)["coverage_tier"]
+        entry = {
+            "feature_id": fid,
+            "name": row["name"],
+            "severity": row["severity"],
+            "occurrence": row["occurrence"],
+            "criticality": row["criticality"],
+            "baseline_rpn": int(round(baseline_rpn[fid])),
+            "residual_rpn": int(round(residual)),
+            "rpn_removed": int(round(baseline_rpn[fid] - residual)),
+            "planned_tests": len(chosen),
+            "planned_tier": tier,
+            "planned_cost_minutes": round(
+                sum(_cost(t, costs) for t in chosen), 1
+            ),
+        }
+        per_feature.append(entry)
+
+        if residual >= 100 or tier in ("none", "disabled-only", "minimal", "thin"):
+            gaps.append(
+                {
+                    **entry,
+                    "reason": _gap_reason(row, tier, residual),
+                    "indirect": row.get("indirect", False),
+                    "iso25010": row["iso25010"],
+                    "severity_rationale": row["severity_rationale"],
+                    "churned_lines": row["churned_lines"],
+                    "disabled_count": row["disabled_count"],
+                }
+            )
+
+    per_feature.sort(key=lambda e: e["residual_rpn"], reverse=True)
+    gaps.sort(key=lambda g: g["residual_rpn"], reverse=True)
+
+    total_residual = int(round(sum(e["residual_rpn"] for e in per_feature)))
+    total_inherent = sum(r["inherent_rpn"] for r in risk_result["rows"])
+
+    return {
+        "budget_minutes": budget_minutes,
+        "selected_count": len(selected),
+        "estimated_minutes": round(spent, 1),
+        "estimated_hours": round(spent / 60.0, 2),
+        "selected": sorted(selected, key=lambda t: t["rpn_removed"], reverse=True),
+        "redundant_count": len(redundant),
+        "redundant": redundant,
+        "per_feature": per_feature,
+        "gaps": gaps,
+        "totals": {
+            "residual_rpn": total_residual,
+            "inherent_rpn": total_inherent,
+            "rpn_removed": total_inherent - total_residual,
+            "release_confidence": round(
+                1 - total_residual / total_inherent, 3
+            ) if total_inherent else 0.0,
+            "features_with_gaps": len(gaps),
+        },
+    }
+
+
+def _gap_reason(row: Dict, tier: str, residual: float) -> str:
+    if tier == "none":
+        if row.get("indirect"):
+            return (
+                "Cross-cutting code with no UI test named for it. The suite "
+                "exercises it incidentally, but nothing verifies it directly, "
+                "so a regression here would surface as an unrelated failure - "
+                "or not at all. Best covered by exploratory testing."
+            )
+        if row["test_count"] == 0:
+            return "No UI automation binds to this feature at all."
+        return "Automation exists but none of it reduces risk for this change."
+    if tier == "disabled-only":
+        return "All {} bound tests are disabled or ignored.".format(row["test_count"])
+    if tier in ("minimal", "thin"):
+        return (
+            "Only {} active test(s) bound, {} of them smoke - not enough to "
+            "detect a regression reliably.".format(
+                row["active_count"], row["smoke_count"]
+            )
+        )
+    return (
+        "Residual RPN {} stays above the review threshold even after running "
+        "every bound test.".format(int(round(residual)))
+    )

--- a/release-test-planner/testplanner/platforms.py
+++ b/release-test-planner/testplanner/platforms.py
@@ -1,0 +1,109 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Platform descriptors: everything the pipeline needs to know about a repo.
+
+The risk model, churn measures, plan builder and matrix generator carry no
+platform knowledge and move between platforms unchanged. What differs is only
+where the tests live, what language they are written in, how a test declares
+itself, and whether the platform has a factory-generated candidate space.
+
+Collecting that into one object is what lets `cli.py` stop holding Android path
+constants, and makes adding a third platform a data change.
+
+**Read `has_factories` before trusting a coverage percentage.** On Android the
+generation framework enumerates the candidate space, so coverage has a derived
+denominator. iOS has no equivalent, so a percentage there would be a fraction of
+a number nobody computed. See docs/why-factories.md.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Dict, List, Tuple
+
+
+@dataclass(frozen=True)
+class Platform:
+    id: str
+    label: str
+    language: str
+    extension: str
+    # (path relative to the repo root, suite label). Scanned in order, each
+    # non-recursively, so a parent suite does not swallow a nested one.
+    test_roots: Tuple[Tuple[str, str], ...]
+    source_root: str
+    default_catalog: str
+    # Whether a factory-generated candidate space exists to divide by.
+    has_factories: bool
+    factory_root: str = ""
+    # Directory holding .xctestplan files, if the platform expresses test
+    # selection that way. Android has no analogue.
+    test_plan_root: str = ""
+    # The Xcode target the UI tests belong to. A plan is only relevant if it
+    # includes this target: UnitTest.xctestplan lists two dozen unit-test targets
+    # and no XCUITests, so reading its skip lists made every UI test look like it
+    # ran there.
+    test_target: str = ""
+    notes: str = ""
+
+    def roots(self, repo_root: str) -> List[Tuple[str, str]]:
+        return [(os.path.join(repo_root, p), suite) for p, suite in self.test_roots]
+
+
+_FENIX_APP = "mobile/android/fenix/app"
+_FENIX_UI = _FENIX_APP + "/src/androidTest/java/org/mozilla/fenix/ui"
+
+ANDROID = Platform(
+    id="android",
+    label="Fenix (Android)",
+    language="kotlin",
+    extension=".kt",
+    test_roots=(
+        (_FENIX_UI, "ui"),
+        (_FENIX_UI + "/efficiency/tests", "ui.efficiency"),
+    ),
+    source_root="mobile/android/fenix/app/src/main/java/org/mozilla/fenix",
+    default_catalog="config/features.json",
+    has_factories=True,
+    factory_root=_FENIX_UI + "/efficiency",
+    notes="Coverage has a derived denominator: the generation factories "
+          "enumerate the candidate space.",
+)
+
+# firefox-ios, current layout (release/v106 onwards). Earlier release branches
+# are flat - `Client/` at the repo root rather than under `firefox-ios/` - and
+# the bare vNNN.N branch names belong to that older scheme. Check the layout
+# before pointing this at an old branch.
+IOS = Platform(
+    id="ios",
+    label="Firefox iOS",
+    language="swift",
+    extension=".swift",
+    test_roots=(
+        ("firefox-ios/firefox-ios-tests/Tests/XCUITests", "xcuitest"),
+    ),
+    source_root="firefox-ios/Client",
+    default_catalog="config/features-ios.json",
+    has_factories=False,
+    test_plan_root="firefox-ios/firefox-ios-tests/Tests",
+    test_target="XCUITests",
+    notes="No factory candidate space. Coverage is reported against the "
+          "TestRail case set when one is supplied, and otherwise as counts "
+          "rather than percentages.",
+)
+
+PLATFORMS: Dict[str, Platform] = {p.id: p for p in (ANDROID, IOS)}
+DEFAULT = ANDROID.id
+
+
+def get(platform_id: str) -> Platform:
+    try:
+        return PLATFORMS[platform_id]
+    except KeyError:
+        raise SystemExit(
+            "unknown platform %r (known: %s)"
+            % (platform_id, ", ".join(sorted(PLATFORMS)))
+        )

--- a/release-test-planner/testplanner/platforms.py
+++ b/release-test-planner/testplanner/platforms.py
@@ -47,6 +47,10 @@ class Platform:
     # and no XCUITests, so reading its skip lists made every UI test look like it
     # ran there.
     test_target: str = ""
+    # Heading for the HTML report. Spelled out per platform rather than derived
+    # from `label`, because the products have names people recognise and
+    # "Firefox iOS Release Test Plan" is not one of them.
+    report_title: str = "Release Test Plan"
     notes: str = ""
 
     def roots(self, repo_root: str) -> List[Tuple[str, str]]:
@@ -67,6 +71,7 @@ ANDROID = Platform(
     ),
     source_root="mobile/android/fenix/app/src/main/java/org/mozilla/fenix",
     default_catalog="config/features.json",
+    report_title="Fenix Release Test Plan",
     has_factories=True,
     factory_root=_FENIX_UI + "/efficiency",
     notes="Coverage has a derived denominator: the generation factories "
@@ -79,7 +84,7 @@ ANDROID = Platform(
 # before pointing this at an old branch.
 IOS = Platform(
     id="ios",
-    label="Firefox iOS",
+    label="Firefox for iOS",
     language="swift",
     extension=".swift",
     test_roots=(
@@ -87,6 +92,7 @@ IOS = Platform(
     ),
     source_root="firefox-ios/Client",
     default_catalog="config/features-ios.json",
+    report_title="Firefox for iOS Release Test Plan",
     has_factories=False,
     test_plan_root="firefox-ios/firefox-ios-tests/Tests",
     test_target="XCUITests",

--- a/release-test-planner/testplanner/platforms.py
+++ b/release-test-planner/testplanner/platforms.py
@@ -51,6 +51,10 @@ class Platform:
     # from `label`, because the products have names people recognise and
     # "Firefox iOS Release Test Plan" is not one of them.
     report_title: str = "Release Test Plan"
+    # Paths a sparse worktree needs in order to analyse this platform. Used only
+    # to print correct remediation when the checkout does not contain the range -
+    # advice naming the wrong product's directories is worse than none.
+    sparse_paths: Tuple[str, ...] = ()
     notes: str = ""
 
     def roots(self, repo_root: str) -> List[Tuple[str, str]]:
@@ -72,6 +76,7 @@ ANDROID = Platform(
     source_root="mobile/android/fenix/app/src/main/java/org/mozilla/fenix",
     default_catalog="config/features.json",
     report_title="Fenix Release Test Plan",
+    sparse_paths=("mobile/android/fenix",),
     has_factories=True,
     factory_root=_FENIX_UI + "/efficiency",
     notes="Coverage has a derived denominator: the generation factories "
@@ -93,6 +98,7 @@ IOS = Platform(
     source_root="firefox-ios/Client",
     default_catalog="config/features-ios.json",
     report_title="Firefox for iOS Release Test Plan",
+    sparse_paths=("firefox-ios", "BrowserKit"),
     has_factories=False,
     test_plan_root="firefox-ios/firefox-ios-tests/Tests",
     test_target="XCUITests",

--- a/release-test-planner/testplanner/report.py
+++ b/release-test-planner/testplanner/report.py
@@ -185,6 +185,16 @@ h3 { font-size: 13.5px; margin: 0 0 6px; }
   border-radius: 4px; border: 1px solid var(--border); color: var(--text-secondary); }
 .src.parsed { border-color: var(--good); color: var(--success-text); }
 
+.warn { border: 1px solid var(--critical); border-left-width: 4px;
+  border-radius: 10px; padding: 14px 16px; margin-bottom: 20px;
+  background: var(--surface-1); }
+.warn .hd { font-weight: 700; font-size: 13.5px; margin-bottom: 6px;
+  display: flex; align-items: center; gap: 7px; }
+.warn .hd .dot { width: 9px; height: 9px; border-radius: 50%;
+  background: var(--critical); flex: none; }
+.warn p { font-size: 12.5px; color: var(--text-secondary); margin: 0 0 6px; }
+.warn pre { margin-top: 8px; }
+
 .mtx { font-size: 12px; }
 .mtx td { padding: 6px 9px; }
 .mtx td.cfg { font-variant-numeric: tabular-nums; color: var(--muted); }
@@ -216,6 +226,8 @@ pre { background: var(--plane); border: 1px solid var(--border);
   </div>
   <button class="theme" id="themeBtn">Toggle theme</button>
 </header>
+
+<div id="warnings"></div>
 
 <div class="kpis" id="kpis"></div>
 
@@ -380,6 +392,23 @@ document.getElementById('meta').innerHTML =
   (SOURCE === 'live'
     ? ` &middot; <span class="src parsed">live</span> reading report.json`
     : ` &middot; <span class="src">snapshot</span> embedded copy`);
+
+/* warnings - these travel with the file, so a report generated against the
+   wrong tree says so wherever it ends up */
+document.getElementById('warnings').innerHTML = D.meta.tree_mismatch_tip
+  ? `<div class="warn">
+      <div class="hd"><i class="dot"></i>These numbers are not trustworthy</div>
+      <p>The checkout used to generate this report does not contain the code
+      being analysed &mdash; range tip <code>${esc(D.meta.tree_mismatch_tip)}</code>
+      is not an ancestor of its <code>HEAD</code>. Churn was scored against a
+      different revision's tests, so coverage and confidence are wrong, and
+      usually overstated.</p>
+      <p>Regenerate from a worktree of the branch being analysed:</p>
+      <pre>git worktree add --no-checkout ../firefox-beta origin/beta
+cd ../firefox-beta &amp;&amp; git sparse-checkout set mobile/android/fenix &amp;&amp; git checkout
+./plan.py analyze --repo ../firefox-beta --range "${esc(D.meta.range)}"</pre>
+    </div>`
+  : '';
 
 /* KPIs */
 const P = D.plan.totals, R = D.risk.totals;

--- a/release-test-planner/testplanner/report.py
+++ b/release-test-planner/testplanner/report.py
@@ -1,0 +1,621 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 7: render the self-contained HTML dashboard.
+
+One file, no dependencies, no server. The payload is embedded as JSON so the
+report can be attached to a release ticket and still work.
+"""
+
+from __future__ import annotations
+
+import json
+
+TEMPLATE = r"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Fenix Release Test Plan</title>
+<style>
+:root {
+  color-scheme: light;
+  --surface-1: #fcfcfb;
+  --plane: #f9f9f7;
+  --text-primary: #0b0b0b;
+  --text-secondary: #52514e;
+  --muted: #898781;
+  --grid: #e1e0d9;
+  --baseline: #c3c2b7;
+  --border: rgba(11,11,11,0.10);
+  --series-1: #2a78d6;
+  --series-2: #eb6834;
+  --good: #0ca30c;
+  --warning: #fab219;
+  --critical: #d03b3b;
+  --success-text: #006300;
+}
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) {
+    color-scheme: dark;
+    --surface-1: #1a1a19;
+    --plane: #0d0d0d;
+    --text-primary: #ffffff;
+    --text-secondary: #c3c2b7;
+    --muted: #898781;
+    --grid: #2c2c2a;
+    --baseline: #383835;
+    --border: rgba(255,255,255,0.10);
+    --series-1: #3987e5;
+    --series-2: #d95926;
+    --success-text: #0ca30c;
+  }
+}
+:root[data-theme="dark"] {
+  color-scheme: dark;
+  --surface-1: #1a1a19;
+  --plane: #0d0d0d;
+  --text-primary: #ffffff;
+  --text-secondary: #c3c2b7;
+  --muted: #898781;
+  --grid: #2c2c2a;
+  --baseline: #383835;
+  --border: rgba(255,255,255,0.10);
+  --series-1: #3987e5;
+  --series-2: #d95926;
+  --success-text: #0ca30c;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  padding: 32px 28px 80px;
+  background: var(--plane);
+  color: var(--text-primary);
+  font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.wrap { max-width: 1180px; margin: 0 auto; }
+
+header { display: flex; justify-content: space-between; align-items: flex-start;
+  gap: 24px; margin-bottom: 28px; flex-wrap: wrap; }
+h1 { font-size: 22px; margin: 0 0 6px; letter-spacing: -0.01em; }
+.sub { color: var(--text-secondary); font-size: 13px; }
+.sub code { background: var(--surface-1); border: 1px solid var(--border);
+  padding: 1px 6px; border-radius: 4px; font-size: 12px; }
+
+button.theme { background: var(--surface-1); color: var(--text-secondary);
+  border: 1px solid var(--border); border-radius: 8px; padding: 7px 13px;
+  cursor: pointer; font-size: 13px; font-family: inherit; }
+button.theme:hover { color: var(--text-primary); }
+
+section { background: var(--surface-1); border: 1px solid var(--border);
+  border-radius: 12px; padding: 22px 24px; margin-bottom: 20px; }
+h2 { font-size: 15px; margin: 0 0 4px; letter-spacing: -0.005em; }
+.note { color: var(--text-secondary); font-size: 12.5px; margin: 0 0 18px;
+  max-width: 78ch; }
+
+/* KPI row */
+.kpis { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px,1fr));
+  gap: 1px; background: var(--border); border: 1px solid var(--border);
+  border-radius: 12px; overflow: hidden; margin-bottom: 20px; }
+.kpi { background: var(--surface-1); padding: 18px 20px; }
+.kpi .label { font-size: 11.5px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: 0.055em; margin-bottom: 8px; }
+.kpi .value { font-size: 30px; line-height: 1.1; font-weight: 600;
+  letter-spacing: -0.02em; }
+.kpi .value.sm { font-size: 22px; }
+.kpi .foot { font-size: 12px; color: var(--text-secondary); margin-top: 6px; }
+.hero .value { font-size: 42px; }
+
+/* chart */
+.legend { display: flex; gap: 20px; margin-bottom: 16px; font-size: 12.5px;
+  color: var(--text-secondary); flex-wrap: wrap; }
+.legend span { display: inline-flex; align-items: center; gap: 7px; }
+.swatch { width: 11px; height: 11px; border-radius: 3px; display: inline-block; }
+
+.bars { display: flex; flex-direction: column; gap: 9px; }
+.bar-row { display: grid; grid-template-columns: 210px 1fr 84px; gap: 14px;
+  align-items: center; }
+.bar-name { font-size: 12.5px; color: var(--text-secondary); text-align: right;
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.track { height: 20px; display: flex; background: transparent; }
+.seg { height: 100%; }
+.seg.removed { background: var(--series-1); border-radius: 4px 0 0 4px; }
+.seg.residual { background: var(--series-2); border-radius: 0 4px 4px 0;
+  margin-left: 2px; }
+.seg.removed.full { border-radius: 4px; }
+.seg.residual.full { border-radius: 4px; margin-left: 0; }
+.bar-val { font-size: 12.5px; color: var(--text-secondary);
+  font-variant-numeric: tabular-nums; }
+.bar-row:hover .bar-name, .bar-row:hover .bar-val { color: var(--text-primary); }
+
+/* tables */
+table { width: 100%; border-collapse: collapse; font-size: 13px; }
+th { text-align: left; font-size: 11.5px; text-transform: uppercase;
+  letter-spacing: 0.05em; color: var(--muted); font-weight: 600;
+  padding: 0 10px 9px; border-bottom: 1px solid var(--grid); white-space: nowrap; }
+th.num, td.num { text-align: right; font-variant-numeric: tabular-nums; }
+td { padding: 9px 10px; border-bottom: 1px solid var(--grid);
+  vertical-align: top; }
+tbody tr:hover { background: var(--plane); }
+td.feat { font-weight: 500; }
+.dim { color: var(--text-secondary); font-size: 12px; }
+
+.badge { display: inline-flex; align-items: center; gap: 5px; font-size: 11.5px;
+  font-weight: 600; white-space: nowrap; }
+.badge .dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.badge.good .dot { background: var(--good); }
+.badge.warning .dot { background: var(--warning); }
+.badge.critical .dot { background: var(--critical); }
+
+.meter { display: inline-flex; gap: 2px; vertical-align: middle;
+  margin-right: 7px; }
+.meter i { width: 5px; height: 11px; border-radius: 1px;
+  background: var(--grid); display: block; }
+.meter i.on { background: var(--series-1); }
+
+h3 { font-size: 13.5px; margin: 0 0 6px; }
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 26px;
+  margin-bottom: 20px; }
+.split .note { margin-bottom: 0; }
+@media (max-width: 820px) { .split { grid-template-columns: 1fr; } }
+
+.cmp { display: flex; flex-direction: column; gap: 9px; margin-bottom: 22px; }
+.cmp-row { display: grid; grid-template-columns: 150px 1fr 128px; gap: 14px;
+  align-items: center; }
+.cmp-bar { height: 20px; background: var(--series-1); border-radius: 4px; }
+.cmp-bar.muted { background: var(--baseline); }
+
+.cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(230px,1fr));
+  gap: 14px; margin-bottom: 6px; }
+.card { border: 1px solid var(--border); border-radius: 10px; padding: 15px 16px; }
+.card .hd { display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 10px; gap: 8px; }
+.card .big { font-size: 25px; font-weight: 600; letter-spacing: -0.02em; }
+.card .cap { font-size: 11.5px; color: var(--muted); text-transform: uppercase;
+  letter-spacing: 0.05em; }
+.card p { font-size: 12px; color: var(--text-secondary); margin: 8px 0 0; }
+.check { font-size: 11.5px; font-weight: 600; display: inline-flex;
+  align-items: center; gap: 5px; }
+.check .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--good); }
+
+.src { display: inline-block; font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.04em; text-transform: uppercase; padding: 1px 6px;
+  border-radius: 4px; border: 1px solid var(--border); color: var(--text-secondary); }
+.src.parsed { border-color: var(--good); color: var(--success-text); }
+
+.mtx { font-size: 12px; }
+.mtx td { padding: 6px 9px; }
+.mtx td.cfg { font-variant-numeric: tabular-nums; color: var(--muted); }
+
+details { border-top: 1px solid var(--grid); padding: 11px 0 3px; }
+details:first-of-type { border-top: none; }
+summary { cursor: pointer; font-size: 13px; font-weight: 500; }
+summary::marker { color: var(--muted); }
+details .body { padding: 10px 0 6px 18px; font-size: 12.5px;
+  color: var(--text-secondary); }
+pre { background: var(--plane); border: 1px solid var(--border);
+  border-radius: 8px; padding: 12px 14px; overflow-x: auto; font-size: 12px;
+  margin: 8px 0 0; }
+.tag { display: inline-block; background: var(--plane); border: 1px solid var(--border);
+  border-radius: 5px; padding: 1px 7px; font-size: 11px; color: var(--text-secondary);
+  margin-right: 5px; font-variant-numeric: tabular-nums; }
+.empty { color: var(--text-secondary); font-size: 13px; font-style: italic; }
+.toggle-tbl { background: none; border: none; color: var(--series-1);
+  font: inherit; font-size: 12.5px; cursor: pointer; padding: 0; margin-top: 14px; }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+<header>
+  <div>
+    <h1>Fenix Release Test Plan</h1>
+    <div class="sub" id="meta"></div>
+  </div>
+  <button class="theme" id="themeBtn">Toggle theme</button>
+</header>
+
+<div class="kpis" id="kpis"></div>
+
+<section>
+  <h2>Where the risk goes</h2>
+  <p class="note">Each bar is one feature's <strong>inherent risk</strong>
+  (Severity x Occurrence x 10, the risk if we shipped with no testing at all).
+  The blue portion is what the planned automated tests remove; the orange
+  portion survives the run and is what a release decision actually rides on.</p>
+  <div class="legend">
+    <span><i class="swatch" style="background:var(--series-1)"></i>
+      Risk removed by planned automation</span>
+    <span><i class="swatch" style="background:var(--series-2)"></i>
+      Residual risk after the run</span>
+  </div>
+  <div class="bars" id="chart"></div>
+  <button class="toggle-tbl" id="tblBtn">Show as table</button>
+  <div id="chartTable" hidden></div>
+</section>
+
+<section>
+  <h2>FMEA risk register</h2>
+  <p class="note">RPN = Severity x Occurrence x Detection (IEC 60812). Detection
+  is inverted coverage: 10 means a defect would almost certainly escape to
+  release, 2 means our automation would very likely catch it. Thresholds follow
+  conventional AIAG practice - 200+ demands action, 100+ demands review.</p>
+  <table id="fmea"></table>
+</section>
+
+<section>
+  <h2>Recommended test run</h2>
+  <p class="note" id="planNote"></p>
+  <table id="plan"></table>
+</section>
+
+<section>
+  <h2>Generated-test candidate space</h2>
+  <p class="note">The efficiency framework does not only hold hand-written
+  tests. Factories under <code>generation/</code> synthesise cases from the
+  page-object model, and they scale combinatorially. This is the catalogue the
+  planner filters - risk is what turns it into a run list.</p>
+  <table id="factories"></table>
+  <div id="factoryNote"></div>
+</section>
+
+<section>
+  <h2>Combinatorial matrix</h2>
+  <p class="note">A test is not one thing - it is a test run in a configuration.
+  Every feature multiplies out against devices, API levels and product state,
+  and the full cross product is unaffordable. Two standard reductions, and the
+  gap between them is the whole argument for picking the right one:</p>
+
+  <div class="split">
+    <div>
+      <h3>Orthogonal array</h3>
+      <p class="note">Every pair of levels appears <em>exactly</em> the same
+      number of times. That balance is what lets you attribute an effect to a
+      factor - it is a design for <strong>analysis</strong>, from Taguchi's
+      design of experiments. Balance costs runs, and strength-2 arrays only
+      exist for particular level structures.</p>
+    </div>
+    <div>
+      <h3>Covering array</h3>
+      <p class="note">Every pair appears <em>at least</em> once. Dropping
+      balance makes it markedly smaller and lets it take any mix of level
+      counts. It is a design for <strong>detection</strong> - generated here
+      with IPOG, the algorithm behind NIST's ACTS, and the form used for
+      large-scale combinatorial test selection.</p>
+    </div>
+  </div>
+
+  <div id="matrixCompare"></div>
+  <div id="matrixDesigns"></div>
+
+  <h3 style="margin-top:26px">Allocation by risk band</h3>
+  <p class="note">How much matrix a feature earns is a function of its FMEA
+  band. Spending 3-way coverage everywhere is how a matrix becomes
+  unaffordable; spending a single config on an action-required feature is how a
+  release ships broken.</p>
+  <table id="matrixAlloc"></table>
+
+  <h3 style="margin-top:26px">The review-band matrix, in full</h3>
+  <p class="note">This is the artifact a test lead would actually review - the
+  pairwise configurations every review-band feature runs against.</p>
+  <div id="matrixTable"></div>
+</section>
+
+<section>
+  <h2>Coverage gaps - manual testing required</h2>
+  <p class="note">Risk that survives running every automated test we own. This
+  is the scope that has to be covered by hand, or accepted explicitly.</p>
+  <div id="gaps"></div>
+</section>
+
+<section>
+  <h2>Open questions for an agent</h2>
+  <p class="note">The pipeline is deterministic and stops where judgement
+  starts. These are the calls it will not make on its own. Answer them into a
+  JSON file and re-run with <code>--answers</code> to fold them back in.</p>
+  <div id="tasks"></div>
+</section>
+
+</div>
+
+<script id="payload" type="application/json">__PAYLOAD__</script>
+<script>
+/* Data source, in priority order:
+   1. report.json sitting next to this file - so `testplanner serve` gives a
+      plain browser refresh instead of regenerating the HTML.
+   2. the copy embedded below - so the file still works from file:// and can be
+      dropped onto a static host on its own.
+   Never both, and the header says which one won. */
+const EMBEDDED = JSON.parse(document.getElementById('payload').textContent);
+let D = EMBEDDED;
+let SOURCE = 'snapshot';
+
+async function boot() {
+  // Paint the embedded copy first. Under `serve --live` the fetch below kicks
+  // off a full pipeline re-run server-side, which takes seconds - without this
+  // the page would sit blank until it finished.
+  render();
+  try {
+    const res = await fetch('report.json?t=' + Date.now(), { cache: 'no-store' });
+    if (res.ok) {
+      D = await res.json();
+      SOURCE = 'live';
+      render();
+    }
+  } catch (e) {
+    /* file:// or no sibling report.json - the embedded copy is correct. */
+  }
+}
+
+function render() {
+const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g,
+  c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const pct = n => (n * 100).toFixed(1) + '%';
+
+const BANDS = {
+  'action-required': ['critical', 'Action required'],
+  'review':          ['warning',  'Review'],
+  'acceptable':      ['good',     'Acceptable'],
+};
+const badge = b => {
+  const [cls, label] = BANDS[b] || ['good', b];
+  return `<span class="badge ${cls}"><i class="dot"></i>${label}</span>`;
+};
+const TIERS = ['none','disabled-only','thin','moderate','good','deep'];
+const meter = tier => {
+  const n = TIERS.indexOf(tier) + 1;
+  let s = '<span class="meter" role="img" aria-label="coverage ' + esc(tier) + '">';
+  for (let i = 0; i < 6; i++) s += `<i class="${i < n ? 'on' : ''}"></i>`;
+  return s + '</span>';
+};
+
+/* meta */
+document.getElementById('meta').innerHTML =
+  `range <code>${esc(D.meta.range)}</code> &middot; ` +
+  `${D.changes.commit_count} commits &middot; ${D.changes.file_count} files &middot; ` +
+  `${D.changes.total_churn.toLocaleString()} lines churned &middot; ` +
+  `${D.risk.totals.features_touched} features touched` +
+  (SOURCE === 'live'
+    ? ` &middot; <span class="src parsed">live</span> reading report.json`
+    : ` &middot; <span class="src">snapshot</span> embedded copy`);
+
+/* KPIs */
+const P = D.plan.totals, R = D.risk.totals;
+document.getElementById('kpis').innerHTML = [
+  `<div class="kpi hero"><div class="label">Release confidence</div>
+    <div class="value">${pct(P.release_confidence)}</div>
+    <div class="foot">of inherent risk removed by the planned run</div></div>`,
+  `<div class="kpi"><div class="label">Residual RPN</div>
+    <div class="value">${P.residual_rpn.toLocaleString()}</div>
+    <div class="foot">of ${P.inherent_rpn.toLocaleString()} inherent</div></div>`,
+  `<div class="kpi"><div class="label">Action required</div>
+    <div class="value">${R.action_required}</div>
+    <div class="foot">features with RPN &ge; 200</div></div>`,
+  `<div class="kpi"><div class="label">Coverage gaps</div>
+    <div class="value">${P.features_with_gaps}</div>
+    <div class="foot">need manual testing</div></div>`,
+  `<div class="kpi"><div class="label">Planned run</div>
+    <div class="value sm">${D.plan.estimated_hours} h</div>
+    <div class="foot">${D.plan.selected_count} tests &middot; ${D.plan.redundant_count} skipped as redundant</div></div>`,
+  `<div class="kpi"><div class="label">Across the matrix</div>
+    <div class="value sm">${D.matrix.totals.est_hours} h</div>
+    <div class="foot">${D.matrix.totals.executions} executions &middot; ${D.matrix.totals.matrix_multiplier}&times; the single-config run</div></div>`,
+].join('');
+
+/* chart */
+const rows = D.plan.per_feature.filter(r => r.baseline_rpn > 0).slice(0, 18);
+const max = Math.max(...rows.map(r => r.baseline_rpn), 1);
+document.getElementById('chart').innerHTML = rows.map(r => {
+  const removedW = (r.rpn_removed / max) * 100;
+  const residW = (r.residual_rpn / max) * 100;
+  const noneRemoved = r.rpn_removed === 0, noneResid = r.residual_rpn === 0;
+  const tip = `${r.name}: inherent ${r.baseline_rpn}, removed ${r.rpn_removed}, `
+    + `residual ${r.residual_rpn} (S${r.severity} x O${r.occurrence}), `
+    + `${r.planned_tests} tests planned`;
+  return `<div class="bar-row" title="${esc(tip)}">
+    <div class="bar-name">${esc(r.name)}</div>
+    <div class="track">
+      ${noneRemoved ? '' : `<div class="seg removed ${noneResid ? 'full' : ''}" style="width:${removedW}%"></div>`}
+      ${noneResid ? '' : `<div class="seg residual ${noneRemoved ? 'full' : ''}" style="width:${residW}%"></div>`}
+    </div>
+    <div class="bar-val">${r.residual_rpn} left</div>
+  </div>`;
+}).join('');
+
+document.getElementById('chartTable').innerHTML =
+  '<table><thead><tr><th>Feature</th><th class="num">Inherent</th>' +
+  '<th class="num">Removed</th><th class="num">Residual</th></tr></thead><tbody>' +
+  rows.map(r => `<tr><td>${esc(r.name)}</td><td class="num">${r.baseline_rpn}</td>
+    <td class="num">${r.rpn_removed}</td><td class="num">${r.residual_rpn}</td></tr>`).join('') +
+  '</tbody></table>';
+
+document.getElementById('tblBtn').onclick = e => {
+  const t = document.getElementById('chartTable');
+  t.hidden = !t.hidden;
+  e.target.textContent = t.hidden ? 'Show as table' : 'Hide table';
+};
+
+/* FMEA */
+document.getElementById('fmea').innerHTML =
+  `<thead><tr>
+    <th>Feature</th><th class="num">S</th><th class="num">O</th><th class="num">D</th>
+    <th class="num">RPN</th><th>Band</th><th>Coverage</th>
+    <th class="num" title="Directly bound tests. '+n off' are disabled; '+n inc' only pass through the feature and are not counted as coverage.">Tests</th>
+    <th class="num">Churn</th><th class="num">CRAP</th>
+  </tr></thead><tbody>` +
+  D.risk.rows.map(r => `<tr>
+    <td class="feat">${esc(r.name)}
+      <div class="dim">${esc(r.occurrence_basis)}${r.backout_touched ? ' &middot; touched by a backout' : ''}</div></td>
+    <td class="num">${r.severity}</td>
+    <td class="num">${r.occurrence}</td>
+    <td class="num">${r.detection}</td>
+    <td class="num"><strong>${r.rpn}</strong></td>
+    <td>${badge(r.band)}</td>
+    <td>${meter(r.coverage_tier)}<span class="dim">${esc(r.coverage_tier)}</span></td>
+    <td class="num">${r.direct_count}${r.disabled_count ? ` <span class="dim">+${r.disabled_count} off</span>` : ''}${r.incidental_count ? ` <span class="dim">+${r.incidental_count} inc</span>` : ''}</td>
+    <td class="num">${r.churned_lines.toLocaleString()}</td>
+    <td class="num">${r.crap_score}</td>
+  </tr>`).join('') + '</tbody>';
+
+/* plan */
+document.getElementById('planNote').innerHTML =
+  `Greedy budgeted selection: tests ordered by RPN removed per device-minute. ` +
+  `<strong>${D.plan.selected_count}</strong> tests, ~<strong>${D.plan.estimated_minutes} min</strong>` +
+  (D.plan.budget_minutes ? ` against a ${D.plan.budget_minutes} min budget` : ' (unbudgeted)') +
+  `. ${D.plan.redundant_count} further bound tests were skipped because they ` +
+  `removed no additional risk.`;
+
+document.getElementById('plan').innerHTML =
+  `<thead><tr><th>Test</th><th>Suite</th><th>Covers</th>
+   <th class="num">RPN removed</th><th class="num">Min</th></tr></thead><tbody>` +
+  D.plan.selected.slice(0, 60).map(t => `<tr>
+    <td class="feat">${esc(t.name)}
+      <div class="dim">${esc(t.class_name)}${t.is_smoke ? ' &middot; smoke' : ''}${t.testrail_id ? ' &middot; C' + esc(t.testrail_id) : ''}</div></td>
+    <td class="dim">${esc(t.suite)}</td>
+    <td class="dim">${t.covers_features.map(f => `<span class="tag">${esc(f)}</span>`).join('')}</td>
+    <td class="num">${t.rpn_removed}</td>
+    <td class="num">${t.cost_minutes}</td>
+  </tr>`).join('') + '</tbody>';
+
+/* factories */
+const F = D.factories;
+document.getElementById('factories').innerHTML =
+  `<thead><tr><th>Factory</th><th>Unit of generation</th>
+   <th class="num">Candidates</th><th>Basis</th></tr></thead><tbody>` +
+  F.factories.map(f => `<tr>
+    <td class="feat">${esc(f.name)} <span class="src ${f.source === 'parsed' ? 'parsed' : ''}">${esc(f.source)}</span></td>
+    <td class="dim">${esc(f.unit)}</td>
+    <td class="num"><strong>${f.candidates.toLocaleString()}</strong></td>
+    <td class="dim">${esc(f.basis)}</td>
+  </tr>`).join('') +
+  `<tr><td class="feat">Total candidate space</td><td></td>
+   <td class="num"><strong>${F.total_candidates.toLocaleString()}</strong></td>
+   <td class="dim">before any risk filtering</td></tr></tbody>`;
+
+const beh = F.factories.find(f => f.id === 'behavior');
+document.getElementById('factoryNote').innerHTML = `
+  <details><summary>Why the behavior factory looks small today</summary>
+    <div class="body">
+      <p>${esc(beh.note || '')}</p>
+      <p>Parsed from the tree: <strong>${F.capabilities.length}</strong> capabilities
+      (covering ${F.capability_features.map(x => `<span class="tag">${esc(x)}</span>`).join('')}),
+      <strong>${F.templates.length}</strong> templates, and
+      <strong>${F.context_profiles.EXHAUSTIVE_PREVIEW}</strong> exhaustive context variants
+      from <code>BehaviorContextMatrix.kt</code>.</p>
+      <p>Context profiles already defined:
+      ${Object.entries(F.context_profiles).map(([k, v]) => `<span class="tag">${esc(k)} = ${v}</span>`).join('')}</p>
+      <p>Projected at ${beh.projection.assumed_entities} entities (one CRUD entity per
+      catalogued feature, <em>stubbed</em>): <strong>${beh.projection.candidates.toLocaleString()}</strong>
+      candidates - which would make it the largest factory of the four.</p>
+    </div></details>`;
+
+/* matrix */
+const M = D.matrix;
+const rev = M.designs['review'];
+const cmp = [
+  ['Full factorial', rev.full_factorial, true],
+  ['Orthogonal array', rev.orthogonal_alternative ? rev.orthogonal_alternative.runs : 0, false],
+  ['Covering array (2-way)', rev.config_count, false],
+].filter(r => r[1] > 0);
+const cmax = Math.max(...cmp.map(r => r[1]));
+document.getElementById('matrixCompare').innerHTML =
+  '<div class="cmp">' + cmp.map(([label, val, muted]) => `
+    <div class="cmp-row" title="${esc(label)}: ${val} configurations">
+      <div class="bar-name">${esc(label)}</div>
+      <div><div class="cmp-bar ${muted ? 'muted' : ''}" style="width:${(val / cmax) * 100}%"></div></div>
+      <div class="bar-val">${val} configs</div>
+    </div>`).join('') + '</div>' +
+  (rev.orthogonal_alternative && !rev.orthogonal_alternative.balanced
+    ? `<p class="note">${rev.orthogonal_alternative.notes.map(esc).join(' ')}</p>` : '');
+
+document.getElementById('matrixDesigns').innerHTML = '<div class="cards">' +
+  ['action-required', 'review', 'acceptable'].map(b => {
+    const g = M.designs[b];
+    if (!g) return '';
+    const v = g.verification;
+    return `<div class="card">
+      <div class="hd">${badge(b)}<span class="cap">${g.strength === 0 ? 'baseline' : g.strength + '-way'}</span></div>
+      <div class="big">${g.config_count} <span class="cap">configs</span></div>
+      <p>${g.factors.length} factors, ${g.full_factorial} full cross product
+      (&minus;${(g.reduction * 100).toFixed(0)}%).</p>
+      ${v ? `<p class="check"><i class="dot"></i>all ${v.tuples_required} ${g.strength}-way tuples verified covered</p>` : ''}
+      <p>${esc(g.rationale)}</p>
+    </div>`;
+  }).join('') + '</div>';
+
+document.getElementById('matrixAlloc').innerHTML =
+  `<thead><tr><th>Feature</th><th>Band</th><th class="num">Strength</th>
+   <th class="num">Configs</th><th class="num">Tests</th>
+   <th class="num">Executions</th><th class="num">Device min</th></tr></thead><tbody>` +
+  M.per_feature.map(e => `<tr>
+    <td class="feat">${esc(e.name)}${e.planned_tests === 0 ? '<div class="dim">no automation - this matrix is the manual scope</div>' : ''}</td>
+    <td>${badge(e.band)}</td>
+    <td class="num">${e.strength === 0 ? 'base' : e.strength + '-way'}</td>
+    <td class="num">${e.config_count}</td>
+    <td class="num">${e.planned_tests}</td>
+    <td class="num"><strong>${e.executions}</strong></td>
+    <td class="num">${e.est_minutes}</td>
+  </tr>`).join('') +
+  `<tr><td class="feat">Total</td><td></td><td></td><td></td><td></td>
+   <td class="num"><strong>${M.totals.executions}</strong></td>
+   <td class="num"><strong>${M.totals.est_minutes}</strong></td></tr></tbody>`;
+
+const mf = rev.factors.map(f => f.name);
+document.getElementById('matrixTable').innerHTML =
+  '<table class="mtx"><thead><tr><th class="num">#</th>' +
+  mf.map(n => `<th>${esc(n)}</th>`).join('') + '</tr></thead><tbody>' +
+  rev.configs.map((c, i) => `<tr><td class="cfg">${i + 1}</td>` +
+    mf.map(n => `<td>${esc(c[n])}</td>`).join('') + '</tr>').join('') +
+  '</tbody></table>';
+
+/* gaps */
+document.getElementById('gaps').innerHTML = D.plan.gaps.length
+  ? D.plan.gaps.map(g => `<details>
+      <summary>${esc(g.name)} &mdash; residual RPN ${g.residual_rpn}</summary>
+      <div class="body">
+        <p><strong>Why it is a gap:</strong> ${esc(g.reason)}</p>
+        <p><strong>Why it matters:</strong> ${esc(g.severity_rationale)}</p>
+        <p>${(g.iso25010 || []).map(a => `<span class="tag">${esc(a)}</span>`).join('')}</p>
+        <p class="dim">S${g.severity} x O${g.occurrence} &middot;
+          ${g.planned_tests} automated test(s) planned &middot;
+          ${g.churned_lines.toLocaleString()} lines churned</p>
+      </div></details>`).join('')
+  : '<p class="empty">No coverage gaps. Every touched feature is adequately covered.</p>';
+
+/* agent tasks */
+const byType = {};
+D.agent_tasks.tasks.forEach(t => (byType[t.type] ||= []).push(t));
+document.getElementById('tasks').innerHTML = Object.entries(byType).map(([type, ts]) =>
+  `<details>
+    <summary>${esc(type)} <span class="dim">(${ts.length})</span></summary>
+    <div class="body">
+      <p>${esc(ts[0].why_this_needs_judgement)}</p>
+      <pre>${esc(JSON.stringify(ts.slice(0, 6), null, 2))}</pre>
+      ${ts.length > 6 ? `<p class="dim">+ ${ts.length - 6} more in agent-tasks.json</p>` : ''}
+    </div></details>`).join('') ||
+  '<p class="empty">No open questions.</p>';
+}
+
+boot();
+
+/* theme */
+document.getElementById('themeBtn').onclick = () => {
+  const cur = document.documentElement.getAttribute('data-theme');
+  const dark = cur ? cur === 'dark'
+    : matchMedia('(prefers-color-scheme: dark)').matches;
+  document.documentElement.setAttribute('data-theme', dark ? 'light' : 'dark');
+};
+</script>
+</body>
+</html>
+"""
+
+
+def render(payload: dict, out_path: str) -> str:
+    blob = json.dumps(payload).replace("</", "<\\/")
+    html = TEMPLATE.replace("__PAYLOAD__", blob)
+    with open(out_path, "w") as fh:
+        fh.write(html)
+    return out_path

--- a/release-test-planner/testplanner/report.py
+++ b/release-test-planner/testplanner/report.py
@@ -10,14 +10,19 @@ report can be attached to a release ticket and still work.
 
 from __future__ import annotations
 
+import html as _html
 import json
+
+
+def _esc(text: str) -> str:
+    return _html.escape(str(text), quote=True)
 
 TEMPLATE = r"""<!DOCTYPE html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Fenix Release Test Plan</title>
+<title>__TITLE__</title>
 <style>
 :root {
   color-scheme: light;
@@ -224,7 +229,7 @@ pre { background: var(--plane); border: 1px solid var(--border);
 
 <header>
   <div>
-    <h1>Fenix Release Test Plan</h1>
+    <h1>__TITLE__</h1>
     <div class="sub" id="meta"></div>
   </div>
   <button class="theme" id="themeBtn">Toggle theme</button>
@@ -728,7 +733,12 @@ document.getElementById('themeBtn').onclick = () => {
 
 def render(payload: dict, out_path: str) -> str:
     blob = json.dumps(payload).replace("</", "<\\/")
+    # The heading names the product, so it comes from the platform rather than
+    # being baked into the template - an iOS report headed "Fenix" is worse than
+    # no heading at all.
+    title = payload.get("meta", {}).get("report_title") or "Release Test Plan"
     html = TEMPLATE.replace("__PAYLOAD__", blob)
+    html = html.replace("__TITLE__", _esc(title))
     with open(out_path, "w") as fh:
         fh.write(html)
     return out_path

--- a/release-test-planner/testplanner/report.py
+++ b/release-test-planner/testplanner/report.py
@@ -273,6 +273,20 @@ pre { background: var(--plane); border: 1px solid var(--border);
   <div id="factoryNote"></div>
 </section>
 
+<section id="testrailSection" style="display:none">
+  <h2>TestRail case set &mdash; an assumed denominator</h2>
+  <p class="note">The factory space above is <em>derived</em>: it is computed by
+  enumerating what the page-object model can reach. The TestRail case set is
+  <em>assumed</em> &mdash; someone decided each case was worth writing, which
+  makes it a statement of intent about what a release needs, but not a complete
+  map of the app. It answers "how much of the plan we wrote down is automated",
+  never "how much of the app is covered". The join is exact rather than
+  heuristic: both codebases already carry the case id above each test.</p>
+  <table id="testrailTotals"></table>
+  <div id="testrailNote"></div>
+  <table id="testrailPerFeature"></table>
+</section>
+
 <section>
   <h2>Combinatorial matrix</h2>
   <p class="note">A test is not one thing - it is a test run in a configuration.
@@ -510,6 +524,19 @@ document.getElementById('plan').innerHTML =
 
 /* factories */
 const F = D.factories;
+if (!F.factories.length) {
+  /* A platform with no factory framework. Not a gap to fill with an estimate:
+     the candidate space is what gives coverage a derived denominator, so
+     inventing one here would fabricate the number the model rests on. */
+  document.getElementById('factories').innerHTML =
+    `<thead><tr><th>Generated-test candidate space</th></tr></thead><tbody><tr>
+      <td class="dim">Not available on ${esc(D.meta.platform_label || D.meta.platform || 'this platform')}.
+      ${esc(F.reason || '')}</td></tr></tbody>`;
+  document.getElementById('factoryNote').innerHTML =
+    `<p class="note">Coverage below is reported as counts, and as a ratio only
+     against the TestRail case set when one was supplied - an assumed
+     denominator, not a derived one.</p>`;
+} else {
 document.getElementById('factories').innerHTML =
   `<thead><tr><th>Factory</th><th>Unit of generation</th>
    <th class="num">Candidates</th><th>Basis</th></tr></thead><tbody>` +
@@ -539,6 +566,43 @@ document.getElementById('factoryNote').innerHTML = `
       catalogued feature, <em>stubbed</em>): <strong>${beh.projection.candidates.toLocaleString()}</strong>
       candidates - which would make it the largest factory of the four.</p>
     </div></details>`;
+}
+
+/* TestRail: an assumed denominator, shown only when an export was supplied */
+const TR = D.testrail;
+if (TR) {
+  const t = TR.totals;
+  document.getElementById('testrailSection').style.display = '';
+  document.getElementById('testrailTotals').innerHTML =
+    `<thead><tr><th>Cases in export</th><th class="num">Automated</th>
+     <th class="num">Manual only</th><th class="num">Automated by a skipped test</th>
+     <th class="num">Automated share</th></tr></thead><tbody><tr>
+      <td class="feat">${t.cases.toLocaleString()}</td>
+      <td class="num">${t.automated.toLocaleString()}</td>
+      <td class="num">${t.manual_only.toLocaleString()}</td>
+      <td class="num">${t.skipped_automation.toLocaleString()}</td>
+      <td class="num"><strong>${pct(t.automated_ratio)}</strong></td>
+     </tr></tbody>`;
+  document.getElementById('testrailPerFeature').innerHTML =
+    `<thead><tr><th>Feature</th><th class="num">Cases</th><th class="num">Automated</th>
+     <th class="num">Skipped</th><th class="num">Manual</th><th class="num">Automated</th>
+     </tr></thead><tbody>` +
+    TR.per_feature.filter(e => e.cases).map(e => `<tr>
+      <td class="feat">${esc(e.feature)}</td>
+      <td class="num">${e.cases}</td>
+      <td class="num">${e.automated}</td>
+      <td class="num">${e.skipped_automation || ''}</td>
+      <td class="num">${e.manual_only}</td>
+      <td class="num">${e.automated_ratio == null ? '-' : pct(e.automated_ratio)}</td>
+    </tr>`).join('') + '</tbody>';
+  document.getElementById('testrailNote').innerHTML =
+    `<p class="note">${esc(TR.denominator_note)}</p>
+     <p class="note">${t.skipped_automation.toLocaleString()} case(s) are claimed by
+     an automated test that no test plan runs, so they fall back to manual.
+     ${t.tests_without_case_id.toLocaleString()} automated test(s) carry no case id and
+     cannot be counted either way. ${t.unmatched_ids.toLocaleString()} id(s) referenced by
+     tests are absent from this export.</p>`;
+}
 
 /* matrix */
 const M = D.matrix;

--- a/release-test-planner/testplanner/report.py
+++ b/release-test-planner/testplanner/report.py
@@ -92,6 +92,9 @@ button.theme:hover { color: var(--text-primary); }
 section { background: var(--surface-1); border: 1px solid var(--border);
   border-radius: 12px; padding: 22px 24px; margin-bottom: 20px; }
 h2 { font-size: 15px; margin: 0 0 4px; letter-spacing: -0.005em; }
+.warn-box { color: var(--warn, #8a5a00); background: rgba(250,178,25,0.10);
+  border: 1px solid rgba(250,178,25,0.55); border-radius: 6px;
+  padding: 9px 11px; font-size: 12.5px; margin: 0 0 14px; }
 .note { color: var(--text-secondary); font-size: 12.5px; margin: 0 0 18px;
   max-width: 78ch; }
 
@@ -596,12 +599,29 @@ if (TR) {
       <td class="num">${e.automated_ratio == null ? '-' : pct(e.automated_ratio)}</td>
     </tr>`).join('') + '</tbody>';
   document.getElementById('testrailNote').innerHTML =
-    `<p class="note">${esc(TR.denominator_note)}</p>
-     <p class="note">${t.skipped_automation.toLocaleString()} case(s) are claimed by
+    (TR.populations_disjoint
+      ? `<p class="warn-box"><strong>These are different case sets.</strong>
+         ${esc(TR.disjoint_note)}</p>`
+      : '') +
+    `<p class="note">${esc(TR.denominator_note)}</p>` +
+    (t.deliberately_manual
+      ? `<p class="note"><strong>${pct(t.automated_ratio_addressable)}</strong> of the
+         ${t.addressable_cases.toLocaleString()} addressable cases are automated;
+         ${t.deliberately_manual.toLocaleString()} are triaged manual-forever and are
+         not a gap.</p>` : '') +
+    (t.claims ? `<p class="note">TestRail's own triage: ` +
+      Object.entries(t.claims).sort((a, b) => b[1] - a[1])
+        .map(([k, v]) => `<span class="tag">${esc(k)} ${v}</span>`).join('') +
+      `. Disagreements with the tree: <strong>${t.claimed_not_in_code}</strong> triaged
+       automated with no test linking to them, <strong>${t.in_code_not_claimed}</strong>
+       linked by a test but not triaged as automated.</p>` : '') +
+    `<p class="note">${t.skipped_automation.toLocaleString()} case(s) are claimed by
      an automated test that no test plan runs, so they fall back to manual.
      ${t.tests_without_case_id.toLocaleString()} automated test(s) carry no case id and
      cannot be counted either way. ${t.unmatched_ids.toLocaleString()} id(s) referenced by
-     tests are absent from this export.</p>`;
+     tests are absent from this export` +
+    (t.malformed_rows ? `, and ${t.malformed_rows} export row(s) had shifted columns`
+                      : '') + `.</p>`;
 }
 
 /* matrix */

--- a/release-test-planner/testplanner/risk.py
+++ b/release-test-planner/testplanner/risk.py
@@ -1,0 +1,185 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Stage 5: score risk per feature using FMEA.
+
+The model is Failure Mode and Effects Analysis (IEC 60812), the same scheme
+ISTQB's risk-based testing material builds on:
+
+    RPN = Severity x Occurrence x Detection      (1 .. 1000)
+
+  Severity   blast radius if the feature breaks. From the feature catalog.
+  Occurrence likelihood this cycle's change broke it. Derived from relative
+             code churn (Nagappan & Ball, ICSE 2005).
+  Detection  likelihood the defect ESCAPES to release. Inverted coverage, so
+             better automation lowers RPN. This is the factor a test plan moves.
+
+Two derived numbers matter for release decisions:
+
+  Criticality (FMECA) = S x O
+      Inherent risk of the change, independent of how well we test it. You
+      cannot reduce this without changing the code.
+
+  Residual RPN
+      What is left after the planned tests run. The gap between criticality
+      and residual risk is exactly the argument for running a given suite.
+
+RPN action thresholds follow conventional AIAG FMEA practice.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+ACTION_REQUIRED = 200
+REVIEW_REQUIRED = 100
+
+# Relative churn (churned LOC / total LOC) -> base Occurrence.
+CHURN_BANDS = [
+    (0.02, 1),
+    (0.05, 2),
+    (0.10, 3),
+    (0.20, 4),
+    (0.35, 5),
+    (0.50, 6),
+    (0.75, 7),
+    (10.0, 8),
+]
+
+
+def occurrence(bucket: Dict) -> Dict:
+    """Derive the FMEA Occurrence factor from churn measures."""
+    ratio = bucket.get("m1_churn_ratio", 0.0)
+
+    base = 8
+    for threshold, score in CHURN_BANDS:
+        if ratio < threshold:
+            base = score
+            break
+
+    modifiers = []
+    score = base
+
+    if bucket.get("file_count", 0) >= 10:
+        score += 1
+        modifiers.append("touched 10+ files (broad change surface)")
+    if bucket.get("commits", 0) >= 15:
+        score += 1
+        modifiers.append("15+ commits (sustained churn)")
+    if bucket.get("authors", 0) >= 4:
+        score += 1
+        modifiers.append("4+ authors (coordination risk)")
+    if bucket.get("backout_touched"):
+        score += 2
+        modifiers.append("touched by a backout/revert (proven instability)")
+
+    delta = bucket.get("agent_occurrence_delta")
+    if delta:
+        score += int(delta)
+        modifiers.append(
+            "agent review: {} ({:+d})".format(
+                bucket.get("agent_change_kind", "semantics"), int(delta)
+            )
+        )
+
+    score = max(1, min(10, score))
+
+    return {
+        "occurrence": score,
+        "occurrence_base": base,
+        "occurrence_basis": "relative churn {:.1%} of feature LOC".format(ratio),
+        "occurrence_modifiers": modifiers,
+    }
+
+
+def _crap(occ: int, detection: int) -> float:
+    """CRAP score adapted from per-method to per-feature scope.
+
+    Original: CRAP(m) = CC(m)^2 * (1 - cov(m))^3 + CC(m). We substitute a
+    change-complexity proxy for cyclomatic complexity and derive coverage from
+    the Detection factor, keeping the shape that punishes complex-and-untested.
+    """
+    complexity = occ * 3.0
+    cov = (10 - detection) / 9.0
+    return round(complexity ** 2 * (1 - cov) ** 3 + complexity, 1)
+
+
+def band(rpn: int) -> str:
+    if rpn >= ACTION_REQUIRED:
+        return "action-required"
+    if rpn >= REVIEW_REQUIRED:
+        return "review"
+    return "acceptable"
+
+
+def score(attribution: Dict, coverage: Dict) -> Dict:
+    """Produce a per-feature FMEA row for every feature touched this cycle."""
+    rows: List[Dict] = []
+
+    for bucket in attribution["features_touched"]:
+        fid = bucket["feature_id"]
+        cov = coverage["per_feature"].get(fid, {})
+
+        occ = occurrence(bucket)
+        s = bucket["severity"]
+        o = occ["occurrence"]
+        d = cov.get("detection", 10.0)
+
+        rpn = int(round(s * o * d))
+        inherent = s * o * 10
+        criticality = s * o
+
+        rows.append(
+            {
+                "feature_id": fid,
+                "name": bucket["name"],
+                "severity": s,
+                "severity_rationale": bucket["severity_rationale"],
+                "iso25010": bucket["iso25010"],
+                "indirect": bucket.get("indirect", False),
+                "detection": round(d, 1),
+                "coverage_tier": cov.get("coverage_tier", "none"),
+                "rpn": rpn,
+                "inherent_rpn": inherent,
+                "criticality": criticality,
+                "band": band(rpn),
+                "risk_reduced_by_automation": round(1 - (d / 10.0), 3),
+                "crap_score": _crap(o, d),
+                "churned_lines": bucket["churned_lines"],
+                "file_count": bucket["file_count"],
+                "commits": bucket["commits"],
+                "authors": bucket["authors"],
+                "m1_churn_ratio": bucket["m1_churn_ratio"],
+                "backout_touched": bucket["backout_touched"],
+                "test_count": cov.get("test_count", 0),
+                "active_count": cov.get("active_count", 0),
+                "direct_count": cov.get("direct_count", 0),
+                "incidental_count": cov.get("incidental_count", 0),
+                "smoke_count": cov.get("smoke_count", 0),
+                "disabled_count": cov.get("disabled_count", 0),
+                "modernised_count": cov.get("modernised_count", 0),
+                **occ,
+            }
+        )
+
+    rows.sort(key=lambda r: r["rpn"], reverse=True)
+
+    total_rpn = sum(r["rpn"] for r in rows)
+    total_inherent = sum(r["inherent_rpn"] for r in rows)
+    confidence = (1 - total_rpn / total_inherent) if total_inherent else 0.0
+
+    return {
+        "rows": rows,
+        "totals": {
+            "features_touched": len(rows),
+            "total_rpn": total_rpn,
+            "total_inherent_rpn": total_inherent,
+            "total_criticality": sum(r["criticality"] for r in rows),
+            "action_required": sum(1 for r in rows if r["band"] == "action-required"),
+            "review": sum(1 for r in rows if r["band"] == "review"),
+            "acceptable": sum(1 for r in rows if r["band"] == "acceptable"),
+            "coverage_confidence": round(confidence, 3),
+            "uncovered_features": sum(1 for r in rows if r["test_count"] == 0),
+        },
+    }

--- a/release-test-planner/testplanner/testrail.py
+++ b/release-test-planner/testplanner/testrail.py
@@ -67,10 +67,43 @@ from typing import Dict, List, Optional, Set
 # TestRail ids appear as bare integers, as C-prefixed display ids, and inside
 # case URLs. Normalised to the bare integer so all three join.
 ID_RE = re.compile(r"(\d+)")
+# A well-formed display id is exactly `C` followed by digits. Anything else in
+# that column means the row's fields have shifted.
+CASE_ID_RE = re.compile(r"^[CT]?\d+$")
 
-ID_COLUMNS = ("id", "case id", "case_id", "caseid", "c")
+# ORDER MATTERS, and getting it wrong is silent. A TestRail *run* export has both
+# an `ID` column holding the test-instance id (`T9474971`) and a `Case ID` column
+# holding the case id (`C2306813`). Only the case id appears in the source tree,
+# so preferring `ID` joins nothing, reports 0% automated, and looks entirely
+# plausible. Case-id spellings therefore come first.
+ID_COLUMNS = ("case id", "case_id", "caseid", "case", "id", "c")
 TITLE_COLUMNS = ("title", "case title", "name")
-SECTION_COLUMNS = ("section", "section name", "section_id", "suite")
+SECTION_COLUMNS = ("section", "section name", "section_id", "test area")
+# Present in run exports, absent from plain case exports.
+STATUS_COLUMNS = ("status", "result")
+PRIORITY_COLUMNS = ("priority", "case priority")
+DEPTH_COLUMNS = ("section depth", "section_depth", "depth")
+# TestRail's own view of automation, present in a case export. Worth reading
+# rather than inferring: it is a human triage decision, and comparing it against
+# what the source tree actually references is more useful than either alone.
+AUTOMATION_COLUMNS = ("automation", "automation status", "custom_automation_status")
+AUTOMATION_COVERAGE_COLUMNS = ("automation coverage", "coverage")
+AUTOMATED_NAME_COLUMNS = ("automated test name(s)", "automated test name",
+                          "automated test names")
+CONVERTED_COLUMNS = ("is_converted", "converted")
+SUBSUITE_COLUMNS = ("sub test suite(s)", "sub test suite", "suite")
+
+# `Automation` values that assert automation exists.
+CLAIMED_AUTOMATED = {"completed", "automated", "done"}
+# ...that it is possible but not done. This is the actionable backlog.
+CLAIMED_AUTOMATABLE = {"suitable"}
+# ...that it never will be, which makes the case permanently manual and is a
+# legitimate answer rather than a gap.
+CLAIMED_MANUAL = {"unsuitable", "not suitable", "manual"}
+# Statuses that mean the case was not executed in this run.
+NOT_RUN_STATUSES = {"untested", "retest", "", "in progress"}
+# ...and that it was deliberately excluded rather than left undone.
+EXCLUDED_STATUSES = {"not applicable", "n/a"}
 
 
 def normalise_id(value) -> str:
@@ -96,9 +129,13 @@ def load_export(path: str) -> List[Dict]:
                 "{\"cases\": [...]}" % path)
         return [
             {
-                "id": normalise_id(c.get("id")),
+                # A run export in JSON form carries `case_id` alongside its own
+                # `id`; the case id is the one the source tree references.
+                "id": normalise_id(c.get("case_id") or c.get("id")),
                 "title": str(c.get("title") or ""),
                 "section": str(c.get("section") or c.get("section_id") or ""),
+                "status": str(c.get("status") or c.get("status_id") or ""),
+                "priority": str(c.get("priority") or c.get("priority_id") or ""),
                 "automation_status": c.get("custom_automation_status",
                                            c.get("custom_automated", "")),
             }
@@ -127,40 +164,172 @@ def load_export(path: str) -> List[Dict]:
                     "no id column in %s (looked for %s; found %s)"
                     % (path, "/".join(ID_COLUMNS), ", ".join(reader.fieldnames)))
             section_col = column(SECTION_COLUMNS)
-            return [
-                {
-                    "id": normalise_id(row.get(id_col)),
+            status_col = column(STATUS_COLUMNS)
+            priority_col = column(PRIORITY_COLUMNS)
+            depth_col = column(DEPTH_COLUMNS)
+            automation_col = column(AUTOMATION_COLUMNS)
+            coverage_col = column(AUTOMATION_COVERAGE_COLUMNS)
+            names_col = column(AUTOMATED_NAME_COLUMNS)
+            converted_col = column(CONVERTED_COLUMNS)
+            subsuite_col = column(SUBSUITE_COLUMNS)
+
+            # A TestRail CSV carries only the leaf section name, but the rows come
+            # out in section-tree order with a depth number - so the ancestors can
+            # be recovered with a stack. This matters because a lot of leaves are
+            # named "Layout", "Functional" or "Other", which say nothing on their
+            # own and everything in context.
+            out = []
+            malformed = 0
+            ancestors: List[str] = []
+            for row in reader:
+                raw_id = str(row.get(id_col) or "").strip()
+                case_id = normalise_id(raw_id)
+                if not case_id:
+                    continue        # blank trailing row, or nothing to join to
+                # Rich-text case fields containing newlines and quotes shift the
+                # remaining columns of a row. Detected rather than trusted: the
+                # id column still parses, so the wrong values would otherwise be
+                # read as real automation statuses.
+                if not CASE_ID_RE.match(raw_id):
+                    malformed += 1
+                section = str(row.get(section_col) or "") if section_col else ""
+                path: List[str] = []
+                if depth_col:
+                    try:
+                        depth = int(str(row.get(depth_col) or "0").strip() or 0)
+                    except ValueError:
+                        depth = 0
+                    del ancestors[depth:]
+                    while len(ancestors) < depth:
+                        ancestors.append("")
+                    path = [a for a in ancestors if a]
+                    ancestors.append(section)
+                def cell(col):
+                    return str(row.get(col) or "").strip() if col else ""
+
+                out.append({
+                    "id": case_id,
                     "title": str(row.get(title_col) or "") if title_col else "",
-                    "section": str(row.get(section_col) or "") if section_col else "",
-                    "automation_status": "",
-                }
-                for row in reader
-            ]
+                    "section": section,
+                    "section_path": path,
+                    "status": cell(status_col),
+                    "priority": cell(priority_col),
+                    "automation_status": cell(automation_col),
+                    "automation_coverage": cell(coverage_col),
+                    "automated_names": cell(names_col),
+                    "is_converted": cell(converted_col),
+                    "sub_suite": cell(subsuite_col),
+                    "malformed": not CASE_ID_RE.match(raw_id),
+                })
+            return out
 
     raise SystemExit(
         "unsupported TestRail export %s - use .json or .csv (xlsx needs a "
         "dependency this tool deliberately does not have)" % path)
 
 
-def _match_feature(case: Dict, catalog) -> Optional[str]:
-    """Bind a case to a feature by section name, then by title keywords.
+def load_exports(paths) -> List[Dict]:
+    """Merge several exports by case id, earlier files winning per field.
 
-    Section first because it is a curated grouping and title text is not. Both
-    are weaker evidence than the id join used for automation, so a case that
-    matches nothing is reported as unattributed rather than spread around.
+    Two exports from the same project usually carry different columns: a run
+    export has the section tree (so a case titled "Verify swipe functionality"
+    can be attributed at all) while a case export has TestRail's automation
+    triage and every case in the suite rather than the subset one run selected.
+    Merging gives both, and neither file alone does.
     """
-    haystacks = [case.get("section", ""), case.get("title", "")]
-    for feature in catalog.features:
-        needles = [feature.id.replace("-", " "), feature.name.lower()]
-        needles += [p.lower() for p in getattr(feature, "test_patterns", [])]
-        for level, hay in enumerate(haystacks):
-            hay_l = hay.lower()
-            if not hay_l:
+    if isinstance(paths, str):
+        paths = [paths]
+    merged: Dict[str, Dict] = {}
+    order: List[str] = []
+    for path in paths:
+        for case in load_export(path):
+            cid = case["id"]
+            if cid not in merged:
+                merged[cid] = dict(case, sources=[os.path.basename(path)])
+                order.append(cid)
                 continue
-            for needle in needles:
-                if needle and needle in hay_l:
-                    return feature.id
-    return None
+            existing = merged[cid]
+            existing["sources"].append(os.path.basename(path))
+            for key, value in case.items():
+                if key in ("id", "sources"):
+                    continue
+                # Fill blanks only: the first file that had an opinion keeps it.
+                if not existing.get(key) and value:
+                    existing[key] = value
+    return [merged[cid] for cid in order]
+
+
+def _claim(case: Dict) -> str:
+    """TestRail's own automation verdict, normalised to one of four words."""
+    status = (case.get("automation_status") or "").strip().lower()
+    coverage = (case.get("automation_coverage") or "").strip().lower()
+    if status in CLAIMED_AUTOMATED or coverage == "full":
+        return "automated"
+    if status in CLAIMED_MANUAL:
+        return "manual"
+    if status in CLAIMED_AUTOMATABLE or coverage == "partial":
+        return "automatable"
+    return "untriaged"
+
+
+def _normalise(text: str) -> str:
+    """Lowercase, depunctuate, and singularise, so "Update a bookmark" can match
+    the `bookmarks` feature. TestRail section names are prose written by hand
+    over years; the catalog's vocabulary is not going to line up by luck."""
+    text = re.sub(r"[^a-z0-9]+", " ", (text or "").lower())
+    words = [w[:-1] if len(w) > 3 and w.endswith("s") else w for w in text.split()]
+    return " " + " ".join(words) + " "
+
+
+def _needles(feature) -> List[str]:
+    out = [feature.id.replace("-", " "), feature.name]
+    out += list(getattr(feature, "test_patterns", []) or [])
+    out += list(getattr(feature, "testrail_keywords", []) or [])
+    # Split a compound feature name into its parts: "Logins & Passwords" should
+    # be reachable from a section called just "Passwords".
+    for part in re.split(r"[&/,]| and ", feature.name):
+        part = part.strip()
+        if len(part) > 3:
+            out.append(part)
+    return [_normalise(n).strip() for n in out if n]
+
+
+def _match_feature(case: Dict, catalog) -> Optional[str]:
+    """Bind a case to a feature, scoring every candidate rather than taking the
+    first.
+
+    Returning the first match made catalog order decide attribution: a feature
+    listed early captured any case whose section merely mentioned one of its
+    words. Now the longest match wins, so `Password generator` binds to
+    `logins-passwords` on "password" rather than to whichever feature happened to
+    come first.
+
+    Section outranks title because it is a curated grouping and title text is
+    not. Both are weaker evidence than the id join used for automation, so a case
+    matching nothing is reported as unattributed rather than spread around.
+    """
+    # Weight by how much the text is a statement about what the case covers:
+    # the leaf section is the strongest, its ancestors give context to leaves
+    # named "Layout" or "Other", and the title is prose.
+    haystacks = [
+        (_normalise(case.get("section", "")), 3),
+        (_normalise(" ".join(case.get("section_path") or [])), 2),
+        (_normalise(case.get("title", "")), 1),
+    ]
+
+    best_id, best_score = None, 0
+    for feature in catalog.features:
+        for needle in _needles(feature):
+            if not needle:
+                continue
+            padded = " %s " % needle
+            for hay, weight in haystacks:
+                if padded in hay:
+                    score = len(needle) * weight
+                    if score > best_score:
+                        best_id, best_score = feature.id, score
+                    break
+    return best_id
 
 
 def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
@@ -170,8 +339,9 @@ def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
     manager reads first: how much of the written-down plan a machine will run,
     and therefore what has to be covered by hand.
     """
-    cases = load_export(path)
+    cases = load_exports(path)
     by_id: Dict[str, Dict] = {c["id"]: c for c in cases if c["id"]}
+    malformed_rows = sum(1 for c in cases if c.get("malformed"))
 
     # Which case ids the automation claims, and which test claims each.
     automated: Dict[str, List[str]] = {}
@@ -232,14 +402,65 @@ def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
         del entry["case_ids_manual"][40:]
 
     total_cases = len(by_id)
+
+    # Execution status, present in a run export and absent from a case export.
+    # A release run that left a third of its plan untested is worth surfacing
+    # next to the automation ratio, since both feed the same decision.
+    status_counts: Dict[str, int] = {}
+    for case in by_id.values():
+        label = (case.get("status") or "").strip() or "unknown"
+        status_counts[label] = status_counts.get(label, 0) + 1
+    not_run = sum(n for s, n in status_counts.items()
+                  if s.lower() in NOT_RUN_STATUSES)
+    excluded = sum(n for s, n in status_counts.items()
+                   if s.lower() in EXCLUDED_STATUSES)
+
+    # How much the two populations actually overlap. This decides whether the
+    # ratio above means anything at all: if the automation references 440 cases
+    # and only 25 are in this export, then the export is a different population -
+    # a manual run, most likely - and 3.4% is not an automation rate. Saying
+    # "3.4% automated" without this check would be the most misleading number the
+    # tool could print.
+    referenced = len(automated)
+    overlap = len(live_automated) + len(skipped_automated)
+    overlap_ratio = round(overlap / referenced, 4) if referenced else 0.0
+    disjoint = referenced > 20 and overlap_ratio < 0.5
+
+    # TestRail's own triage vs what the source tree actually references. Neither
+    # is authoritative on its own, and the disagreements are the useful part:
+    #   claimed_not_in_code  TestRail believes this is automated but no test
+    #                        links to it - a stale status, or a lost link
+    #   in_code_not_claimed  a test links to a case TestRail has not triaged as
+    #                        automated - the status is behind the code
+    #   automatable          triaged as automatable and still not done: the
+    #                        actionable backlog, distinct from "manual forever"
+    claims = {cid: _claim(case) for cid, case in by_id.items()}
+    claim_counts: Dict[str, int] = {}
+    for verdict in claims.values():
+        claim_counts[verdict] = claim_counts.get(verdict, 0) + 1
+    claimed_ids = {cid for cid, v in claims.items() if v == "automated"}
+    in_code = set(automated) & set(by_id)
+    claimed_not_in_code = sorted(claimed_ids - in_code)
+    in_code_not_claimed = sorted(in_code - claimed_ids)
+
     return {
-        "source": os.path.abspath(path),
+        "sources": [os.path.abspath(p)
+                    for p in ([path] if isinstance(path, str) else path)],
         "denominator": "assumed",
         "denominator_note": (
             "The TestRail case set is taken as the intended release-test plan. "
             "It measures how much of that plan is automated, not how much of "
             "the app is covered."
         ),
+        "populations_disjoint": disjoint,
+        "disjoint_note": (
+            "The automated tests reference %d case ids; only %d of them are in "
+            "this export. These are largely different case sets, so the "
+            "automated share below is 'how much of THIS set is automated', not "
+            "an automation rate for the project. A run export is usually a "
+            "manual plan; cross-check against a case export covering the ids "
+            "the tests reference." % (referenced, overlap)
+        ) if disjoint else "",
         "totals": {
             "cases": total_cases,
             "automated": len(live_automated),
@@ -249,9 +470,33 @@ def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
                                 if total_cases else 0.0),
             "unattributed_cases": unattributed,
             "unmatched_ids": len(unmatched),
+            "ids_referenced_by_automation": referenced,
+            "overlap_with_automation": overlap,
+            "overlap_ratio": overlap_ratio,
             "tests_without_case_id": sum(
                 1 for t in inventory.get("tests", []) if not t.get("testrail_id")),
+            "status_counts": status_counts,
+            "not_run": not_run,
+            "excluded": excluded,
+            "executed": total_cases - not_run - excluded,
+            "malformed_rows": malformed_rows,
+            # TestRail's own triage, and where it disagrees with the tree.
+            "claims": claim_counts,
+            "claimed_automated": len(claimed_ids),
+            "claimed_not_in_code": len(claimed_not_in_code),
+            "in_code_not_claimed": len(in_code_not_claimed),
+            # A case triaged "Unsuitable" is deliberately manual forever, so
+            # counting it as an automation gap makes the gap look worse than it
+            # is and never shrinks. The addressable denominator excludes them.
+            "deliberately_manual": claim_counts.get("manual", 0),
+            "addressable_cases": total_cases - claim_counts.get("manual", 0),
+            "automated_ratio_addressable": (
+                round(len(live_automated)
+                      / (total_cases - claim_counts.get("manual", 0)), 4)
+                if total_cases - claim_counts.get("manual", 0) else 0.0),
         },
+        "claimed_not_in_code": claimed_not_in_code[:50],
+        "in_code_not_claimed": in_code_not_claimed[:50],
         "unmatched_ids": unmatched[:50],
         "per_feature": sorted(per_feature.values(),
                               key=lambda e: e["cases"], reverse=True),

--- a/release-test-planner/testplanner/testrail.py
+++ b/release-test-planner/testplanner/testrail.py
@@ -1,0 +1,258 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""An assumed coverage denominator, from the TestRail case set.
+
+## What this is, and what it is not
+
+The factory space (see docs/why-factories.md) is a *derived* denominator: the
+generation framework enumerates what is reachable, so the total is computed, not
+asserted. It only exists on Android.
+
+The TestRail case set is an *assumed* denominator. Taking it as "full coverage"
+is a judgement, and it is worth being explicit about why the judgement is
+defensible and where it is not:
+
+  * It is defensible because TestRail is a deliberate artefact. Someone decided
+    each case was worth writing for a release. That is a statement of intent
+    about what a release needs, which is precisely the question a release plan
+    asks - and unlike the automated suite, it was not constrained by what was
+    cheap to automate.
+
+  * It is not complete. TestRail is also a pile that accumulated: cases cluster
+    where bugs were once found and thin out where nobody wrote them. A
+    percentage against it answers "how much of the plan we wrote down is
+    automated", never "how much of the app is covered". Reported as
+    `automated_ratio`, never as `coverage`.
+
+So the two denominators answer different questions and must not be merged into
+one number. Android can have both. iOS can only have this one, which is exactly
+why it is worth wiring: it is the only denominator that works on both platforms.
+
+## Why the join is exact
+
+Both codebases already carry the key. Fenix writes
+
+    // TestRail link: https://mozilla.testrail.io/index.php?/cases/view/2283299
+
+above a @Test, and firefox-ios writes the same URL above `func testFoo()`.
+`corpus.py` extracts it on both platforms with one regex. So binding automation
+to cases is an id join, not a name-similarity heuristic - which matters, because
+a heuristic would be one more assumption stacked on the assumed denominator.
+
+## Input formats
+
+Stdlib only, so no xlsx. Accepted:
+
+  * JSON - either the raw TestRail API `get_cases` response (`{"cases": [...]}`)
+    or a bare list of case objects. Keys used: `id`, `title`, `section_id`,
+    `custom_automation_status`/`custom_automated` when present, plus anything
+    matching a feature via section or title.
+  * CSV - the export TestRail's UI produces. A column named `ID`/`Case ID` and
+    one named `Title` are required; `Section` is used when present.
+
+`testops-tools/testrail/testcases-deduplication/fetch_testrail_export.py` writes
+xlsx; convert it, or point this at the API response directly.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import re
+from typing import Dict, List, Optional, Set
+
+# TestRail ids appear as bare integers, as C-prefixed display ids, and inside
+# case URLs. Normalised to the bare integer so all three join.
+ID_RE = re.compile(r"(\d+)")
+
+ID_COLUMNS = ("id", "case id", "case_id", "caseid", "c")
+TITLE_COLUMNS = ("title", "case title", "name")
+SECTION_COLUMNS = ("section", "section name", "section_id", "suite")
+
+
+def normalise_id(value) -> str:
+    """`C2283299`, `2283299`, `.../cases/view/2283299` -> `2283299`."""
+    if value is None:
+        return ""
+    m = ID_RE.search(str(value))
+    return m.group(1) if m else ""
+
+
+def load_export(path: str) -> List[Dict]:
+    """Read a TestRail export into a list of {id, title, section} dicts."""
+    if not os.path.isfile(path):
+        raise SystemExit("no such TestRail export: %s" % path)
+
+    if path.lower().endswith(".json"):
+        with open(path, errors="replace") as fh:
+            data = json.load(fh)
+        raw = data.get("cases", data) if isinstance(data, dict) else data
+        if not isinstance(raw, list):
+            raise SystemExit(
+                "unexpected JSON shape in %s: expected a list of cases or "
+                "{\"cases\": [...]}" % path)
+        return [
+            {
+                "id": normalise_id(c.get("id")),
+                "title": str(c.get("title") or ""),
+                "section": str(c.get("section") or c.get("section_id") or ""),
+                "automation_status": c.get("custom_automation_status",
+                                           c.get("custom_automated", "")),
+            }
+            for c in raw if isinstance(c, dict)
+        ]
+
+    if path.lower().endswith((".csv", ".tsv")):
+        delimiter = "\t" if path.lower().endswith(".tsv") else ","
+        with open(path, newline="", errors="replace") as fh:
+            reader = csv.DictReader(fh, delimiter=delimiter)
+            if not reader.fieldnames:
+                raise SystemExit("empty CSV: %s" % path)
+            lookup = {(name or "").strip().lower(): name
+                      for name in reader.fieldnames}
+
+            def column(candidates):
+                for cand in candidates:
+                    if cand in lookup:
+                        return lookup[cand]
+                return None
+
+            id_col = column(ID_COLUMNS)
+            title_col = column(TITLE_COLUMNS)
+            if not id_col:
+                raise SystemExit(
+                    "no id column in %s (looked for %s; found %s)"
+                    % (path, "/".join(ID_COLUMNS), ", ".join(reader.fieldnames)))
+            section_col = column(SECTION_COLUMNS)
+            return [
+                {
+                    "id": normalise_id(row.get(id_col)),
+                    "title": str(row.get(title_col) or "") if title_col else "",
+                    "section": str(row.get(section_col) or "") if section_col else "",
+                    "automation_status": "",
+                }
+                for row in reader
+            ]
+
+    raise SystemExit(
+        "unsupported TestRail export %s - use .json or .csv (xlsx needs a "
+        "dependency this tool deliberately does not have)" % path)
+
+
+def _match_feature(case: Dict, catalog) -> Optional[str]:
+    """Bind a case to a feature by section name, then by title keywords.
+
+    Section first because it is a curated grouping and title text is not. Both
+    are weaker evidence than the id join used for automation, so a case that
+    matches nothing is reported as unattributed rather than spread around.
+    """
+    haystacks = [case.get("section", ""), case.get("title", "")]
+    for feature in catalog.features:
+        needles = [feature.id.replace("-", " "), feature.name.lower()]
+        needles += [p.lower() for p in getattr(feature, "test_patterns", [])]
+        for level, hay in enumerate(haystacks):
+            hay_l = hay.lower()
+            if not hay_l:
+                continue
+            for needle in needles:
+                if needle and needle in hay_l:
+                    return feature.id
+    return None
+
+
+def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
+    """Join a TestRail export to the automated corpus.
+
+    Returns per-feature automated/manual counts plus the totals a release
+    manager reads first: how much of the written-down plan a machine will run,
+    and therefore what has to be covered by hand.
+    """
+    cases = load_export(path)
+    by_id: Dict[str, Dict] = {c["id"]: c for c in cases if c["id"]}
+
+    # Which case ids the automation claims, and which test claims each.
+    automated: Dict[str, List[str]] = {}
+    for test in inventory.get("tests", []):
+        case_id = normalise_id(test.get("testrail_id"))
+        if not case_id:
+            continue
+        automated.setdefault(case_id, []).append(
+            "%s.%s" % (test.get("class_name"), test.get("name")))
+
+    # A test can reference a case that is not in the export - a different
+    # project or suite, or a deleted case. Counting those as automated coverage
+    # of this export would inflate the ratio, so they are reported separately.
+    unmatched = sorted(set(automated) - set(by_id))
+
+    # Automation that exists but never runs is not automated coverage. This is
+    # the same rule as the @Ignore / xctestplan-skip handling in corpus.py, and
+    # the reason it matters here is that these cases must fall back to manual.
+    disabled_ids: Set[str] = set()
+    for test in inventory.get("tests", []):
+        case_id = normalise_id(test.get("testrail_id"))
+        if case_id and test.get("is_disabled"):
+            disabled_ids.add(case_id)
+    live_automated = {cid for cid in automated
+                      if cid in by_id and cid not in disabled_ids}
+    skipped_automated = {cid for cid in automated
+                         if cid in by_id and cid in disabled_ids}
+
+    per_feature: Dict[str, Dict] = {
+        f.id: {"feature_id": f.id, "feature": f.name, "cases": 0,
+               "automated": 0, "skipped_automation": 0, "manual_only": 0,
+               "case_ids_manual": []}
+        for f in catalog.features
+    }
+    unattributed = 0
+    for case_id, case in sorted(by_id.items()):
+        fid = _match_feature(case, catalog)
+        if fid is None:
+            unattributed += 1
+            continue
+        entry = per_feature[fid]
+        entry["cases"] += 1
+        if case_id in live_automated:
+            entry["automated"] += 1
+        elif case_id in skipped_automated:
+            entry["skipped_automation"] += 1
+            entry["manual_only"] += 1
+            entry["case_ids_manual"].append(case_id)
+        else:
+            entry["manual_only"] += 1
+            entry["case_ids_manual"].append(case_id)
+
+    for entry in per_feature.values():
+        entry["automated_ratio"] = (
+            round(entry["automated"] / entry["cases"], 4) if entry["cases"] else None
+        )
+        # Keep the list useful rather than enormous.
+        del entry["case_ids_manual"][40:]
+
+    total_cases = len(by_id)
+    return {
+        "source": os.path.abspath(path),
+        "denominator": "assumed",
+        "denominator_note": (
+            "The TestRail case set is taken as the intended release-test plan. "
+            "It measures how much of that plan is automated, not how much of "
+            "the app is covered."
+        ),
+        "totals": {
+            "cases": total_cases,
+            "automated": len(live_automated),
+            "skipped_automation": len(skipped_automated),
+            "manual_only": total_cases - len(live_automated),
+            "automated_ratio": (round(len(live_automated) / total_cases, 4)
+                                if total_cases else 0.0),
+            "unattributed_cases": unattributed,
+            "unmatched_ids": len(unmatched),
+            "tests_without_case_id": sum(
+                1 for t in inventory.get("tests", []) if not t.get("testrail_id")),
+        },
+        "unmatched_ids": unmatched[:50],
+        "per_feature": sorted(per_feature.values(),
+                              key=lambda e: e["cases"], reverse=True),
+    }

--- a/release-test-planner/testplanner/testrail.py
+++ b/release-test-planner/testplanner/testrail.py
@@ -414,6 +414,11 @@ def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
                   if s.lower() in NOT_RUN_STATUSES)
     excluded = sum(n for s, n in status_counts.items()
                    if s.lower() in EXCLUDED_STATUSES)
+    # A case export has no Status column at all, so every case reads "unknown".
+    # Reporting `executed = total - 0 - 0` there would claim the whole suite ran,
+    # which is the opposite of what the absence of data means.
+    has_status = any(s != "unknown" for s in status_counts)
+    executed = (total_cases - not_run - excluded) if has_status else None
 
     # How much the two populations actually overlap. This decides whether the
     # ratio above means anything at all: if the automation references 440 cases
@@ -475,10 +480,11 @@ def build(path: str, catalog, inventory: Dict, cov: Dict) -> Dict:
             "overlap_ratio": overlap_ratio,
             "tests_without_case_id": sum(
                 1 for t in inventory.get("tests", []) if not t.get("testrail_id")),
-            "status_counts": status_counts,
-            "not_run": not_run,
-            "excluded": excluded,
-            "executed": total_cases - not_run - excluded,
+            "status_counts": status_counts if has_status else {},
+            "has_execution_data": has_status,
+            "not_run": not_run if has_status else None,
+            "excluded": excluded if has_status else None,
+            "executed": executed,
             "malformed_rows": malformed_rows,
             # TestRail's own triage, and where it disagrees with the tree.
             "claims": claim_counts,

--- a/release-test-planner/tests/ab_check.py
+++ b/release-test-planner/tests/ab_check.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Prove a change did not alter the analysis it was not meant to alter.
+
+The unit tests say the pieces behave. They cannot say "the Android report is the
+same report it was before the iOS port", which is the question a reviewer of a
+cross-platform change actually has. This runs the pipeline at two git revisions
+over the same range and compares the decisions rather than the bytes.
+
+    # does the current branch still produce the pre-port Android report?
+    tests/ab_check.py --before 94ad20f --repo ~/Workspace/firefox \\
+        --range "HEAD~300..HEAD"
+
+    # same idea for iOS between two of your own commits
+    tests/ab_check.py --before HEAD~1 --platform ios \\
+        --repo ~/Workspace/firefox-ios --range "HEAD~120..HEAD"
+
+Exit status is 0 when every decision matches. Additive fields are reported and
+tolerated: a new key, or a new per-test field carrying its default, is not a
+behaviour change. A changed *value* on a field both revisions have is.
+
+Uses git worktrees, so it never touches your working tree or index.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+# Keys the port legitimately adds. Listed explicitly so that a *different* new
+# key still shows up as something to look at.
+EXPECTED_NEW = {
+    "meta": {"platform", "platform_label", "has_factories", "platform_notes"},
+    "inventory": {"platform", "missing_roots", "test_plans"},
+    "factories": {"platform", "has_candidate_space", "reason"},
+    "_root": {"testrail"},
+}
+
+# Sections whose equality is the actual claim: if these match, the tool reached
+# the same conclusions.
+DECISION_SECTIONS = ("changes", "attribution", "risk", "matrix", "factories")
+
+
+def run(cmd, **kw):
+    return subprocess.run(cmd, check=True, capture_output=True, text=True, **kw)
+
+
+def analyse(tool_root: str, args, out_dir: str) -> dict:
+    cmd = [sys.executable, os.path.join(tool_root, "plan.py"), "analyze",
+           "--repo", args.repo, "--range", args.range, "--out", out_dir]
+    if args.budget:
+        cmd += ["--budget", str(args.budget)]
+    # `--platform` does not exist before the port; omit it for the default so the
+    # older revision can still be driven by this script.
+    if args.platform != "android":
+        cmd += ["--platform", args.platform]
+    if args.testrail_export:
+        cmd += ["--testrail-export"] + args.testrail_export
+    run(cmd, cwd=tool_root)
+    with open(os.path.join(out_dir, "report.json")) as fh:
+        return json.load(fh)
+
+
+def test_key(entry: dict):
+    return (entry.get("class_name"), entry.get("name"), entry.get("feature_id"))
+
+
+def compare(before: dict, after: dict) -> int:
+    problems = []
+
+    new_root = set(after) - set(before)
+    unexpected = new_root - EXPECTED_NEW["_root"]
+    print("new top-level keys: %s" % (sorted(new_root) or "none"))
+    if unexpected:
+        problems.append("unexpected new top-level keys: %s" % sorted(unexpected))
+    missing_root = set(before) - set(after)
+    if missing_root:
+        problems.append("top-level keys disappeared: %s" % sorted(missing_root))
+
+    for section in ("meta", "inventory", "factories"):
+        if section not in before or section not in after:
+            continue
+        added = set(after[section]) - set(before[section])
+        unexpected = added - EXPECTED_NEW.get(section, set())
+        changed = [k for k in before[section]
+                   if k in after[section]
+                   and before[section][k] != after[section][k]
+                   and k not in ("repo", "catalog")]
+        print("%-11s added %-42s changed %s"
+              % (section, sorted(added) or "none", changed or "none"))
+        if unexpected:
+            problems.append("%s: unexpected new keys %s" % (section, sorted(unexpected)))
+        if changed:
+            problems.append("%s: values changed for %s" % (section, changed))
+
+    for section in DECISION_SECTIONS:
+        if section not in before:
+            continue
+        a = json.dumps(before[section], sort_keys=True)
+        b = json.dumps(after[section], sort_keys=True)
+        if section == "factories":
+            continue        # compared key-wise above; it gains keys by design
+        same = a == b
+        print("%-11s identical: %s" % (section, same))
+        if not same:
+            problems.append("%s differs" % section)
+
+    pa, pb = before.get("plan", {}), after.get("plan", {})
+    if pa and pb:
+        print("plan        totals identical: %s" % (pa["totals"] == pb["totals"]))
+        if pa["totals"] != pb["totals"]:
+            problems.append("plan totals differ")
+        for name in ("selected", "redundant"):
+            la, lb = pa.get(name) or [], pb.get(name) or []
+            same = [test_key(t) for t in la] == [test_key(t) for t in lb]
+            print("plan        %-9s same tests, same order: %s (%d)"
+                  % (name, same, len(lb)))
+            if not same:
+                problems.append("plan %s list differs" % name)
+            # A field both revisions carry must not change value.
+            for x, y in zip(la, lb):
+                for key in set(x) & set(y):
+                    if x[key] != y[key]:
+                        problems.append(
+                            "plan %s: %s changed on %s" % (name, key, test_key(x)))
+                        break
+        for name in ("gaps",):
+            same = (json.dumps(pa.get(name), sort_keys=True)
+                    == json.dumps(pb.get(name), sort_keys=True))
+            print("plan        %-9s identical: %s" % (name, same))
+            if not same:
+                problems.append("plan %s differs" % name)
+
+    print()
+    if problems:
+        print("DIFFERENT - %d problem(s):" % len(problems))
+        for p in problems:
+            print("  - %s" % p)
+        return 1
+    print("SAME - every decision matches; differences are additive only.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--before", required=True,
+                   help="git revision to compare against (e.g. 94ad20f, HEAD~1)")
+    p.add_argument("--repo", required=True, help="app checkout to analyse")
+    p.add_argument("--range", default="HEAD~300..HEAD")
+    p.add_argument("--platform", default="android")
+    p.add_argument("--budget", type=float, default=240)
+    p.add_argument("--testrail-export", nargs="*", default=None)
+    args = p.parse_args()
+    args.repo = os.path.abspath(os.path.expanduser(args.repo))
+
+    tests_dir = os.path.dirname(os.path.abspath(__file__))
+    tool_root = os.path.dirname(tests_dir)
+    repo_root = run(["git", "rev-parse", "--show-toplevel"],
+                    cwd=tool_root).stdout.strip()
+    rel_tool = os.path.relpath(tool_root, repo_root)
+
+    tmp = tempfile.mkdtemp(prefix="rtp-ab-")
+    worktree = os.path.join(tmp, "before")
+    try:
+        run(["git", "worktree", "add", "-q", "--detach", worktree, args.before],
+            cwd=repo_root)
+        print("comparing %s (before) against the working tree (after)\n"
+              % args.before)
+        before = analyse(os.path.join(worktree, rel_tool), args,
+                         os.path.join(tmp, "out-before"))
+        after = analyse(tool_root, args, os.path.join(tmp, "out-after"))
+        return compare(before, after)
+    finally:
+        subprocess.run(["git", "worktree", "remove", "--force", worktree],
+                       cwd=repo_root, capture_output=True)
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/release-test-planner/tests/ab_check.py
+++ b/release-test-planner/tests/ab_check.py
@@ -39,7 +39,8 @@ import tempfile
 # Keys the port legitimately adds. Listed explicitly so that a *different* new
 # key still shows up as something to look at.
 EXPECTED_NEW = {
-    "meta": {"platform", "platform_label", "has_factories", "platform_notes"},
+    "meta": {"platform", "platform_label", "has_factories", "platform_notes",
+             "report_title"},
     "inventory": {"platform", "missing_roots", "test_plans"},
     "factories": {"platform", "has_candidate_space", "reason"},
     "_root": {"testrail"},

--- a/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorCapability.kt
+++ b/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorCapability.kt
@@ -1,0 +1,24 @@
+package org.mozilla.fenix.ui.efficiency.generation.behavior
+
+object BehaviorCapabilityCatalog {
+    val all: List<BehaviorCapability> = listOf(
+        BehaviorCapability(
+            id = "bookmarks.folder.create",
+            feature = "bookmarks",
+            entity = "folder",
+            operation = BehaviorOperation.CREATE,
+            pagePropertyName = "bookmarks",
+            description = "Create a bookmark folder",
+            action = { on.bookmarks.createFolder("x") },
+        ),
+        BehaviorCapability(
+            id = "bookmarks.folder.delete",
+            feature = "bookmarks",
+            entity = "folder",
+            operation = BehaviorOperation.DELETE,
+            pagePropertyName = "bookmarks",
+            description = "Delete a bookmark folder",
+            action = { on.bookmarks.deleteFolder("x") },
+        ),
+    )
+}

--- a/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorContextMatrix.kt
+++ b/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorContextMatrix.kt
@@ -1,0 +1,32 @@
+package org.mozilla.fenix.ui.efficiency.generation.behavior
+
+object BehaviorContextMatrix {
+
+    private fun smoke(): List<BehaviorContextVariant> = listOf(
+        defaultContext(),
+    )
+
+    private fun baseFlags(): List<BehaviorContextVariant> = listOf(
+        defaultContext(),
+        defaultContext("PocketEnabled" to "false"),
+    )
+
+    private fun pairwisePreview(): List<BehaviorContextVariant> = listOf(
+        defaultContext(),
+        defaultContext("BrowserMode" to "Private"),
+        defaultContext("DeviceClass" to "Tablet"),
+    )
+
+    private fun exhaustivePreview(): List<BehaviorContextVariant> {
+        val browserModes = listOf("Default", "Private")
+        val deviceClasses = listOf("Phone", "Tablet")
+
+        return buildList {
+            for (browserMode in browserModes) {
+                for (deviceClass in deviceClasses) {
+                    add(defaultContext(browserMode, deviceClass))
+                }
+            }
+        }
+    }
+}

--- a/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorTemplate.kt
+++ b/release-test-planner/tests/fixtures/efficiency/generation/behavior/BehaviorTemplate.kt
@@ -1,0 +1,20 @@
+package org.mozilla.fenix.ui.efficiency.generation.behavior
+
+object BehaviorTemplateCatalog {
+    val all: List<BehaviorTemplate> = listOf(
+        BehaviorTemplate(
+            id = "entity.create.visible",
+            automationSuffix = "create.visible",
+            titlePattern = "{feature} - created {entity} is visible",
+            requiredOperations = listOf(BehaviorOperation.CREATE),
+            assertionKind = AssertionKind.PRESENT,
+        ),
+        BehaviorTemplate(
+            id = "entity.delete.absent",
+            automationSuffix = "delete.absent",
+            titlePattern = "{feature} - deleted {entity} is gone",
+            requiredOperations = listOf(BehaviorOperation.DELETE),
+            assertionKind = AssertionKind.ABSENT,
+        ),
+    )
+}

--- a/release-test-planner/tests/fixtures/efficiency/helpers/PageContext.kt
+++ b/release-test-planner/tests/fixtures/efficiency/helpers/PageContext.kt
@@ -1,0 +1,6 @@
+package org.mozilla.fenix.ui.efficiency.helpers
+
+class PageContext(private val composeRule: ComposeRule) {
+    val bookmarks = BookmarksPage(composeRule)
+    val downloads = DownloadsPage(composeRule)
+}

--- a/release-test-planner/tests/fixtures/efficiency/selectors/BookmarksSelectors.kt
+++ b/release-test-planner/tests/fixtures/efficiency/selectors/BookmarksSelectors.kt
@@ -1,0 +1,6 @@
+package org.mozilla.fenix.ui.efficiency.selectors
+
+object BookmarksSelectors {
+    val ADD_FOLDER = Selector(strategy = COMPOSE_BY_TAG, value = "addFolder")
+    val FOLDER_TITLE = Selector(strategy = COMPOSE_BY_TAG, value = "folderTitle")
+}

--- a/release-test-planner/tests/fixtures/efficiency/selectors/DownloadsSelectors.kt
+++ b/release-test-planner/tests/fixtures/efficiency/selectors/DownloadsSelectors.kt
@@ -1,0 +1,5 @@
+package org.mozilla.fenix.ui.efficiency.selectors
+
+object DownloadsSelectors {
+    val DOWNLOAD_LIST = Selector(strategy = ESPRESSO_BY_ID, value = "download_list")
+}

--- a/release-test-planner/tests/fixtures/ios/XCUITests/SampleFeatureTests.swift
+++ b/release-test-planner/tests/fixtures/ios/XCUITests/SampleFeatureTests.swift
@@ -1,0 +1,45 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import XCTest
+
+class SampleFeatureTests: BaseTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/1000001
+    func testBookmarkCanBeAdded() {
+        navigator.nowAt(NewTabScreen)
+        navigator.goto(LibraryPanel_Bookmarks)
+        navigator.performAction(Action.AddNewBookmark)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/1000002
+    func testHistoryListShows() throws {
+        navigator.goto(LibraryPanel_History)
+    }
+
+    // A test that reports success having asserted nothing on older OSes - the
+    // same shape as an all-@Ignore'd Android class.
+    // https://mozilla.testrail.io/index.php?/cases/view/1000003
+    func testNewToolbarOnly() throws {
+        guard #available(iOS 17.0, *), !skipPlatform else { return }
+        navigator.goto(ToolbarSettings)
+    }
+
+    // https://mozilla.testrail.io/index.php?/cases/view/1000004
+    func testExplicitlySkipped() throws {
+        throw XCTSkip("blocked on FXIOS-1234")
+    }
+
+    func testWithoutATestRailCase() {
+        navigator.goto(SettingsScreen)
+    }
+
+    // Not a test: no `test` prefix, so XCTest ignores it and so must we.
+    func helperThatLooksLikeATest() {
+        navigator.goto(SettingsScreen)
+    }
+}

--- a/release-test-planner/tests/fixtures/ios/plans/Smoketest.xctestplan
+++ b/release-test-planner/tests/fixtures/ios/plans/Smoketest.xctestplan
@@ -1,0 +1,14 @@
+{
+  "configurations": [{"id": "1", "name": "Configuration 1", "options": {}}],
+  "defaultOptions": {},
+  "testTargets": [
+    {
+      "target": {"containerPath": "container:Client.xcodeproj", "identifier": "X", "name": "XCUITests"},
+      "skippedTests": [
+        "SampleFeatureTests/testHistoryListShows()",
+        "SomeOtherClass"
+      ]
+    }
+  ],
+  "version": 1
+}

--- a/release-test-planner/tests/fixtures/ios/plans/UnitTest.xctestplan
+++ b/release-test-planner/tests/fixtures/ios/plans/UnitTest.xctestplan
@@ -1,0 +1,9 @@
+{
+  "configurations": [{"id": "1", "name": "Configuration 1", "options": {}}],
+  "defaultOptions": {},
+  "testTargets": [
+    {"target": {"containerPath": "container:Client.xcodeproj", "identifier": "Y", "name": "ClientTests"},
+     "skippedTests": []}
+  ],
+  "version": 1
+}

--- a/release-test-planner/tests/fixtures/ui/SampleFeatureTest.kt
+++ b/release-test-planner/tests/fixtures/ui/SampleFeatureTest.kt
@@ -1,0 +1,37 @@
+/* Fixture for the corpus parser tests. Mirrors the shape of a real Fenix UI
+ * test: robot imports, TestRail link comments, and mixed annotations. */
+
+package org.mozilla.fenix.ui
+
+import org.junit.Ignore
+import org.junit.Test
+import org.mozilla.fenix.customannotations.SmokeTest
+import org.mozilla.fenix.ui.robots.downloadRobot
+
+class SampleFeatureTest {
+
+    // TestRail link: https://mozilla.testrail.io/index.php?/cases/view/3205329
+    @SmokeTest
+    @Test
+    fun smokeTest() {
+        on.downloads.navigateToPage()
+            .verifySomething()
+    }
+
+    @Test
+    fun plainTest() {
+        downloadRobot {
+            doSomething()
+        }
+    }
+
+    @Ignore("Bug 123456 - disabled while flaky")
+    @Test
+    fun disabledTest() {
+        on.downloads.navigateToPage()
+    }
+
+    private fun notATest() {
+        // A helper, not annotated with @Test - must not be counted.
+    }
+}

--- a/release-test-planner/tests/planner_tests.py
+++ b/release-test-planner/tests/planner_tests.py
@@ -496,6 +496,57 @@ class GitChangeTests(unittest.TestCase):
         self.assertEqual(changes.collect(self.repo, "HEAD..HEAD")["files"], [])
 
 
+@unittest.skipIf(shutil.which("git") is None, "git not available")
+class WorkingTreeMismatchTests(unittest.TestCase):
+    """Guards the silent-wrong-answer case.
+
+    Churn comes from the range; the test corpus comes from the checked-out
+    tree. Analysing `origin/release..origin/beta` from a `main` checkout scores
+    one branch's changes against another branch's tests and reports an inflated
+    confidence number, with nothing else in the pipeline noticing.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.repo = tempfile.mkdtemp(prefix="planner-mismatch-")
+
+        def run(*a):
+            subprocess.run(a, cwd=cls.repo, check=True, capture_output=True)
+
+        def commit(name, body, message):
+            with open(os.path.join(cls.repo, name), "w") as fh:
+                fh.write(body)
+            run("git", "add", name)
+            run("git", "commit", "-q", "-m", message)
+
+        run("git", "init", "-q")
+        run("git", "config", "user.email", "t@example.com")
+        run("git", "config", "user.name", "Tester")
+        commit("base.txt", "base\n", "No bug - base")
+
+        # A side branch whose commits never reach the checked-out main line.
+        run("git", "checkout", "-q", "-b", "sidebranch")
+        commit("side.txt", "side\n", "Bug 999999 - only on the side branch")
+        run("git", "checkout", "-q", "-")
+        commit("main.txt", "main\n", "Bug 888888 - only on the main line")
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.repo, ignore_errors=True)
+
+    def test_flags_a_range_the_checkout_does_not_contain(self):
+        data = changes.collect(self.repo, "HEAD..sidebranch")
+        tip = changes.tip_in_working_tree(self.repo, data["commits"])
+        self.assertIsNotNone(tip, "side-branch range should have been flagged")
+
+    def test_does_not_flag_a_range_the_checkout_does_contain(self):
+        data = changes.collect(self.repo, "HEAD~1..HEAD")
+        self.assertIsNone(changes.tip_in_working_tree(self.repo, data["commits"]))
+
+    def test_no_commits_is_not_a_mismatch(self):
+        self.assertIsNone(changes.tip_in_working_tree(self.repo, []))
+
+
 # ---------------------------------------------------------------------------
 # planning
 # ---------------------------------------------------------------------------

--- a/release-test-planner/tests/planner_tests.py
+++ b/release-test-planner/tests/planner_tests.py
@@ -26,7 +26,8 @@ FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
 sys.path.insert(0, TOOL_ROOT)
 
 from testplanner import (  # noqa: E402
-    changes, corpus, coverage, factories, featuremap, matrix, plan, risk,
+    changes, corpus, coverage, factories, featuremap, matrix, plan,
+    platforms, risk, testrail,
 )
 
 
@@ -687,6 +688,318 @@ class ConfigTests(unittest.TestCase):
             self.assertTrue(factor.get("origin"), factor["name"])
             self.assertGreaterEqual(len(factor["levels"]), 2, factor["name"])
 
+
+
+
+# ---------------------------------------------------------------------------
+# iOS: Swift corpus, test plans, platform descriptors
+# ---------------------------------------------------------------------------
+
+IOS_FIXTURE = os.path.join(FIXTURES, "ios")
+
+
+class SwiftCorpusTests(unittest.TestCase):
+    """XCUITest parsing. A test is a naming convention here, not an annotation."""
+
+    def setUp(self):
+        self.cases = corpus.parse_swift_file(
+            os.path.join(IOS_FIXTURE, "XCUITests", "SampleFeatureTests.swift"),
+            "xcuitest", IOS_FIXTURE)
+        self.by_name = {c.name: c for c in self.cases}
+
+    def test_finds_every_test_method(self):
+        self.assertEqual(
+            sorted(self.by_name),
+            ["testBookmarkCanBeAdded", "testExplicitlySkipped",
+             "testHistoryListShows", "testNewToolbarOnly",
+             "testWithoutATestRailCase"])
+
+    def test_a_helper_named_like_a_test_is_not_a_test(self):
+        self.assertNotIn("helperThatLooksLikeATest", self.by_name)
+
+    def test_class_name_is_read_from_the_declaration(self):
+        self.assertEqual(self.by_name["testBookmarkCanBeAdded"].class_name,
+                         "SampleFeatureTests")
+
+    def test_testrail_id_uses_the_same_url_form_as_fenix(self):
+        self.assertEqual(self.by_name["testBookmarkCanBeAdded"].testrail_id,
+                         "1000001")
+
+    def test_a_test_without_a_case_link_has_no_id_rather_than_the_previous_one(self):
+        self.assertEqual(self.by_name["testWithoutATestRailCase"].testrail_id, "")
+
+    def test_surfaces_come_from_the_navigator_screen_graph(self):
+        surfaces = self.by_name["testBookmarkCanBeAdded"].surfaces
+        self.assertIn("LibraryPanel_Bookmarks", surfaces)
+        self.assertIn("NewTabScreen", surfaces)
+        self.assertIn("Action.AddNewBookmark", surfaces)
+
+    def test_xctskip_is_recognised_as_a_skip(self):
+        self.assertTrue(self.by_name["testExplicitlySkipped"].skipped_in_code)
+
+    def test_an_availability_guard_that_returns_is_a_skip(self):
+        # `guard #available ... else { return }` passes having asserted nothing.
+        self.assertTrue(self.by_name["testNewToolbarOnly"].skipped_in_code)
+
+    def test_an_ordinary_test_is_not_marked_skipped(self):
+        self.assertFalse(self.by_name["testBookmarkCanBeAdded"].skipped_in_code)
+
+
+class TestPlanResolutionTests(unittest.TestCase):
+    def setUp(self):
+        self.plans = corpus.load_test_plans(IOS_FIXTURE, "plans", "XCUITests")
+
+    def test_only_plans_including_the_ui_target_are_read(self):
+        # UnitTest.xctestplan lists ClientTests and no XCUITests, so reading it
+        # would make every UI test look as though it ran there.
+        self.assertEqual(sorted(self.plans), ["Smoketest"])
+
+    def test_method_and_class_skips_are_kept_apart(self):
+        plan_data = self.plans["Smoketest"]
+        self.assertIn("testHistoryListShows", plan_data["skipped_tests"])
+        self.assertIn("SomeOtherClass", plan_data["skipped_classes"])
+
+    def test_a_skipped_method_does_not_run_in_that_plan(self):
+        cases = corpus.parse_swift_file(
+            os.path.join(IOS_FIXTURE, "XCUITests", "SampleFeatureTests.swift"),
+            "xcuitest", IOS_FIXTURE)
+        corpus.apply_test_plans(cases, self.plans)
+        by_name = {c.name: c for c in cases}
+        self.assertEqual(by_name["testHistoryListShows"].plans, [])
+        self.assertEqual(by_name["testBookmarkCanBeAdded"].plans, ["Smoketest"])
+
+    def test_a_test_no_plan_runs_is_disabled(self):
+        cases = corpus.parse_swift_file(
+            os.path.join(IOS_FIXTURE, "XCUITests", "SampleFeatureTests.swift"),
+            "xcuitest", IOS_FIXTURE)
+        corpus.apply_test_plans(cases, self.plans)
+        by_name = {c.name: c for c in cases}
+        self.assertTrue(by_name["testHistoryListShows"].is_disabled)
+        self.assertFalse(by_name["testBookmarkCanBeAdded"].is_disabled)
+
+    def test_android_tests_are_not_disabled_by_absent_plans(self):
+        # `plans is None` means the platform has no test plans; `[]` means every
+        # plan skips the test. Conflating them would disable the Android suite.
+        case = corpus.TestCase(name="t", class_name="C", suite="ui", file="C.kt")
+        self.assertIsNone(case.plans)
+        self.assertFalse(case.is_disabled)
+
+
+class PlatformTests(unittest.TestCase):
+    def test_android_declares_a_candidate_space_and_ios_does_not(self):
+        self.assertTrue(platforms.ANDROID.has_factories)
+        self.assertFalse(platforms.IOS.has_factories)
+
+    def test_unknown_platform_fails_loudly(self):
+        with self.assertRaises(SystemExit):
+            platforms.get("windows-phone")
+
+    def test_empty_factory_scan_matches_the_real_scan_shape(self):
+        # matrix.allocate and the report both read these keys.
+        real_keys = {"total_candidates", "page_count", "capabilities",
+                     "capability_features", "templates", "factories",
+                     "selectors_per_page", "context_factors", "context_profiles"}
+        self.assertTrue(real_keys.issubset(set(factories.empty("ios"))))
+        self.assertEqual(factories.empty("ios")["total_candidates"], 0)
+        self.assertFalse(factories.empty("ios")["has_candidate_space"])
+
+
+class CatalogIgnoreTests(unittest.TestCase):
+    def test_a_catalog_can_replace_the_ignore_list(self):
+        cat = featuremap.FeatureCatalog([], ignored_globs=["**/*.swift"])
+        self.assertTrue(featuremap.is_ignored("a/b/C.swift", cat.ignored_globs))
+        self.assertFalse(featuremap.is_ignored("a/b/C.kt", cat.ignored_globs))
+
+    def test_the_default_ignore_list_still_applies_without_one(self):
+        cat = featuremap.FeatureCatalog([])
+        self.assertTrue(featuremap.is_ignored("x/androidTest/Y.kt",
+                                              cat.ignored_globs))
+
+    def test_the_shipped_ios_catalog_loads_and_ignores_its_test_target(self):
+        cat = featuremap.FeatureCatalog.load(
+            os.path.join(TOOL_ROOT, "config", "features-ios.json"))
+        self.assertEqual(cat.platform, "ios")
+        self.assertTrue(cat.features)
+        self.assertTrue(featuremap.is_ignored(
+            "firefox-ios/firefox-ios-tests/Tests/XCUITests/A.swift",
+            cat.ignored_globs))
+        # focus-ios is a different product living in the same repository.
+        self.assertTrue(featuremap.is_ignored(
+            "focus-ios/Blockzilla/AppDelegate.swift", cat.ignored_globs))
+
+    def test_ios_feature_ids_overlap_android_so_reports_compare(self):
+        ios = featuremap.FeatureCatalog.load(
+            os.path.join(TOOL_ROOT, "config", "features-ios.json"))
+        android = featuremap.FeatureCatalog.load(
+            os.path.join(TOOL_ROOT, "config", "features.json"))
+        shared = {f.id for f in ios} & {f.id for f in android}
+        self.assertGreater(len(shared), 20)
+        # A feature that exists on both platforms describes the same user impact,
+        # so its severity must not drift between the two catalogs.
+        for fid in shared:
+            self.assertEqual(ios.get(fid).severity, android.get(fid).severity,
+                             "severity differs for %s" % fid)
+
+
+# ---------------------------------------------------------------------------
+# TestRail as an assumed denominator
+# ---------------------------------------------------------------------------
+
+class TestRailLoaderTests(unittest.TestCase):
+    CASES = [
+        {"id": 2306905, "title": "Bookmark a page", "section": "Bookmarks"},
+        {"id": 2306906, "title": "Delete a bookmark", "section": "Bookmarks"},
+        {"id": 2307300, "title": "Clear history", "section": "History"},
+    ]
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.json_path = os.path.join(self.tmp, "export.json")
+        with open(self.json_path, "w") as fh:
+            json.dump({"cases": self.CASES}, fh)
+        self.csv_path = os.path.join(self.tmp, "export.csv")
+        with open(self.csv_path, "w") as fh:
+            fh.write("Case ID,Title,Section\n")
+            for c in self.CASES:
+                fh.write("C%d,%s,%s\n" % (c["id"], c["title"], c["section"]))
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_id_forms_all_normalise_to_the_bare_integer(self):
+        for raw in (2306905, "2306905", "C2306905",
+                    "https://mozilla.testrail.io/index.php?/cases/view/2306905"):
+            self.assertEqual(testrail.normalise_id(raw), "2306905")
+
+    def test_missing_id_is_empty_not_an_exception(self):
+        self.assertEqual(testrail.normalise_id(None), "")
+        self.assertEqual(testrail.normalise_id("no digits here"), "")
+
+    def test_json_and_csv_produce_the_same_cases(self):
+        from_json = testrail.load_export(self.json_path)
+        from_csv = testrail.load_export(self.csv_path)
+        self.assertEqual([c["id"] for c in from_json], [c["id"] for c in from_csv])
+        self.assertEqual(len(from_json), 3)
+
+    def test_a_bare_json_list_is_accepted_too(self):
+        path = os.path.join(self.tmp, "bare.json")
+        with open(path, "w") as fh:
+            json.dump(self.CASES, fh)
+        self.assertEqual(len(testrail.load_export(path)), 3)
+
+    def test_an_unsupported_format_fails_with_a_readable_error(self):
+        path = os.path.join(self.tmp, "export.xlsx")
+        open(path, "w").close()
+        with self.assertRaises(SystemExit):
+            testrail.load_export(path)
+
+    def test_a_csv_without_an_id_column_fails_loudly(self):
+        path = os.path.join(self.tmp, "bad.csv")
+        with open(path, "w") as fh:
+            fh.write("Name,Section\nfoo,Bookmarks\n")
+        with self.assertRaises(SystemExit):
+            testrail.load_export(path)
+
+    def test_a_missing_file_fails_loudly(self):
+        with self.assertRaises(SystemExit):
+            testrail.load_export(os.path.join(self.tmp, "nope.json"))
+
+
+class TestRailJoinTests(unittest.TestCase):
+    """The join rules that decide what counts as automated coverage."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7,
+                               test_patterns=["BookmarksTests"]),
+            featuremap.Feature(id="history", name="History", severity=7,
+                               test_patterns=["HistoryTests"]),
+        ])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _export(self, cases):
+        path = os.path.join(self.tmp, "export.json")
+        with open(path, "w") as fh:
+            json.dump({"cases": cases}, fh)
+        return path
+
+    def _inventory(self, tests):
+        return {"tests": tests}
+
+    def test_a_live_test_makes_its_case_automated(self):
+        path = self._export([{"id": 1, "title": "t", "section": "Bookmarks"}])
+        inv = self._inventory([
+            {"class_name": "BookmarksTests", "name": "testA", "testrail_id": "1",
+             "is_disabled": False}])
+        out = testrail.build(path, self.catalog, inv, {})
+        self.assertEqual(out["totals"]["automated"], 1)
+        self.assertEqual(out["totals"]["manual_only"], 0)
+
+    def test_a_case_automated_only_by_a_skipped_test_is_manual(self):
+        # Automation that never runs is not coverage - the same rule the corpus
+        # applies to @Ignore and to xctestplan skips.
+        path = self._export([{"id": 1, "title": "t", "section": "Bookmarks"}])
+        inv = self._inventory([
+            {"class_name": "BookmarksTests", "name": "testA", "testrail_id": "1",
+             "is_disabled": True}])
+        out = testrail.build(path, self.catalog, inv, {})
+        self.assertEqual(out["totals"]["automated"], 0)
+        self.assertEqual(out["totals"]["manual_only"], 1)
+        self.assertEqual(out["totals"]["skipped_automation"], 1)
+
+    def test_a_case_no_test_references_is_manual(self):
+        path = self._export([{"id": 9, "title": "t", "section": "History"}])
+        out = testrail.build(path, self.catalog, self._inventory([]), {})
+        self.assertEqual(out["totals"]["manual_only"], 1)
+        self.assertEqual(out["totals"]["automated_ratio"], 0.0)
+
+    def test_ids_referenced_but_absent_from_the_export_are_reported_not_counted(self):
+        # Otherwise a test pointing at another project's case would inflate the
+        # ratio against this export.
+        path = self._export([{"id": 1, "title": "t", "section": "Bookmarks"}])
+        inv = self._inventory([
+            {"class_name": "BookmarksTests", "name": "testA", "testrail_id": "1",
+             "is_disabled": False},
+            {"class_name": "BookmarksTests", "name": "testB",
+             "testrail_id": "424242", "is_disabled": False}])
+        out = testrail.build(path, self.catalog, inv, {})
+        self.assertEqual(out["totals"]["cases"], 1)
+        self.assertEqual(out["totals"]["automated"], 1)
+        self.assertEqual(out["totals"]["unmatched_ids"], 1)
+
+    def test_cases_are_attributed_to_features_by_section(self):
+        path = self._export([
+            {"id": 1, "title": "x", "section": "Bookmarks"},
+            {"id": 2, "title": "y", "section": "History"}])
+        out = testrail.build(path, self.catalog, self._inventory([]), {})
+        per = {e["feature_id"]: e["cases"] for e in out["per_feature"]}
+        self.assertEqual(per["bookmarks"], 1)
+        self.assertEqual(per["history"], 1)
+
+    def test_a_case_matching_no_feature_is_reported_rather_than_spread_around(self):
+        path = self._export([{"id": 1, "title": "z", "section": "Telemetry"}])
+        out = testrail.build(path, self.catalog, self._inventory([]), {})
+        self.assertEqual(out["totals"]["unattributed_cases"], 1)
+        self.assertEqual(sum(e["cases"] for e in out["per_feature"]), 0)
+
+    def test_tests_without_a_case_id_are_counted_separately(self):
+        path = self._export([{"id": 1, "title": "t", "section": "Bookmarks"}])
+        inv = self._inventory([
+            {"class_name": "BookmarksTests", "name": "testA", "testrail_id": "",
+             "is_disabled": False}])
+        out = testrail.build(path, self.catalog, inv, {})
+        self.assertEqual(out["totals"]["tests_without_case_id"], 1)
+
+    def test_the_denominator_is_labelled_assumed(self):
+        # The report must never present this as a derived coverage percentage.
+        path = self._export([{"id": 1, "title": "t", "section": "Bookmarks"}])
+        out = testrail.build(path, self.catalog, self._inventory([]), {})
+        self.assertEqual(out["denominator"], "assumed")
+        self.assertIn("not how much of the app is covered",
+                      out["denominator_note"])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/release-test-planner/tests/planner_tests.py
+++ b/release-test-planner/tests/planner_tests.py
@@ -13,6 +13,7 @@ in a temp dir. No network, no device, no API key.
     python -m unittest discover -s release-test-planner/tests -p '*tests.py'
 """
 
+import csv
 import json
 import os
 import shutil
@@ -1000,6 +1001,186 @@ class TestRailJoinTests(unittest.TestCase):
         self.assertEqual(out["denominator"], "assumed")
         self.assertIn("not how much of the app is covered",
                       out["denominator_note"])
+
+
+class TestRailRunExportTests(unittest.TestCase):
+    """Run exports: the columns that differ, and the one that silently lies."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _csv(self, header, rows, name="run.csv"):
+        path = os.path.join(self.tmp, name)
+        with open(path, "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(header)
+            for r in rows:
+                w.writerow(r)
+        return path
+
+    def test_case_id_column_wins_over_the_run_instance_id(self):
+        # A run export has both. `ID` is the test-instance id and appears nowhere
+        # in the source tree, so preferring it joins nothing and reports 0%
+        # automated - plausible and completely wrong.
+        path = self._csv(["ID", "Title", "Case ID", "Status"],
+                         [["T9474971", "Update from previous version",
+                           "C2306813", "Passed"]])
+        [case] = testrail.load_export(path)
+        self.assertEqual(case["id"], "2306813")
+
+    def test_status_and_priority_are_read_when_present(self):
+        path = self._csv(["Case ID", "Title", "Status", "Priority"],
+                         [["C1", "t", "Untested", "Critical"]])
+        [case] = testrail.load_export(path)
+        self.assertEqual(case["status"], "Untested")
+        self.assertEqual(case["priority"], "Critical")
+
+    def test_section_ancestors_are_rebuilt_from_the_depth_column(self):
+        # TestRail exports only the leaf name, in tree order, with a depth. Many
+        # leaves are called "Layout" or "Other" and mean nothing alone.
+        path = self._csv(["Case ID", "Title", "Section", "Section Depth"],
+                         [["C1", "a", "Bookmarks", "0"],
+                          ["C2", "b", "Layout", "1"],
+                          ["C3", "c", "History", "0"],
+                          ["C4", "d", "Other", "1"]])
+        cases = testrail.load_export(path)
+        by_id = {c["id"]: c for c in cases}
+        self.assertEqual(by_id["2"]["section_path"], ["Bookmarks"])
+        # Depth returning to 0 must pop the stack, not accumulate.
+        self.assertEqual(by_id["4"]["section_path"], ["History"])
+
+    def test_ancestors_give_an_ambiguous_leaf_a_feature(self):
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7)])
+        ambiguous = {"section": "Layout", "section_path": ["Bookmarks"],
+                     "title": "Verify images across all cards"}
+        self.assertEqual(testrail._match_feature(ambiguous, catalog), "bookmarks")
+
+    def test_the_longest_match_wins_rather_than_catalog_order(self):
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="settings-general", name="Settings",
+                               severity=7, testrail_keywords=["setting"]),
+            featuremap.Feature(id="logins-passwords", name="Logins & Passwords",
+                               severity=9, testrail_keywords=["password"]),
+        ])
+        case = {"section": "Settings -> Passwords section", "section_path": [],
+                "title": ""}
+        # "password" is longer than "setting", so the more specific feature wins
+        # even though settings-general is listed first.
+        self.assertEqual(testrail._match_feature(case, catalog),
+                         "logins-passwords")
+
+    def test_a_row_with_shifted_columns_is_flagged(self):
+        # Rich text in a case field pushes the remaining columns along; the id
+        # column still parses, so the wrong values would look like real statuses.
+        path = self._csv(["Case ID", "Title", "Automation"],
+                         [["C1", "fine", "Completed"],
+                          ["sans-serif; font-size: 14px", "broken", "32"]])
+        cases = testrail.load_export(path)
+        self.assertFalse(cases[0]["malformed"])
+        self.assertTrue(cases[1]["malformed"])
+
+
+class TestRailMergeTests(unittest.TestCase):
+    """Two exports carry different columns; neither alone is enough."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.suite = os.path.join(self.tmp, "suite.csv")
+        with open(self.suite, "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["ID", "Title", "Automation", "Automation Coverage"])
+            w.writerow(["C1", "Bookmark a page", "Completed", "Full"])
+            w.writerow(["C2", "Verify swipe functionality", "Unsuitable", "None"])
+            w.writerow(["C3", "Something new", "Suitable", "None"])
+        self.run = os.path.join(self.tmp, "run.csv")
+        with open(self.run, "w", newline="") as fh:
+            w = csv.writer(fh)
+            w.writerow(["ID", "Case ID", "Title", "Section", "Section Depth",
+                        "Status"])
+            w.writerow(["T9", "C2", "Verify swipe functionality", "Bookmarks",
+                        "0", "Passed"])
+
+    def tearDown(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_merging_fills_blanks_without_overwriting(self):
+        cases = testrail.load_exports([self.suite, self.run])
+        by_id = {c["id"]: c for c in cases}
+        self.assertEqual(len(cases), 3)
+        # section came from the run export...
+        self.assertEqual(by_id["2"]["section"], "Bookmarks")
+        # ...and the automation triage from the suite export.
+        self.assertEqual(by_id["2"]["automation_status"], "Unsuitable")
+
+    def test_the_first_file_wins_a_contested_field(self):
+        cases = testrail.load_exports([self.suite, self.run])
+        by_id = {c["id"]: c for c in cases}
+        self.assertEqual(by_id["2"]["title"], "Verify swipe functionality")
+
+    def test_claims_normalise_to_four_verdicts(self):
+        self.assertEqual(testrail._claim({"automation_status": "Completed"}),
+                         "automated")
+        self.assertEqual(testrail._claim({"automation_status": "Unsuitable"}),
+                         "manual")
+        self.assertEqual(testrail._claim({"automation_status": "Suitable"}),
+                         "automatable")
+        self.assertEqual(testrail._claim({"automation_status": "Untriaged"}),
+                         "untriaged")
+        # Coverage alone is enough when the status column is absent.
+        self.assertEqual(testrail._claim({"automation_coverage": "Full"}),
+                         "automated")
+
+    def test_deliberately_manual_cases_leave_the_addressable_denominator(self):
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7)])
+        inv = {"tests": [{"class_name": "B", "name": "testA",
+                          "testrail_id": "1", "is_disabled": False}]}
+        out = testrail.build([self.suite], catalog, inv, {})
+        t = out["totals"]
+        self.assertEqual(t["cases"], 3)
+        self.assertEqual(t["deliberately_manual"], 1)
+        self.assertEqual(t["addressable_cases"], 2)
+        # 1 of 3 overall, but 1 of the 2 that could ever be automated.
+        self.assertEqual(t["automated_ratio"], round(1 / 3, 4))
+        self.assertEqual(t["automated_ratio_addressable"], 0.5)
+
+    def test_triage_disagreeing_with_the_tree_is_reported_both_ways(self):
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7)])
+        # C1 is triaged automated but nothing links to it; C3 is linked but
+        # triaged only "Suitable".
+        inv = {"tests": [{"class_name": "B", "name": "testC",
+                          "testrail_id": "3", "is_disabled": False}]}
+        out = testrail.build([self.suite], catalog, inv, {})
+        self.assertEqual(out["totals"]["claimed_not_in_code"], 1)
+        self.assertEqual(out["totals"]["in_code_not_claimed"], 1)
+        self.assertIn("1", out["claimed_not_in_code"])
+        self.assertIn("3", out["in_code_not_claimed"])
+
+    def test_near_disjoint_populations_are_flagged(self):
+        # A run export is usually a manual plan. If the automation references
+        # hundreds of ids and almost none are here, the ratio is meaningless and
+        # printing it without saying so would be the worst output of the tool.
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7)])
+        inv = {"tests": [{"class_name": "B", "name": "test%d" % i,
+                          "testrail_id": str(1000 + i), "is_disabled": False}
+                         for i in range(50)]}
+        out = testrail.build([self.suite], catalog, inv, {})
+        self.assertTrue(out["populations_disjoint"])
+        self.assertIn("different case sets", out["disjoint_note"])
+
+    def test_overlapping_populations_are_not_flagged(self):
+        catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="bookmarks", name="Bookmarks", severity=7)])
+        inv = {"tests": [{"class_name": "B", "name": "testA",
+                          "testrail_id": "1", "is_disabled": False}]}
+        out = testrail.build([self.suite], catalog, inv, {})
+        self.assertFalse(out["populations_disjoint"])
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/release-test-planner/tests/planner_tests.py
+++ b/release-test-planner/tests/planner_tests.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""Tests for the release test planner.
+
+Runs without a Firefox checkout: the Kotlin parsers are exercised against
+fixtures in tests/fixtures, and the git parser against a throwaway repo built
+in a temp dir. No network, no device, no API key.
+
+    python -m unittest discover -s release-test-planner/tests -p '*tests.py'
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+TOOL_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+FIXTURES = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures")
+sys.path.insert(0, TOOL_ROOT)
+
+from testplanner import (  # noqa: E402
+    changes, corpus, coverage, factories, featuremap, matrix, plan, risk,
+)
+
+
+# ---------------------------------------------------------------------------
+# combinatorial arrays
+# ---------------------------------------------------------------------------
+
+class CoveringArrayTests(unittest.TestCase):
+    SHAPES = [
+        [("A", ["1", "2"]), ("B", ["x", "y"]), ("C", ["p", "q"])],
+        [("A", ["1", "2", "3"]), ("B", ["w", "x", "y", "z"]), ("C", ["p", "q"]),
+         ("D", ["m", "n"]), ("E", ["j", "k"])],
+        [("A", ["1", "2"]), ("B", ["x", "y"]), ("C", ["p", "q"]),
+         ("D", ["m", "n"]), ("E", ["j", "k"]), ("F", ["s", "t"]),
+         ("G", ["u", "v"])],
+    ]
+
+    def test_pairwise_covers_every_pair(self):
+        for factors in self.SHAPES:
+            rows = matrix.covering_array(factors, strength=2)
+            check = matrix.verify(rows, factors, strength=2)
+            self.assertTrue(
+                check["complete"],
+                "missing pairs for {}: {}".format(
+                    [n for n, _ in factors], check["missing_examples"]),
+            )
+
+    def test_three_way_covers_every_triple(self):
+        factors = self.SHAPES[1]
+        rows = matrix.covering_array(factors, strength=3)
+        self.assertTrue(matrix.verify(rows, factors, strength=3)["complete"])
+
+    def test_smaller_than_full_factorial(self):
+        factors = self.SHAPES[2]
+        rows = matrix.covering_array(factors, strength=2)
+        self.assertLess(len(rows), matrix.full_factorial_size(factors))
+
+    def test_higher_strength_is_never_smaller(self):
+        factors = self.SHAPES[1]
+        two = len(matrix.covering_array(factors, strength=2))
+        three = len(matrix.covering_array(factors, strength=3))
+        self.assertGreaterEqual(three, two)
+
+    def test_strength_zero_is_one_baseline_config(self):
+        rows = matrix.covering_array(self.SHAPES[0], strength=0)
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0], {"A": "1", "B": "x", "C": "p"})
+
+    def test_every_row_assigns_every_factor(self):
+        factors = self.SHAPES[1]
+        names = {n for n, _ in factors}
+        for row in matrix.covering_array(factors, strength=2):
+            self.assertEqual(set(row), names)
+            for name, levels in factors:
+                self.assertIn(row[name], levels)
+
+
+class VerifierTests(unittest.TestCase):
+    """The verifier is the safety net, so it has to be able to fail."""
+
+    def test_detects_a_missing_pair(self):
+        factors = [("A", ["1", "2"]), ("B", ["x", "y"])]
+        incomplete = [{"A": "1", "B": "x"}, {"A": "2", "B": "y"}]
+        check = matrix.verify(incomplete, factors, strength=2)
+        self.assertFalse(check["complete"])
+        self.assertEqual(check["tuples_required"], 4)
+        self.assertEqual(check["tuples_covered"], 2)
+
+
+class OrthogonalArrayTests(unittest.TestCase):
+    def test_four_three_level_factors_gives_textbook_l9(self):
+        factors = [(n, ["a", "b", "c"]) for n in "ABCD"]
+        oa = matrix.orthogonal_array(factors)
+        self.assertEqual(oa["runs"], 9)
+        self.assertTrue(oa["balanced"])
+        self.assertTrue(matrix.verify(oa["rows"], factors, 2)["complete"])
+
+    def test_l9_is_perfectly_balanced(self):
+        factors = [(n, ["a", "b", "c"]) for n in "ABCD"]
+        rows = matrix.orthogonal_array(factors)["rows"]
+        for first in "ABCD":
+            for second in "ABCD":
+                if first >= second:
+                    continue
+                seen = {}
+                for r in rows:
+                    key = (r[first], r[second])
+                    seen[key] = seen.get(key, 0) + 1
+                self.assertEqual(
+                    set(seen.values()), {1},
+                    "{}x{} is not balanced: {}".format(first, second, seen))
+
+    def test_three_two_level_factors_gives_l4(self):
+        factors = [(n, ["0", "1"]) for n in "ABC"]
+        oa = matrix.orthogonal_array(factors)
+        self.assertEqual(oa["runs"], 4)
+        self.assertTrue(oa["balanced"])
+
+    def test_mixed_levels_still_cover_but_are_flagged_unbalanced(self):
+        factors = [("A", ["1", "2", "3"]), ("B", ["x", "y"]), ("C", ["p", "q"])]
+        oa = matrix.orthogonal_array(factors)
+        self.assertFalse(oa["balanced"])
+        self.assertTrue(oa["notes"])
+        self.assertTrue(matrix.verify(oa["rows"], factors, 2)["complete"])
+
+    def test_covering_array_is_no_larger_than_the_orthogonal_one(self):
+        factors = [("A", ["1", "2", "3"]), ("B", ["w", "x", "y", "z"]),
+                   ("C", ["p", "q"]), ("D", ["m", "n"]), ("E", ["j", "k"])]
+        ca = len(matrix.covering_array(factors, strength=2))
+        oa = matrix.orthogonal_array(factors)["runs"]
+        self.assertLessEqual(ca, oa)
+
+
+# ---------------------------------------------------------------------------
+# risk scoring
+# ---------------------------------------------------------------------------
+
+def _bucket(**kw):
+    base = {
+        "feature_id": "f", "name": "F", "severity": 5, "severity_rationale": "",
+        "iso25010": [], "files": [], "added": 0, "deleted": 0,
+        "churned_lines": 0, "total_lines": 100, "commits": 1, "authors": 1,
+        "backout_touched": False, "file_count": 1, "m1_churn_ratio": 0.0,
+        "m2_delete_ratio": 0.0, "indirect": False,
+    }
+    base.update(kw)
+    return base
+
+
+class OccurrenceTests(unittest.TestCase):
+    def test_rises_with_relative_churn(self):
+        low = risk.occurrence(_bucket(m1_churn_ratio=0.01))["occurrence"]
+        mid = risk.occurrence(_bucket(m1_churn_ratio=0.25))["occurrence"]
+        high = risk.occurrence(_bucket(m1_churn_ratio=0.90))["occurrence"]
+        self.assertLess(low, mid)
+        self.assertLess(mid, high)
+
+    def test_backout_raises_occurrence_and_is_explained(self):
+        clean = risk.occurrence(_bucket(m1_churn_ratio=0.1))
+        backed = risk.occurrence(_bucket(m1_churn_ratio=0.1, backout_touched=True))
+        self.assertEqual(backed["occurrence"], clean["occurrence"] + 2)
+        self.assertTrue(any("backout" in m for m in backed["occurrence_modifiers"]))
+
+    def test_agent_delta_is_applied_and_recorded(self):
+        out = risk.occurrence(_bucket(
+            m1_churn_ratio=0.25, agent_occurrence_delta=-2,
+            agent_change_kind="refactor"))
+        base = risk.occurrence(_bucket(m1_churn_ratio=0.25))["occurrence"]
+        self.assertEqual(out["occurrence"], base - 2)
+        self.assertTrue(any("refactor" in m for m in out["occurrence_modifiers"]))
+
+    def test_clamped_to_the_fmea_scale(self):
+        floor = risk.occurrence(_bucket(m1_churn_ratio=0.0,
+                                        agent_occurrence_delta=-9))
+        ceiling = risk.occurrence(_bucket(
+            m1_churn_ratio=0.99, file_count=50, commits=99, authors=9,
+            backout_touched=True, agent_occurrence_delta=3))
+        self.assertGreaterEqual(floor["occurrence"], 1)
+        self.assertLessEqual(ceiling["occurrence"], 10)
+
+
+class RiskScoreTests(unittest.TestCase):
+    def _score(self, severity, churn, detection):
+        attribution = {
+            "features_touched": [_bucket(severity=severity, m1_churn_ratio=churn)],
+            "unmapped_files": [], "ignored_count": 0,
+        }
+        cov = {"per_feature": {"f": {"detection": detection, "coverage_tier": "x",
+                                     "test_count": 1, "active_count": 1}},
+               "unbound_tests": [], "unbound_count": 0}
+        return risk.score(attribution, cov)
+
+    def test_rpn_is_the_product_of_the_three_factors(self):
+        row = self._score(5, 0.25, 4.0)["rows"][0]
+        self.assertEqual(row["rpn"], round(row["severity"] * row["occurrence"] * 4.0))
+
+    def test_bands_follow_the_aiag_thresholds(self):
+        self.assertEqual(risk.band(250), "action-required")
+        self.assertEqual(risk.band(200), "action-required")
+        self.assertEqual(risk.band(199), "review")
+        self.assertEqual(risk.band(100), "review")
+        self.assertEqual(risk.band(99), "acceptable")
+
+    def test_better_detection_lowers_rpn(self):
+        poor = self._score(8, 0.3, 10.0)["rows"][0]["rpn"]
+        good = self._score(8, 0.3, 2.0)["rows"][0]["rpn"]
+        self.assertLess(good, poor)
+
+    def test_confidence_is_zero_with_no_detection_at_all(self):
+        totals = self._score(8, 0.3, 10.0)["totals"]
+        self.assertAlmostEqual(totals["coverage_confidence"], 0.0, places=6)
+
+    def test_inherent_rpn_ignores_detection(self):
+        a = self._score(7, 0.3, 2.0)["rows"][0]
+        b = self._score(7, 0.3, 10.0)["rows"][0]
+        self.assertEqual(a["inherent_rpn"], b["inherent_rpn"])
+        self.assertEqual(a["criticality"], b["criticality"])
+
+
+# ---------------------------------------------------------------------------
+# coverage / detection
+# ---------------------------------------------------------------------------
+
+def _test_row(**kw):
+    base = {"name": "t", "class_name": "C", "suite": "ui.efficiency",
+            "file": "C.kt", "annotations": [], "testrail_id": "",
+            "surfaces": [], "line": 1, "is_smoke": False, "is_disabled": False,
+            "binding": "strong"}
+    base.update(kw)
+    return base
+
+
+class DetectionTests(unittest.TestCase):
+    def test_no_tests_means_no_detection(self):
+        self.assertEqual(coverage.detection_for([]), coverage.DETECTION_CEILING)
+
+    def test_detection_decreases_monotonically_and_never_passes_the_floor(self):
+        previous = coverage.DETECTION_CEILING + 1
+        for count in range(0, 40):
+            d = coverage.detection_for([_test_row() for _ in range(count)])
+            self.assertLessEqual(d, previous)
+            self.assertGreaterEqual(d, coverage.DETECTION_FLOOR)
+            previous = d
+
+    def test_every_added_test_still_gains_something(self):
+        """A plateau here is what stalled the greedy planner. Guard it."""
+        for count in range(0, 12):
+            a = coverage.detection_for([_test_row() for _ in range(count)])
+            b = coverage.detection_for([_test_row() for _ in range(count + 1)])
+            self.assertLess(b, a, "no gain going from {} to {} tests".format(
+                count, count + 1))
+
+    def test_incidental_bindings_are_worth_nothing(self):
+        many = [_test_row(binding="incidental") for _ in range(500)]
+        self.assertEqual(coverage.detection_for(many), coverage.DETECTION_CEILING)
+
+    def test_disabled_tests_are_worth_nothing(self):
+        self.assertEqual(
+            coverage.detection_for([_test_row(is_disabled=True) for _ in range(9)]),
+            coverage.DETECTION_CEILING)
+
+    def test_smoke_counts_for_more_than_a_plain_test(self):
+        self.assertLess(
+            coverage.detection_for([_test_row(is_smoke=True)]),
+            coverage.detection_for([_test_row()]))
+
+    def test_disabled_only_is_labelled_distinctly(self):
+        scored = coverage._score([_test_row(is_disabled=True)])
+        self.assertEqual(scored["coverage_tier"], "disabled-only")
+        self.assertEqual(scored["detection"], coverage.DETECTION_CEILING)
+
+
+class BindingTests(unittest.TestCase):
+    def setUp(self):
+        self.catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="downloads", name="Downloads", severity=8,
+                               page_objects=["downloads"],
+                               test_patterns=["Download"]),
+        ])
+
+    def _bind(self, test):
+        return coverage.bind(self.catalog, {"tests": [test]})
+
+    def test_name_and_surface_is_a_strong_binding(self):
+        out = self._bind(_test_row(class_name="DownloadTest",
+                                   surfaces=["downloads"]))
+        self.assertEqual(out["per_feature"]["downloads"]["tests"][0]["binding"],
+                         "strong")
+
+    def test_name_only_binding(self):
+        out = self._bind(_test_row(class_name="DownloadTest"))
+        self.assertEqual(out["per_feature"]["downloads"]["tests"][0]["binding"],
+                         "name-only")
+
+    def test_surface_without_a_matching_name_is_only_incidental(self):
+        out = self._bind(_test_row(class_name="BookmarksTest",
+                                   surfaces=["downloads"]))
+        self.assertEqual(out["per_feature"]["downloads"]["tests"][0]["binding"],
+                         "incidental")
+
+    def test_unrelated_test_binds_to_nothing(self):
+        out = self._bind(_test_row(class_name="SyncTest", surfaces=["sync"]))
+        self.assertEqual(out["unbound_count"], 1)
+
+
+# ---------------------------------------------------------------------------
+# feature mapping
+# ---------------------------------------------------------------------------
+
+class FeatureMapTests(unittest.TestCase):
+    def setUp(self):
+        self.catalog = featuremap.FeatureCatalog([
+            featuremap.Feature(id="broad", name="Broad", severity=5,
+                               source_globs=["**/org/mozilla/fenix/settings/**"]),
+            featuremap.Feature(id="narrow", name="Narrow", severity=9,
+                               source_globs=[
+                                   "**/org/mozilla/fenix/settings/logins/**"]),
+        ])
+
+    def test_most_specific_glob_becomes_the_primary_feature(self):
+        path = "mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/L.kt"
+        out = featuremap.attribute(self.catalog, [self._file(path)])
+        primary = out["features_touched"][0]
+        self.assertEqual(primary["feature_id"], "narrow")
+        self.assertIn("broad", primary["files"][0]["secondary_features"])
+
+    def test_a_file_is_counted_once(self):
+        path = "mobile/android/fenix/app/src/main/java/org/mozilla/fenix/settings/logins/L.kt"
+        out = featuremap.attribute(self.catalog, [self._file(path)])
+        self.assertEqual(len(out["features_touched"]), 1)
+
+    def test_test_sources_are_ignored_not_unmapped(self):
+        path = "mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/ATest.kt"
+        out = featuremap.attribute(self.catalog, [self._file(path)])
+        self.assertEqual(out["ignored_count"], 1)
+        self.assertEqual(out["unmapped_files"], [])
+
+    def test_unrecognised_source_is_surfaced_not_dropped(self):
+        out = featuremap.attribute(self.catalog, [self._file("some/other/File.kt")])
+        self.assertEqual(len(out["unmapped_files"]), 1)
+
+    @staticmethod
+    def _file(path):
+        return {"path": path, "added": 10, "deleted": 2, "commits": 1,
+                "authors": 1, "total_lines": 100, "is_binary": False,
+                "touched_by_backout": False, "churned_lines": 12}
+
+
+# ---------------------------------------------------------------------------
+# kotlin parsing, against fixtures
+# ---------------------------------------------------------------------------
+
+class CorpusTests(unittest.TestCase):
+    def setUp(self):
+        self.cases = corpus.parse_file(
+            os.path.join(FIXTURES, "ui", "SampleFeatureTest.kt"), "ui", FIXTURES)
+        self.by_name = {c.name: c for c in self.cases}
+
+    def test_finds_every_annotated_test(self):
+        self.assertEqual(
+            sorted(self.by_name),
+            ["disabledTest", "plainTest", "smokeTest"])
+
+    def test_helper_methods_are_not_tests(self):
+        self.assertNotIn("notATest", self.by_name)
+
+    def test_reads_the_smoke_annotation(self):
+        self.assertTrue(self.by_name["smokeTest"].is_smoke)
+        self.assertFalse(self.by_name["plainTest"].is_smoke)
+
+    def test_reads_the_ignore_annotation(self):
+        self.assertTrue(self.by_name["disabledTest"].is_disabled)
+        self.assertFalse(self.by_name["smokeTest"].is_disabled)
+
+    def test_reads_the_testrail_id_from_the_comment(self):
+        self.assertEqual(self.by_name["smokeTest"].testrail_id, "3205329")
+
+    def test_picks_up_page_object_surfaces(self):
+        self.assertIn("downloads", self.by_name["smokeTest"].surfaces)
+
+    def test_picks_up_legacy_robot_imports(self):
+        self.assertIn("downloadRobot", self.by_name["plainTest"].surfaces)
+
+
+class FactoryScanTests(unittest.TestCase):
+    def setUp(self):
+        self.scan = factories.scan(FIXTURES, "efficiency")
+        self.by_id = {f["id"]: f for f in self.scan["factories"]}
+
+    def test_counts_selectors_for_the_interaction_factory(self):
+        self.assertEqual(self.by_id["interaction"]["candidates"], 3)
+
+    def test_counts_page_objects(self):
+        self.assertEqual(self.scan["page_count"], 2)
+
+    def test_pairs_are_ordered_page_transitions(self):
+        self.assertEqual(self.by_id["pairs"]["candidates"], 2)  # 2 pages -> 2*1
+
+    def test_parses_context_factors_and_names_them_readably(self):
+        names = {f["name"] for f in self.scan["context_factors"]}
+        self.assertEqual(names, {"BrowserMode", "DeviceClass"})
+
+    def test_exhaustive_profile_is_the_product_of_the_factors(self):
+        self.assertEqual(self.scan["context_profiles"]["EXHAUSTIVE_PREVIEW"], 4)
+
+    def test_parses_capabilities_with_their_feature(self):
+        self.assertEqual(self.scan["capability_features"], ["bookmarks"])
+
+
+# ---------------------------------------------------------------------------
+# git parsing, against a throwaway repo
+# ---------------------------------------------------------------------------
+
+@unittest.skipIf(shutil.which("git") is None, "git not available")
+class GitChangeTests(unittest.TestCase):
+    """Guards the record-separator handling in changes.collect().
+
+    git emits --numstat *after* the format string, so a trailing separator
+    silently pairs each commit with the previous commit's file list. That bug
+    reported one commit and zero files, which looked like an empty range.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.repo = tempfile.mkdtemp(prefix="planner-git-")
+        run = lambda *a: subprocess.run(  # noqa: E731
+            a, cwd=cls.repo, check=True, capture_output=True)
+        run("git", "init", "-q")
+        run("git", "config", "user.email", "t@example.com")
+        run("git", "config", "user.name", "Tester")
+
+        # Seed commit so HEAD~4 resolves once the four below are in.
+        cls._commit(run, "seed.txt", "seed\n", "No bug - seed")
+        cls._commit(run, "a.txt", "one\ntwo\nthree\n", "Bug 111111 - add a")
+        cls._commit(run, "b.txt", "x\n", "Bug 222222 - add b")
+        # Rewrites line 2 (+1/-1) and appends two lines (+2) => +3/-1.
+        cls._commit(run, "a.txt", "one\nCHANGED\nthree\nfour\nfive\n",
+                    "Bug 333333 - grow a")
+        cls._commit(run, "b.txt", "x\ny\n",
+                    'Revert "Bug 222222 - add b" for bustage')
+
+    @classmethod
+    def _commit(cls, run, name, body, message):
+        with open(os.path.join(cls.repo, name), "w") as fh:
+            fh.write(body)
+        run("git", "add", name)
+        run("git", "commit", "-q", "-m", message)
+
+    @classmethod
+    def tearDownClass(cls):
+        shutil.rmtree(cls.repo, ignore_errors=True)
+
+    def test_finds_every_commit(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD")
+        self.assertEqual(out["commit_count"], 4)
+
+    def test_attributes_files_to_the_right_commits(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD")
+        by_path = {f["path"]: f for f in out["files"]}
+        self.assertEqual(set(by_path), {"a.txt", "b.txt"})
+        self.assertEqual(by_path["a.txt"]["commits"], 2)
+        self.assertEqual(by_path["b.txt"]["commits"], 2)
+
+    def test_counts_added_and_deleted_lines(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD")
+        a = next(f for f in out["files"] if f["path"] == "a.txt")
+        self.assertEqual(a["added"], 3 + 3)   # 3 on create, 3 on the edit
+        self.assertEqual(a["deleted"], 1)     # one line replaced
+        self.assertEqual(a["churned_lines"], 7)
+
+    def test_extracts_bug_numbers(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD")
+        bugs = {b for c in out["commits"] for b in c["bugs"]}
+        self.assertEqual(bugs, {"111111", "222222", "333333"})
+
+    def test_flags_files_touched_by_a_backout(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD")
+        by_path = {f["path"]: f for f in out["files"]}
+        self.assertTrue(by_path["b.txt"]["touched_by_backout"])
+        self.assertFalse(by_path["a.txt"]["touched_by_backout"])
+
+    def test_pathspec_restricts_the_result(self):
+        out = changes.collect(self.repo, "HEAD~4..HEAD", pathspec=["a.txt"])
+        self.assertEqual([f["path"] for f in out["files"]], ["a.txt"])
+
+    def test_empty_range_yields_no_files(self):
+        self.assertEqual(changes.collect(self.repo, "HEAD..HEAD")["files"], [])
+
+
+# ---------------------------------------------------------------------------
+# planning
+# ---------------------------------------------------------------------------
+
+class PlanTests(unittest.TestCase):
+    def _fixture(self, test_count=10):
+        rows = [{
+            "feature_id": "f", "name": "F", "severity": 9, "occurrence": 8,
+            "detection": 10.0, "band": "action-required", "rpn": 720,
+            "inherent_rpn": 720, "criticality": 72, "test_count": test_count,
+            "active_count": test_count, "smoke_count": 0, "disabled_count": 0,
+            "indirect": False, "iso25010": ["functional_suitability"],
+            "severity_rationale": "fixture", "churned_lines": 100,
+        }]
+        cov = {"per_feature": {"f": {"tests": [
+            _test_row(name="t{}".format(i), suite="ui.efficiency")
+            for i in range(test_count)
+        ]}}}
+        return {"rows": rows, "totals": {}}, cov
+
+    def test_selects_more_than_one_test(self):
+        """Regression guard: a tiered detection curve stalled this at 3."""
+        risk_result, cov = self._fixture(test_count=10)
+        out = plan.build(risk_result, cov)
+        self.assertGreater(out["selected_count"], 1)
+
+    def test_budget_is_never_exceeded(self):
+        risk_result, cov = self._fixture(test_count=40)
+        for budget in (1.5, 3.0, 7.5, 15.0):
+            out = plan.build(risk_result, cov, budget_minutes=budget)
+            self.assertLessEqual(out["estimated_minutes"], budget)
+
+    def test_a_bigger_budget_never_lowers_confidence(self):
+        risk_result, cov = self._fixture(test_count=40)
+        previous = -1.0
+        for budget in (3.0, 7.5, 15.0, 60.0):
+            confidence = plan.build(
+                risk_result, cov,
+                budget_minutes=budget)["totals"]["release_confidence"]
+            self.assertGreaterEqual(confidence, previous)
+            previous = confidence
+
+    def test_residual_risk_is_below_the_baseline(self):
+        risk_result, cov = self._fixture(test_count=10)
+        out = plan.build(risk_result, cov)
+        entry = out["per_feature"][0]
+        self.assertLess(entry["residual_rpn"], entry["baseline_rpn"])
+
+    def test_incidental_tests_are_never_scheduled(self):
+        risk_result, cov = self._fixture(test_count=5)
+        for t in cov["per_feature"]["f"]["tests"]:
+            t["binding"] = "incidental"
+        out = plan.build(risk_result, cov)
+        self.assertEqual(out["selected_count"], 0)
+
+    def test_a_feature_with_no_automation_is_reported_as_a_gap(self):
+        risk_result, cov = self._fixture(test_count=0)
+        out = plan.build(risk_result, cov)
+        self.assertEqual(len(out["gaps"]), 1)
+        self.assertIn("No UI automation", out["gaps"][0]["reason"])
+
+
+class MatrixAllocationTests(unittest.TestCase):
+    def setUp(self):
+        with open(os.path.join(TOOL_ROOT, "config", "environment.json")) as fh:
+            self.env = json.load(fh)
+        self.context = [
+            {"name": "BrowserMode", "levels": ["Default", "Private"]},
+            {"name": "Account", "levels": ["SignedOut", "SignedIn"]},
+        ]
+
+    def _allocate(self, band):
+        rows = [{"feature_id": "f", "name": "F", "band": band, "rpn": 500,
+                 "severity": 9, "occurrence": 8}]
+        plan_result = {
+            "per_feature": [{"feature_id": "f", "planned_cost_minutes": 10.0,
+                             "planned_tests": 4}],
+            "estimated_minutes": 10.0,
+        }
+        return matrix.allocate(rows, plan_result, self.env, self.context)
+
+    def test_higher_risk_earns_more_configurations(self):
+        counts = {b: self._allocate(b)["designs"][b]["config_count"]
+                  for b in ("acceptable", "review", "action-required")}
+        self.assertEqual(counts["acceptable"], 1)
+        self.assertLess(counts["acceptable"], counts["review"])
+        self.assertLess(counts["review"], counts["action-required"])
+
+    def test_each_design_actually_covers_its_strength(self):
+        for band in ("review", "action-required"):
+            design = self._allocate(band)["designs"][band]
+            self.assertTrue(design["verification"]["complete"])
+
+    def test_executions_are_tests_times_configs(self):
+        out = self._allocate("review")
+        entry = out["per_feature"][0]
+        self.assertEqual(entry["executions"],
+                         entry["planned_tests"] * entry["config_count"])
+
+    def test_context_factors_from_source_reach_the_pool(self):
+        pool = {f["name"] for f in self._allocate("review")["factor_pool"]}
+        self.assertIn("BrowserMode", pool)
+        self.assertIn("ApiLevel", pool)
+
+
+class ConfigTests(unittest.TestCase):
+    """The shipped config is data, so it gets validated like data."""
+
+    def test_feature_catalog_loads_and_is_well_formed(self):
+        catalog = featuremap.FeatureCatalog.load(
+            os.path.join(TOOL_ROOT, "config", "features.json"))
+        ids = [f.id for f in catalog]
+        self.assertTrue(ids)
+        self.assertEqual(len(ids), len(set(ids)), "duplicate feature ids")
+        for feature in catalog:
+            self.assertTrue(1 <= feature.severity <= 10, feature.id)
+            self.assertTrue(feature.name, feature.id)
+            self.assertTrue(feature.severity_rationale,
+                            "{} has no severity rationale".format(feature.id))
+            self.assertTrue(feature.source_globs, feature.id)
+
+    def test_allocation_policy_covers_every_band(self):
+        with open(os.path.join(TOOL_ROOT, "config", "environment.json")) as fh:
+            env = json.load(fh)
+        self.assertEqual(set(env["allocation_policy"]),
+                         {"action-required", "review", "acceptable"})
+        for name, spec in env["allocation_policy"].items():
+            self.assertIn("strength", spec)
+            self.assertTrue(spec["factors"], name)
+            self.assertTrue(spec["rationale"], name)
+
+    def test_every_environment_factor_declares_whether_it_is_real(self):
+        with open(os.path.join(TOOL_ROOT, "config", "environment.json")) as fh:
+            env = json.load(fh)
+        for factor in env["infrastructure_factors"]:
+            self.assertIn(factor["source"], ("real", "partly-real", "stubbed"),
+                          factor["name"])
+            self.assertTrue(factor.get("origin"), factor["name"])
+            self.assertGreaterEqual(len(factor["levels"]), 2, factor["name"])
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
<!--
PR title:

release-test-planner: risk-based release test planning prototype (Android)

Everything below the line is the PR body.
-->

---

Early prototype (v0.0.1) of a release test planner: takes a git range, maps the
changed code to Fenix features, checks what test automation exists for them,
scores release risk with FMEA, and produces a recommended test run, the manual
testing gap, and a configuration matrix sized by risk.

**Not wired into anything and not gating anything.** Opening it so it can be
reviewed and argued with rather than described in the abstract. Android/UI-only
today; the risk scoring and array generation carry no platform knowledge and are
built to move unchanged when iOS lands.

## Why this is possible now and wasn't before

Risk-based selection is an old idea that mostly doesn't work, for two reasons
that are rarely said plainly:

1. **Selection only pays off when supply exceeds budget.** If the release window
   fits 200 tests and the suite has 200 tests, the optimal plan is "run
   everything" and the scoring machinery adds nothing.
2. **A hand-written suite has no denominator.** You can't claim "60% coverage of
   tabs" when nobody enumerated what 100% is. It isn't a sample of a defined
   space, it's a pile of files that accumulated as people found time.

The efficiency harness's **test factories** break both. They don't author tests,
they enumerate a space and emit a case per point in it. Current candidate space
is **3,158 cases** from a model of ~50 page objects and 58 selector catalogs —
and it compounds: registering page object #51 costs one authored file and yields
+1 reachability case, +100 pair candidates, and one interaction candidate per
selector, discovered by reflection so there's no registry to forget.

That's what makes this tool worth building. Supply genuinely exceeds budget, so
selection is a real question. And the space is enumerable, so coverage
percentages have a denominator.

Full argument, including the parts I'm not overselling:
`release-test-planner/docs/why-factories.md`.

## What it produces

On a sample range of 43 commits touching Fenix:

| | |
|---|---|
| Release confidence | **51.1%** of inherent risk removed by the planned run |
| Recommended run | **73 tests, 2.46h** — with **244** bound tests skipped as removing no additional risk |
| Action required | **3** features at RPN ≥ 200, all three with **zero** UI automation |
| Across the matrix | **458 executions, 21.7 device-hours** (8.8× the single-config run) |
| Open questions | **44** typed judgement calls emitted for review |

Diminishing returns, which is the curve a release manager actually needs:
15 min → 29.1%, 45 min → 43.3%, 240 min → 51.1%. **45 minutes buys 85% of what
147 minutes buys.**

## Two things it found on its first real run

**Coverage was being badly overstated.** The first pass credited Home Screen with
**502** covering tests. Only **16** actually verify it — the rest import
`homeScreen` to *navigate somewhere else*. Overstated coverage is worse than
none: it suppresses the risk score that should have triggered manual testing.
Bindings are now graded and pass-through ones count zero.

This produced the strongest unplanned argument for the efficiency refactor:
**the legacy suite isn't statically analyzable and the efficiency suite is.** In
the robot DSL navigation and verification are the same gesture, so what a test
covers isn't recoverable from source. `on.<page>` makes it machine-readable. You
can't compute risk-weighted coverage over a suite you can't parse.

**A new feature was hiding inside "infrastructure."** Reading the diffs to answer
the `assess-change-semantics` question showed 342 of 690 lines filed under App
Infrastructure were a new **Google Lens integration** (bug 2028573) under
`components/lens/`. Now its own catalog entry, landing as action-required with
zero UI coverage — which it genuinely has.

## The deterministic / AI split

**The pipeline never calls a model.** It runs deterministically and emits typed
questions for what genuinely needs judgement — unmapped paths,
refactor-vs-behaviour-change, severity review, weak bindings, manual case
authoring. Answers feed back via `--answers` and land in
`meta.agent_overrides_applied`, so every AI-influenced number traces to a
question, an answer, and a rationale.

You can run the whole thing with no AI and get a complete, defensible answer.
Judgement improves it; nothing depends on it.

## Risk model

FMEA — `RPN = Severity × Occurrence × Detection` (IEC 60812), the scheme ISTQB's
risk-based testing material builds on. It fits because FMEA's *Detection* factor
means "how likely does this escape to release," which is the coverage question
already formalised. Occurrence is derived from relative code churn per Nagappan
& Ball (ICSE 2005). Bands follow conventional AIAG thresholds.

The matrix implements both orthogonal arrays (Rao-Hamming; 4×3-level factors
gives the textbook L9) and covering arrays (IPOG, the algorithm behind NIST's
ACTS). On the review-band factor set: 96 full factorial → 23 orthogonal → **13
covering**, same pairwise coverage. Every generated array is verified by
re-deriving its t-tuples, because a subtly wrong array doesn't crash — it
silently under-tests and reports a false coverage number.

## Relationship to `test-recommender`

Adjacent, not duplicate — and both should exist. `test-recommender` is iOS,
starts from the TestRail catalogue, LLM-ranked. This is Android, starts from the
code and the automation that exists, deterministic with LLM for named judgement
calls. The overlap worth exploiting is the risk model: `risk.py` and `matrix.py`
are self-contained and carry no Fenix knowledge, so they could slot under
`test-recommender` too if the scoring proves out.

## Reviewing this

```bash
cd release-test-planner
python -m unittest discover -s tests -p '*tests.py'     # 69 tests, ~0.6s, no checkout needed
./plan.py analyze --repo /path/to/firefox --range "HEAD~300..HEAD" --budget 240 --open
```

Stdlib only, Python 3.9+. No install, no dependencies, no API key, no network.
Tests need no Firefox checkout — Kotlin parsing runs against fixtures, git
parsing against a throwaway repo. CI runs on 3.9 and 3.12 with no install step.

Suggested reading order: `docs/why-factories.md` for the argument,
`docs/risk-model.md` for the scoring, `config/features.json` for the judgement
calls most worth disagreeing with (every severity carries a written rationale,
enforced by a test).

## Real vs stubbed

**Parsed from the tree:** git churn, the UI corpus (629 legacy + 140 efficiency),
466 selectors, 50 page objects, the behavior capability/template catalogs, and
the `BrowserMode / Account / DeviceClass / Pocket / RecentlyVisited /
UnifiedTrustPanel` factors read out of `BehaviorContextMatrix.kt`.

**Stubbed** and labelled in both the UI and config: `ApiLevel` values,
`BuildVariant`, `Network`, `Theme`, `Foldable`, cost multipliers, the
behavior-factory projection. Severities are hand-assigned judgement.

**Factory status** is exactly as the in-tree architecture doc states it:
Reachability is production-ready and auto-covers every registered page;
Interaction is bookmarks-only; Behavior's context matrix is largely
unimplemented; Pairs is unproven. The candidate counts describe the size of the
space the model defines, not runnable tests today. Reachability is the existence
proof for the pattern.

## Known limits

- **UI tests only.** Unit/component/service coverage isn't modelled, so
  confidence is *understated* for well-unit-tested code. Closing this is worth
  more than any refinement of the existing scoring.
- **TestRail is read, not integrated** — IDs are parsed from test comments and
  displayed; the API isn't queried and manual effort isn't sized against the
  catalogue.
- **Factory candidates are counted, not selected** — attributed to features but
  not yet feeding the run plan.
- Occurrence is churn-only; test cost is a flat estimate, not measured runtime;
  flaky tests count as full detection (generous); binding is name/surface
  matching, not execution tracing; the matrix assumes every test runs in every
  config (needs forbidden-tuple support).

## Open questions for reviewers

- Does this belong in `testops-tools` or its own repo? It's the largest tool
  here by LOC (3,669), though `testrail/` is comparable at 3,582. My read is it
  belongs here for adjacency to `test-recommender` — but happy to move it.
- Is `release-test-planner` the right name given `test-recommender` exists?
- Are the severity values in `config/features.json` defensible? That's the
  layer most in need of people who know these features better than I do.
