### PR TITLE
Tae effverify crash verdict

### DIFF
--- a/tae-conversion/README.md
+++ b/tae-conversion/README.md
@@ -13,7 +13,7 @@ tools run on *your* machine; a small watcher (`effwatch.sh`) bridges the two.
 |---|---|
 | Agent skills (`efficiency-test-authoring`, `tae-test-review`, `efficiency-conversion-loop`) | [`firefox-aidev-plugins`](https://github.com/mozilla/firefox-aidev-plugins) → `plugins/tae` |
 | Framework reference docs (guides, gotchas, architecture) | mozilla-central, `mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/docs/` |
-| Device-side dump tools (`effview`, `effpretty`) | mozilla-central, same tree under `devtools/` |
+| Device-side dump tools (`effview`, `effpretty`) | mozilla-central, same tree under `devtools/` — `effloop` resolves `effpretty` from `$REPO`, so no copy or symlink is needed in this repo |
 | Host-side workflow tools | **here** |
 
 The skills tell the agent *how* to work and reference these tools by name. Install the

--- a/tae-conversion/README.md
+++ b/tae-conversion/README.md
@@ -51,7 +51,7 @@ Optional environment, all with sane fallbacks:
 | `effscaffold.py` | agent | Front-loads a conversion: legacy body, TestRail id, already-converted check, robots + selector lines, existing coverage. |
 | `effcheck.py` | agent | Static pre-flight, no device. Resolution, empty nav paths, inline selectors, missing verbs, test-class boilerplate. Exit ≠ 0 = fix something. |
 | `effbuild.py` | agent | Gradle log → one-line verdict plus only the compile errors. `--json`. |
-| `effverify.py` | agent | **Done-gate.** Confirms the named test ran, wasn't skipped, and its *last* run is 0-failed. `clean=false` = passed only on retry, i.e. flaky. `--json`. |
+| `effverify.py` | agent | **Done-gate.** Confirms the named test ran, wasn't skipped, and did not fail in *any* run block. Reads the report's `failed:` markers, its `FAILURES (n of m)` header and `CRASH:` lines, so a test that died from an uncaught exception is not scored as passed. `clean=false` = passed only on retry, i.e. flaky. Refuses to report clean when the declared failure count exceeds what it can attribute (`unattributed_failures`). `--json`. |
 | `effloop.sh` | you | One command: build → run on device → write `build-report.txt`, `run-report.txt`, `status.json`. |
 | `effwatch.sh` | you | Start once, leave running. Polls `conversion-runs/_queue/`, runs the build and the git/Bugzilla actions, writes results back. |
 | `effbug.py` | via bridge | Files a Bugzilla bug, rewords the title to match the commit subject, self-assigns. |

--- a/tae-conversion/docs/CONVERSION-LESSONS.md
+++ b/tae-conversion/docs/CONVERSION-LESSONS.md
@@ -448,6 +448,33 @@ and which assertion to trust.
   `searchMockServerRule.server.port` URL is vestigial, so the efficiency test needs no mock-server rule.
 - Rule: check the fragment before inheriting a rule.
 
+**K13. Ad surfaces (sponsored tiles, Firefox Suggest) are testable locally — fake the app-services client, not the UI.**
+- Both surfaces fetch from region-gated remote inventory that a dev machine or emulator generally is not served,
+  and Suggest additionally races a ~9s startup ingestion whose completion is **not observable anywhere** (no store
+  state, no pref, no Glean metric, no Fact; the result is discarded into `GlobalScope`). You cannot await it.
+- The seam is the app-services client/store, and it is the same one app-services uses in its OWN unit tests:
+  `MozAdsClientProvider.client` (private field, `service-mars`) and `FxSuggestStorage.store`
+  (`internal @VisibleForTesting Lazy<SuggestStore>`). Both `MozAdsClient` and `SuggestStore` are **open** UniFFI
+  classes with a public `NoHandle` constructor, so a fake subclass + reflection is all it takes. See
+  `FakeSponsoredTopSites.kt` / `FakeFxSuggest.kt` in fenix androidTest (bugs 2063093, 2063105).
+- Everything downstream stays real — provider, storage, presenter, store, Compose UI, Glean facts — so the
+  behaviour under test is still the product's. Faking the *network boundary* is not the same as faking the test.
+- Four things that will each cost you a cycle:
+  1. Resolve the component lazy (`components.ads.lazyAdsClientProvider`, `components.fxSuggest.storage`)
+     **before** swapping, or its initializer rebuilds the real object over your fake.
+  2. Override **every** interface method, not just the one you need. A `NoHandle` object throws
+     `uniffiCloneHandle() called on NoHandle object` on any un-overridden call, and displaying a sponsored tile
+     makes the app record an impression on a background coroutine — which failed a test *after* all of its
+     assertions had passed.
+  3. Nimbus gates Suggest's types: `fxsuggest.fml.yaml` defaults `amp`/`ampMobile` to **false**, so the provider
+     never requests AMP and no fake store can make a sponsored-suggestion test pass. Override
+     `availableSuggestionTypes` with `withCachedValue`.
+  4. The artifact is `implementation` inside the AC module, so androidTest cannot see it. Add
+     `androidTestCompileOnly` — **not** `androidTestImplementation`, which puts it on the androidTest runtime
+     classpath and makes Gradle fail to align that with the app's, since both then pull `project(':geckoview')`.
+- `#[cfg(test)]` Rust test utilities (the ads client's `Environment::Test`, suggest's `testing::MockRemoteSettingsClient`)
+  are compiled out of the shipped library and absent from the UniFFI bindings — do not plan around them.
+
 ## Open gaps (unresolved — pick up on next attempt)
 
 - **Address-autofill suggestion not offered on-device.** With the stylus overlay removed AND stylus disabled,

--- a/tae-conversion/docs/CONVERSION-LESSONS.md
+++ b/tae-conversion/docs/CONVERSION-LESSONS.md
@@ -396,10 +396,13 @@ and which assertion to trust.
   `SettingsSearchDefaultSearchEnginePage`. Adding just your own `Case(...)` entries by hand avoids pulling in
   unrelated stale-missing pages; a full regen is a separate cleanup (good-first-bug).
 
-**K8. Tool verdicts: `effverify` crashes on a RED run, and duration is the first triage signal.**
-- `effverify`'s `failure_excerpt` path throws `NameError: name 'txt' is not defined`, so on any failure it gives no
-  verdict. Fall back to `effbuild --json <raw-run.log>` for the build verdict, then read the JUnit XML at
-  `objdir-frontend/gradle/build/.../androidTest-results/connected/debug/TEST-*.xml` for counts and per-testcase results.
+**K8. Tool verdicts: duration is the first triage signal (the RED-run crash is FIXED).**
+- ~~`effverify`'s `failure_excerpt` path throws `NameError: name 'txt' is not defined`~~ — **fixed 2026-08-12**
+  (`txt` should have been `full`; it only ever triggered when there was no `raw-run.log` to read). effverify now
+  returns a verdict on a failing run, with a capped `failure_excerpt`, so the JUnit-XML fallback below is no
+  longer needed for the common case. It is still the right move when `run-report.txt` is missing entirely (A24).
+- **Cross-check `status.json` anyway.** A green effverify next to a non-zero `effloop_exit` means believe the exit
+  code: see A37 for the crash-mode false green that motivated this rule.
 - `effloop_exit:2` in ~45s = COMPILE failure, not a run — read `effbuild --json` for the Kotlin error.
   `effloop_exit:0` in ~50s = warm incremental build + quick run; still confirm `clean:true`, `failed_total:0`,
   `retried:false` (green alone hides a skip or a retry-pass).

--- a/tae-conversion/docs/HARNESS-GOTCHAS.md
+++ b/tae-conversion/docs/HARNESS-GOTCHAS.md
@@ -536,3 +536,52 @@ Last updated: 2026-08-04.
   altogether with `./mach gradle :fenix:ktlint :fenix:detekt`. Note gradle caches those tasks — an `UP-TO-DATE`
   run prints nothing and looks clean; add `--rerun-tasks` when you need certainty. `./mach format` (spotless)
   does NOT catch the ktlint rules that fail the gate, e.g. `no-consecutive-blank-lines` and `standard:kdoc`.
+
+### A39. An arrival check can be satisfied by an element BEHIND an overlay (2026-08-12)
+- **Symptom:** `navigateToPage` reports arrival on a page the test never reached, and the run fails several
+  steps later somewhere unrelated. Cost 5 device cycles on one conversion before the test was parked, then
+  landed in 2 once the dumps were read.
+- **Cause:** `requiredForPage` selectors resolve on nodes that are still in the tree underneath a modal
+  surface. Two confirmed cases: `BrowserPage`'s `ENGINE_VIEW` resolves under the addressbar's edit-mode
+  overlay, and `HomeSelectors.HOMEPAGE_VIEW` resolves under the search overlay while the toolbar is covered.
+- **Check:** after any query submit, `mozWaitUntilAbsent(SearchBarSelectors.TOOLBAR_IN_EDIT_MODE)` before the
+  next hop. When backing out to a page, anchor on something that is genuinely occluded — `MAIN_MENU_BUTTON`,
+  not `HOMEPAGE_VIEW` — or the loop returns while you are still covered and the next `navigateToPage` takes a
+  destructive edge (for HomePage that is the "New tab" click).
+
+### A40. `mozLongClick` is not held long enough for a View-based list row (2026-08-12)
+- **Symptom:** a long press on a history row silently behaves as a TAP: the item opens in the browser, and the
+  next step's "More options" click then hits the browser's main menu instead of a multi-select toolbar. The
+  dump gives it away — the Compose tree starts at `ADDRESSBAR_URL_BOX`.
+- **Cause:** `UiObject.longClick()` uses UiAutomator's default press duration, which this row treats as a tap.
+- **Check:** select the row with an **Espresso** strategy (e.g. `ESPRESSO_BY_TEXT`) so `mozLongClick` goes
+  through Espresso's `longClick()`, which honours the platform long-press timeout. This is what the legacy
+  robots rely on.
+
+### A41. `COMPOSE_BY_TEXT` reports an AMBIGUOUS match as "not found" (2026-08-12)
+- **Symptom:** `mozVerify` fails with "not found after 5000ms" for text that is plainly on screen.
+- **Cause:** the strategy resolves through the singular `onNodeWithText`, which throws when more than one node
+  matches; `mozVerifyElement` swallows that and degrades to `false`. Two sponsored tiles, two identical
+  captions, and the verb says the text is absent.
+- **Check:** use `COMPOSE_BY_TEXT_SUBSTRING` (`onAllNodesWithText(...).onFirst()`) when duplicates are
+  possible, or scope to a container with `COMPOSE_ON_ALL_NODES_BY_TAG_WITH_CHILD_TEXT_ON_FIRST`.
+
+### A42. A caption is not unique to the surface you are testing (2026-08-12)
+- **Symptom:** an absence assertion for the "Sponsored" label can never come true on the homepage, even with
+  sponsored top sites disabled and visibly gone.
+- **Cause:** the Pocket sponsored *story* further down the homepage carries its own "Sponsored" identifier
+  (`pocket.sponsoredContent.identifier`). A bare text match hits it.
+- **Check:** scope the selector to the tile
+  (`COMPOSE_ON_ALL_NODES_BY_TAG_WITH_CHILD_TEXT_ON_FIRST` on `top_sites_list.top_site_item` + the caption).
+  Note the tile root is a plain `Box` that does not merge descendants, so a tag-only text query cannot see the
+  caption either.
+
+### A43. Revoking a runtime permission is not enough to reset a "don't ask again" (2026-08-12)
+- **Symptom:** a permission-dialog test passes on the first attempt and fails on BaseTest's retry, looking for
+  a Deny button that never appears — because the OS auto-denies with no dialog at all.
+- **Cause:** "Deny and don't ask again" sets `FLAG_PERMISSION_USER_FIXED`, which `pm revoke` leaves in place.
+  Legacy gets away with it only because the orchestrator wipes package data between test *methods*; a retry
+  runs in the same process.
+- **Check:** in the test, `pm clear-permission-flags <pkg> <permission> user-fixed user-set` **and**
+  `pm revoke <pkg> <permission>`. Do **not** use the device-wide `pm reset-permissions` — it strips permissions
+  the instrumentation itself relies on and crashes the test process.

--- a/tae-conversion/docs/HARNESS-GOTCHAS.md
+++ b/tae-conversion/docs/HARNESS-GOTCHAS.md
@@ -496,3 +496,38 @@ Last updated: 2026-08-04.
   expresses "checkbox that is a sibling of text X", so the faithful port is the legacy device call:
   `mDevice.findObject(UiSelector().text(name)).getFromParent(UiSelector().index(i)).click()`.
 - **Check:** keep index-fragile device interactions as page-object helpers, NEVER as a shared BasePage verb.
+
+### A37. effverify scored a CRASH-mode failure as passed — a false green (2026-08-12, FIXED)
+- **Symptom:** a class run whose `status.json` said `outcome=fail, failures=1` came back from
+  `effverify --json` as `{"ok": true, "clean": true, "failed_total": 0}`, with the failed test listed as
+  `"passed"`. `effloop_exit` was correctly `1`. The failing test was
+  `scanQRCodeToOpenAWebpageTest`, killed by `IllegalArgumentException: CaptureRequest contains unconfigured
+  Input/Output Surface!` from `QrFragment`.
+- **Cause:** the test died from an uncaught exception rather than a failed assertion, so the report contains
+  **no `failed:` marker** and the gradle log line does not say `FAILED`. effverify built its failed-set from
+  those two signals only and fell through to "appeared in `started:` and not otherwise flagged -> passed".
+  The tell in the JSON is `"gradle": null` on a test reported as passed. This is the same fall-through the
+  2026-08-03 fix closed for assertion failures; crashes survived it.
+- **Fix:** effverify now also reads the report's own `FAILURES (n of m)` header (which names each failed test)
+  and any `CRASH:` line inside a single-test block, and adds an `unattributed_failures` backstop: if the
+  declared failure count exceeds what it can pin to a name, it reports NOT DONE instead of guessing. Verified
+  against 7 real batches with no regressions.
+- **Check:** never take effverify alone as the done-gate. Read `status.json` (`outcome`, `failures`) next to it,
+  and if `effloop_exit` is non-zero while effverify says clean, believe the exit code.
+
+### A38. `mach lint` and every Gradle task serialize on one lockfile, and a killed run leaves it stale (2026-08-12)
+- **Symptom:** `A failure occurred in the android-format linter` with
+  `filelock._error.Timeout: The file lock 'objdir-frontend/gradle/mach_android.lockfile' could not be
+  acquired`, and `0 fixed` — which reads like a linter bug but is pure contention. Two concurrent
+  `mach lint` runs, or a lint started while an effwatch test run is building, will do this to each other.
+- **Cause:** `tools/lint/android/lints.py` wraps every gradle invocation in a `SoftFileLock` on
+  `mach_android.lockfile`. Being a *soft* lock, the file's existence IS the lock, so SIGTERM-ing a lint leaves
+  it behind and every later run waits out the timeout for nothing.
+- **Check:** run one at a time; never lint while a queued conversion run is in flight. After killing a lint,
+  `rm -f objdir-frontend/gradle/mach_android.lockfile`.
+- **Also:** `./mach lint <path>` on Kotlin selects `android-lint` too, which runs `:fenix:lintDebug` over the
+  whole module and takes ~10+ minutes; the path argument cannot narrow it, because the Android linters are
+  wired per Gradle module rather than per file. Use `-l android-format` (ktlint + detekt only), or skip mozlint
+  altogether with `./mach gradle :fenix:ktlint :fenix:detekt`. Note gradle caches those tasks — an `UP-TO-DATE`
+  run prints nothing and looks clean; add `--rerun-tasks` when you need certainty. `./mach format` (spotless)
+  does NOT catch the ktlint rules that fail the gate, e.g. `no-consecutive-blank-lines` and `standard:kdoc`.

--- a/tae-conversion/docs/HARNESS-GOTCHAS.md
+++ b/tae-conversion/docs/HARNESS-GOTCHAS.md
@@ -383,7 +383,12 @@ Last updated: 2026-08-04.
 ### A24. effloop can finish without a `run-report.txt`, silently disabling effverify (2026-08-04)
 - **Symptom:** `effverify` returns `{"ok": false, "error": "no run-report.txt (did it compile/run?)"}` for a
   run that plainly executed, and `status.json` says `"ran": false` while listing per-test results.
-- **Cause:** the `effpretty capture` step produced no report. The consequence beyond effverify is worse: the
+- **Cause (root cause FIXED 2026-08-12):** the `effpretty capture` step produced no report. `effloop.sh`
+  invoked it as `$TOOLS/effpretty.py`, but effpretty lives **in-tree** under
+  `ui/efficiency/devtools/effpretty/` — so it only ever resolved for checkouts that happened to have a local
+  copy or symlink beside the script, and silently did nothing everywhere else. effloop now resolves it under
+  `$REPO` (override with `EFFPRETTY=`), falls back to `$TOOLS`, and exits 2 with a named error if neither
+  exists rather than producing an empty report. The consequence beyond effverify was worse: the
   on-failure ScreenDumps never reach `raw-run.log` either, so diagnostics look absent when they are merely
   unrouted. This is what led me to conclude "mozClick does not dump on click failure" — it does,
   `BasePage.kt:478`.

--- a/tae-conversion/tools/effloop.sh
+++ b/tae-conversion/tools/effloop.sh
@@ -25,6 +25,12 @@ OUT_ROOT="${OUT_ROOT:-$(cd "$(dirname "$0")/.." && pwd)/conversion-runs}"   # de
 # Gradle's own per-run JUnit XML. Authoritative for pass/fail; the logcat trace is for *why*.
 RESULTS_DIR="${RESULTS_DIR:-$REPO/objdir-frontend/gradle/build/mobile/android/fenix/app/outputs/androidTest-results/connected/debug}"
 TOOLS="$(cd "$(dirname "$0")" && pwd)"
+# effpretty.py is NOT in this repo — it lives in-tree with the framework it renders, so resolve it under
+# $REPO. It used to be called as "$TOOLS/effpretty.py", which only worked for checkouts that happened to have
+# a local copy or symlink beside this script; anywhere else the renderer silently never ran, so run-report.txt
+# came out empty and effverify had no input to judge (see HARNESS-GOTCHAS A24).
+EFFPRETTY="${EFFPRETTY:-$REPO/mobile/android/fenix/app/src/androidTest/java/org/mozilla/fenix/ui/efficiency/devtools/effpretty/effpretty.py}"
+[ -f "$EFFPRETTY" ] || EFFPRETTY="$TOOLS/effpretty.py"
 # resolve adb the way effpretty does (effwatch's shell often lacks it on PATH)
 ADB="${ADB:-$(command -v adb 2>/dev/null || echo "${ANDROID_SDK_ROOT:-${ANDROID_HOME:-$HOME/Library/Android/sdk}}/platform-tools/adb")}"
 # ────────────────────────────────────────────────────────────────────────────
@@ -35,6 +41,7 @@ TEST_CLASS="${1:?usage: effloop.sh <TestClass|FQN|Class#method> [batch]}"; BATCH
 case "$TEST_CLASS" in *.*) FQCLASS="$TEST_CLASS" ;; *) FQCLASS="$TESTS_PKG.$TEST_CLASS" ;; esac
 OUT="$OUT_ROOT/$BATCH"; mkdir -p "$OUT"
 cd "$REPO" || { echo "REPO not found: $REPO"; exit 2; }
+[ -f "$EFFPRETTY" ] || { echo "effpretty.py not found at: $EFFPRETTY (set EFFPRETTY or REPO)"; exit 2; }
 
 # Anything in RESULTS_DIR older than this is from a PREVIOUS run — never report it as this run's result.
 RUN_START=$(date +%s)
@@ -54,7 +61,7 @@ cleanup_pretty() {
   PRETTY_PID=""
 }
 trap 'cleanup_pretty' EXIT INT TERM
-python3 "$TOOLS/effpretty.py" capture --mode watch --out "$OUT/run-report.txt" &
+python3 "$EFFPRETTY" capture --mode watch --out "$OUT/run-report.txt" &
 PRETTY_PID=$!
 
 ./mach gradle "$MACH_TASK" $MACH_ARGS \
@@ -72,7 +79,7 @@ if [ "${COMPILE_OK:-1}" -eq 0 ]; then
   # Fall back to a snapshot if the live attach produced nothing (e.g. it lost the device mid-run) —
   # better a late trace than none. Buffers were cleared above, so this cannot pick up an older run.
   if [ ! -s "$OUT/run-report.txt" ]; then
-    python3 "$TOOLS/effpretty.py" capture --mode dump --out "$OUT/run-report.txt" 2>/dev/null || true
+    python3 "$EFFPRETTY" capture --mode dump --out "$OUT/run-report.txt" 2>/dev/null || true
   fi
   if [ -s "$OUT/run-report.txt" ]; then RAN=true; echo "▶ run trace → $OUT/run-report.txt"; else RAN=false; fi
 else

--- a/tae-conversion/tools/effverify.py
+++ b/tae-conversion/tools/effverify.py
@@ -56,18 +56,46 @@ def main():
     def names(pattern, text):
         return set(re.findall(pattern + r":\s*([A-Za-z0-9_]+)\s*\(", text))
 
+    # --- Failure signals the `failed:` marker does not carry (MTE-5822).
+    #
+    # A test that dies from an uncaught exception rather than a failed assertion — a crash, e.g. a camera
+    # `CaptureRequest contains unconfigured Input/Output Surface!` — produces NO `failed:` marker line and
+    # no gradle FAILED line. The marker-based scoring below then fell through to "started and not otherwise
+    # flagged → passed" and reported a red test green, with clean=true and failed_total=0.
+    #
+    # The report does record such a failure, just not as a marker:
+    #   - a FAILURES header block above the first `run started:`, which names each failed test and states
+    #     the count ("FAILURES (1 of 10)");
+    #   - `CRASH:` lines inside the failing test's own run block.
+    # Both are read here, and the declared count is used as a backstop below.
+    preamble = full[:starts[0]] if starts else ""
+    header_failed = set(re.findall(r"^\s*✖\s+([A-Za-z0-9_]+)\s*$", preamble, re.M))
+    m_declared = re.search(r"^FAILURES\s*\((\d+)\s+of\s+\d+\)", preamble, re.M)
+    declared_failures = int(m_declared.group(1)) if m_declared else None
+
     started, ignored, failed_names = set(), set(), set()
     passed_in_some_block = set()
     for b in blocks:
         b_started, b_ignored, b_failed = names("started", b), names("ignored", b), names("failed", b)
+        # A CRASH line means the test in this block died. Only attributable by position when the block ran
+        # a single test; for a multi-test block the FAILURES header is the reliable source of the name.
+        if len(b_started) == 1 and re.search(r"^CRASH:", b, re.M):
+            b_failed |= b_started
         started |= b_started
         ignored |= b_ignored
         failed_names |= b_failed
         # Ran in this block and this block did not record it failing → it passed here.
         passed_in_some_block |= (b_started - b_failed - b_ignored)
 
+    failed_names |= header_failed
+
     # Count actual per-test failures observed anywhere in the report, not one block's summary line.
     failed_total = len(failed_names)
+
+    # Backstop: if the report declares more failures than we could pin to a name, then something failed in
+    # a way this parser still does not understand. Say so and refuse to report clean, rather than let an
+    # unrecognised failure mode read as green — which is exactly how MTE-5822 escaped.
+    unattributed_failures = max(0, (declared_failures or 0) - failed_total)
 
     n_runs = len(starts)
     # Retried if the harness logged a second attempt anywhere, or a test both failed and later passed.
@@ -89,13 +117,13 @@ def main():
     def failure_excerpt(name, cap_lines=30, cap_chars=1800):
         """Capped exception+frames for a FAILED test, so a failure never needs a raw-log read.
         Pull from the gradle raw log (has the stack); fall back to the run trace's [ERR] lines."""
-        src = raw_txt or txt
+        src = raw_txt or full
         # anchor on the test's FAILED marker if present, else its name
         anchor = re.search(r"(?:>\s*)?" + re.escape(name) + r"\b.*?(?:FAILED|Exception|Error)", src, re.S)
         start_i = anchor.start() if anchor else (src.find(name) if name in src else -1)
         if start_i < 0:
             # last resort: the run-trace error lines from the last run block
-            errs = re.findall(r"^\s*\[ERR\].*$", txt, re.M)
+            errs = re.findall(r"^\s*\[ERR\].*$", full, re.M)
             return "\n".join(errs[:cap_lines])[:cap_chars] or None
         chunk = src[start_i:start_i + cap_chars * 3]
         lines = [l for l in chunk.splitlines() if l.strip()][:cap_lines]
@@ -130,12 +158,14 @@ def main():
             if exc:
                 entry["failure_excerpt"] = exc
         tests.append(entry)
-    if failed_total > 0:
+    if failed_total > 0 or unattributed_failures > 0:
         ok = False
     clean = ok and not retried  # a retry-pass is green-but-flaky, not "done"
     if as_json:
         print(json.dumps({"tool": "effverify", "ok": ok, "clean": clean, "batch": batch,
                           "failed_total": failed_total, "runs": n_runs, "retried": retried,
+                          "declared_failures": declared_failures,
+                          "unattributed_failures": unattributed_failures,
                           "tests": tests}))
     else:
         print(f"effverify — {batch}")
@@ -148,7 +178,10 @@ def main():
                        "not-run": "never executed (no 'started:' line)"}[t["status"]]
                 print(f"  ✖ {t['name']}: {lbl}")
         if failed_total > 0:
-            print(f"  ✖ last run reports {failed_total} failed test-run(s)")
+            print(f"  ✖ report records {failed_total} failed test(s): {', '.join(sorted(failed_names))}")
+        if unattributed_failures > 0:
+            print(f"  ✖ report declares {declared_failures} failure(s) but only {failed_total} could be "
+                  f"attributed to a test name — unrecognised failure mode, treating as NOT DONE")
         if retried:
             print(f"  ⚠ retry detected (runs={n_runs}) — passed-on-retry is flaky, NOT clean-done")
         print("RESULT:", ("ALL PASS ✅" if clean else "PASS BUT FLAKY ⚠️") if ok else "NOT DONE ❌")


### PR DESCRIPTION
 ## Two false-signal fixes in the conversion loop, plus the docs they invalidate

  Both bugs had the same shape: the loop reported success when it should have reported
  failure or nothing at all. One scored a red run green; the other silently produced no
  report on any checkout but ours.

  Jira: MTE-5822, MTE-5764

  ### 1. effverify scored a CRASH-mode failure as passed (`03c91d2`)

  A class run whose `status.json` said `outcome=fail, failures=1` came back from
  `effverify --json` as `{"ok": true, "clean": true, "failed_total": 0}`, with the failed
  test listed as `"passed"`. `effloop_exit` was correctly `1` — only effverify lied, and
  effverify is what a conversion gets signed off against.

  Cause: the test died from an uncaught exception rather than a failed assertion, so the
  report contains no `failed:` marker and the gradle log line does not say `FAILED`.
  effverify built its failed-set from those two signals only, then fell through to
  "appeared in `started:` and not otherwise flagged -> passed". The tell in the JSON is
  `"gradle": null` on a test reported as passed. This is the same fall-through the
  2026-08-03 fix closed for assertion failures; crashes survived it.

  Fix:
  - Also read the report's own `FAILURES (n of m)` header, which names each failed test,
    and any `CRASH:` line inside a run block.
  - Add an `unattributed_failures` backstop: if the report declares more failures than can
    be pinned to a name, report NOT DONE rather than guess. This is the part that matters —
    it turns the next unrecognised failure mode into a loud refusal instead of a silent
    pass. New JSON fields: `declared_failures`, `unattributed_failures`.
  - Fix a latent `NameError` in `failure_excerpt()` (`txt` where the variable is `full`),
    which crashed the tool on any batch without a `raw-run.log`.

  ### 2. effloop never ran effpretty outside our own checkout (`532fde5`)

  effloop invoked the trace renderer as `$TOOLS/effpretty.py`, but effpretty is not in this
  repo — it lives in mozilla-central under `ui/efficiency/devtools/effpretty/`. It only
  resolved for checkouts that happened to have a copy or symlink beside `effloop.sh`. Ours
  did, which is exactly why this stayed invisible; everywhere else the renderer silently did
  nothing, `run-report.txt` came out empty, and effverify — whose primary input that is —
  returned no verdict for a run that plainly executed.

  Fix: resolve under `$REPO` (which effloop already knows), overridable with `EFFPRETTY=`,
  keep a `$TOOLS` fallback for existing setups, and exit 2 with a named error if neither
  exists. Failing loudly is the point — the old behaviour read as "the run did not happen"
  rather than "the renderer is not installed".

  ### 3. Docs (`eaa7afa`, plus doc changes in the two commits above)

  Corrections, not just additions:
  - README's tool table still described effverify's pre-2026-08-03 "its *last* run is
    0-failed" scoping.
  - CONVERSION-LESSONS **K8** documented the `NameError: name 'txt' is not defined` crash as
    a live problem — that is the bug fixed here, so K8 is marked fixed and the JUnit-XML
    fallback it recommended is no longer needed for the common case.
  - HARNESS-GOTCHAS **A24** now carries the root cause instead of describing the symptom.

  New:
  - **A37** the crash-mode false green, with reproducer and the `"gradle": null` tell.
  - **A38** `mach lint` and every gradle task serialize on
    `objdir-frontend/gradle/mach_android.lockfile`; a killed run leaves that SoftFileLock
    behind and the next run fails with a lock timeout that reads like a linter error. Also:
    use `-l android-format` to skip the ~10-minute `:fenix:lintDebug` pass.
  - **K13** ad surfaces (sponsored top sites, Firefox Suggest) are testable locally with no
    network by faking the app-services client at the seam app-services uses in its own unit
    tests, with the whole downstream product path left real. Lists the four things that each
    cost a device cycle.
  - **A39–A43** harness gotchas from the same batch: arrival check satisfied by an element
    behind an overlay (cost 5 cycles and parked a test); `mozLongClick` behaving as a tap on
    a View-based row; `COMPOSE_BY_TEXT` reporting an ambiguous match as "not found"; the
    Pocket sponsored story owning the same "Sponsored" caption; `pm revoke` not clearing
  - CONVERSION-LESSONS **K8** documented the `NameError: name 'txt' is not defined` crash as
    a live problem — that is the bug fixed here, so K8 is marked fixed and the JUnit-XML
    fallback it recommended is no longer needed for the common case.
  - HARNESS-GOTCHAS **A24** now carries the root cause instead of describing the symptom.

  New:
  - **A37** the crash-mode false green, with reproducer and the `"gradle": null` tell.
  - **A38** `mach lint` and every gradle task serialize on
    `objdir-frontend/gradle/mach_android.lockfile`; a killed run leaves that SoftFileLock
    behind and the next run fails with a lock timeout that reads like a linter error. Also:
    use `-l android-format` to skip the ~10-minute `:fenix:lintDebug` pass.
  - **K13** ad surfaces (sponsored top sites, Firefox Suggest) are testable locally with no
    network by faking the app-services client at the seam app-services uses in its own unit
    tests, with the whole downstream product path left real. Lists the four things that each
    cost a device cycle.
  - **A39–A43** harness gotchas from the same batch: arrival check satisfied by an element
    behind an overlay (cost 5 cycles and parked a test); `mozLongClick` behaving as a tap on

  Two notes on choices I made:

  from it.
- `bash -n effloop.sh` and an AST parse of `effverify.py` both clean.

### Reviewer notes

The one place to push back is effverify's new failure attribution — could it now
*over*-report? Two guards: a `CRASH:` line is attributed by position only when its block
started exactly one test (for a multi-test block the `FAILURES` header is the authoritative
source of the name), and the backstop only ever tightens the verdict, never loosens it.

No happy-path behaviour changes: a clean run reports exactly as before, with two extra
JSON fields.

  ### Verification

  - effverify re-checked against 7 real batches: the crash-mode batch flips to NOT DONE and
    correctly names the test; five genuinely-green batches still report clean; two genuine
    assertion failures still report failed; a batch that never ran the requested test still
    refuses to pass it.
  - effloop verified on device **with the local symlink deleted**: it resolved effpretty
    in-tree, produced a full 36-line `run-report.txt`, and effverify returned a clean verdict
    from it.
  - `bash -n effloop.sh` and an AST parse of `effverify.py` both clean.

 ### Reviewer notes

The one place to push back is effverify's new failure attribution — could it now
*over*-report? Two guards: a `CRASH:` line is attributed by position only when its block
started exactly one test (for a multi-test block the `FAILURES` header is the authoritative
source of the name), and the backstop only ever tightens the verdict, never loosens it.

No happy-path behaviour changes: a clean run reports exactly as before, with two extra
JSON fields.